### PR TITLE
fix: apply page rotation from INFO chunk in render_pixmap and render_coarse (#10)

### DIFF
--- a/src/djvu_render.rs
+++ b/src/djvu_render.rs
@@ -220,6 +220,52 @@ fn aa_downscale(pm: &Pixmap) -> Pixmap {
     out
 }
 
+// ── Page rotation ───────────────────────────────────────────────────────────
+
+/// Apply page rotation from the INFO chunk to the rendered pixmap.
+///
+/// For 90°/270° rotations, width and height are swapped.
+fn rotate_pixmap(src: Pixmap, rotation: crate::info::Rotation) -> Pixmap {
+    use crate::info::Rotation;
+    match rotation {
+        Rotation::None => src,
+        Rotation::Cw90 => {
+            let w = src.height;
+            let h = src.width;
+            let mut out = Pixmap::white(w, h);
+            for y in 0..src.height {
+                for x in 0..src.width {
+                    let (r, g, b) = src.get_rgb(x, y);
+                    out.set_rgb(src.height - 1 - y, x, r, g, b);
+                }
+            }
+            out
+        }
+        Rotation::Rot180 => {
+            let mut out = Pixmap::white(src.width, src.height);
+            for y in 0..src.height {
+                for x in 0..src.width {
+                    let (r, g, b) = src.get_rgb(x, y);
+                    out.set_rgb(src.width - 1 - x, src.height - 1 - y, r, g, b);
+                }
+            }
+            out
+        }
+        Rotation::Ccw90 => {
+            let w = src.height;
+            let h = src.width;
+            let mut out = Pixmap::white(w, h);
+            for y in 0..src.height {
+                for x in 0..src.width {
+                    let (r, g, b) = src.get_rgb(x, y);
+                    out.set_rgb(y, src.width - 1 - x, r, g, b);
+                }
+            }
+            out
+        }
+    }
+}
+
 // ── FGbz palette parsing ──────────────────────────────────────────────────────
 
 /// An RGB color from the FGbz palette.
@@ -571,7 +617,7 @@ pub fn render_pixmap(page: &DjVuPage, opts: &RenderOptions) -> Result<Pixmap, Re
         pm = aa_downscale(&pm);
     }
 
-    Ok(pm)
+    Ok(rotate_pixmap(pm, page.rotation()))
 }
 
 /// Coarse render: decode only the first BG44 chunk for a fast blurry preview.
@@ -611,7 +657,7 @@ pub fn render_coarse(page: &DjVuPage, opts: &RenderOptions) -> Result<Option<Pix
         composite_into(&ctx, &mut pm.data)?;
     }
 
-    Ok(Some(pm))
+    Ok(Some(rotate_pixmap(pm, page.rotation())))
 }
 
 /// Progressive render: decode BG44 chunks 1..=chunk_n and all other layers.
@@ -683,7 +729,7 @@ pub fn render_progressive(
         composite_into(&ctx, &mut pm.data)?;
     }
 
-    Ok(pm)
+    Ok(rotate_pixmap(pm, page.rotation()))
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -1059,5 +1105,98 @@ mod tests {
     fn _unused_load_page(_: &str) -> ! {
         let _ = load_page; // suppress dead code warning
         panic!("use load_doc instead")
+    }
+
+    // -- Rotation tests -------------------------------------------------------
+
+    #[test]
+    fn rotate_pixmap_none_is_identity() {
+        let mut pm = Pixmap::white(3, 2);
+        pm.set_rgb(0, 0, 255, 0, 0);
+        let rotated = rotate_pixmap(pm.clone(), crate::info::Rotation::None);
+        assert_eq!(rotated.width, 3);
+        assert_eq!(rotated.height, 2);
+        assert_eq!(rotated.get_rgb(0, 0), (255, 0, 0));
+    }
+
+    #[test]
+    fn rotate_pixmap_cw90_swaps_dims() {
+        let mut pm = Pixmap::white(4, 2);
+        pm.set_rgb(0, 0, 255, 0, 0); // top-left red
+        let rotated = rotate_pixmap(pm, crate::info::Rotation::Cw90);
+        assert_eq!(rotated.width, 2);
+        assert_eq!(rotated.height, 4);
+        // Top-left (0,0) of original goes to (height-1-0, 0) = (1, 0) in rotated
+        assert_eq!(rotated.get_rgb(1, 0), (255, 0, 0));
+    }
+
+    #[test]
+    fn rotate_pixmap_180_preserves_dims() {
+        let mut pm = Pixmap::white(3, 2);
+        pm.set_rgb(0, 0, 255, 0, 0); // top-left red
+        let rotated = rotate_pixmap(pm, crate::info::Rotation::Rot180);
+        assert_eq!(rotated.width, 3);
+        assert_eq!(rotated.height, 2);
+        assert_eq!(rotated.get_rgb(2, 1), (255, 0, 0));
+    }
+
+    #[test]
+    fn rotate_pixmap_ccw90_swaps_dims() {
+        let mut pm = Pixmap::white(4, 2);
+        pm.set_rgb(0, 0, 255, 0, 0); // top-left red
+        let rotated = rotate_pixmap(pm, crate::info::Rotation::Ccw90);
+        assert_eq!(rotated.width, 2);
+        assert_eq!(rotated.height, 4);
+        // Top-left (0,0) -> (0, width-1-0) = (0, 3) in rotated
+        assert_eq!(rotated.get_rgb(0, 3), (255, 0, 0));
+    }
+
+    #[test]
+    fn render_pixmap_rotation_90_swaps_dimensions() {
+        let doc = load_doc("boy_jb2_rotate90.djvu");
+        let page = doc.page(0).expect("page 0");
+        let orig_w = page.width();
+        let orig_h = page.height();
+        let opts = RenderOptions {
+            width: orig_w as u32,
+            height: orig_h as u32,
+            ..Default::default()
+        };
+        let pm = render_pixmap(page, &opts).expect("render should succeed");
+        // 90° rotation swaps width and height
+        assert_eq!(pm.width, orig_h as u32, "rotated width should be original height");
+        assert_eq!(pm.height, orig_w as u32, "rotated height should be original width");
+    }
+
+    #[test]
+    fn render_pixmap_rotation_180_preserves_dimensions() {
+        let doc = load_doc("boy_jb2_rotate180.djvu");
+        let page = doc.page(0).expect("page 0");
+        let orig_w = page.width();
+        let orig_h = page.height();
+        let opts = RenderOptions {
+            width: orig_w as u32,
+            height: orig_h as u32,
+            ..Default::default()
+        };
+        let pm = render_pixmap(page, &opts).expect("render should succeed");
+        assert_eq!(pm.width, orig_w as u32);
+        assert_eq!(pm.height, orig_h as u32);
+    }
+
+    #[test]
+    fn render_pixmap_rotation_270_swaps_dimensions() {
+        let doc = load_doc("boy_jb2_rotate270.djvu");
+        let page = doc.page(0).expect("page 0");
+        let orig_w = page.width();
+        let orig_h = page.height();
+        let opts = RenderOptions {
+            width: orig_w as u32,
+            height: orig_h as u32,
+            ..Default::default()
+        };
+        let pm = render_pixmap(page, &opts).expect("render should succeed");
+        assert_eq!(pm.width, orig_h as u32, "rotated width should be original height");
+        assert_eq!(pm.height, orig_w as u32, "rotated height should be original width");
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -72,14 +72,17 @@ impl PageInfo {
             gamma_byte as f32 / 10.0
         };
 
-        // Flags: bits 0–1 encode rotation
+        // Flags byte, bits 0–2: rotation per DjVu spec.
+        // Real-world DjVu files use three specific flag values:
+        //   5 → CW 90°    2 → 180°    6 → CW 270° (= CCW 90°)
+        // Other values (including 1, 3) are treated as no rotation,
+        // matching DjVuLibre behavior.
         let flags = data[9];
-        let rotation = match flags & 0x03 {
-            0 => Rotation::None,
-            1 => Rotation::Ccw90,
+        let rotation = match flags & 0x07 {
+            5 => Rotation::Cw90,
             2 => Rotation::Rot180,
-            3 => Rotation::Cw90,
-            _ => Rotation::None, // unreachable: 2 bits can only be 0-3
+            6 => Rotation::Ccw90,
+            _ => Rotation::None,
         };
 
         Ok(PageInfo {
@@ -139,27 +142,35 @@ mod tests {
     }
 
     #[test]
-    fn rotation_ccw90() {
+    fn rotation_flag1_is_none() {
         let mut bytes = chicken_info_bytes();
-        bytes[9] = 0x01; // flags bits 0-1 = 1
+        bytes[9] = 0x01;
         let info = PageInfo::parse(&bytes).unwrap();
-        assert_eq!(info.rotation, Rotation::Ccw90);
+        assert_eq!(info.rotation, Rotation::None);
     }
 
     #[test]
-    fn rotation_rot180() {
+    fn rotation_flag2_is_180() {
         let mut bytes = chicken_info_bytes();
-        bytes[9] = 0x02; // flags bits 0-1 = 2
+        bytes[9] = 0x02;
         let info = PageInfo::parse(&bytes).unwrap();
         assert_eq!(info.rotation, Rotation::Rot180);
     }
 
     #[test]
-    fn rotation_cw90() {
+    fn rotation_flag5_is_cw90() {
         let mut bytes = chicken_info_bytes();
-        bytes[9] = 0x03; // flags bits 0-1 = 3
+        bytes[9] = 0x05;
         let info = PageInfo::parse(&bytes).unwrap();
         assert_eq!(info.rotation, Rotation::Cw90);
+    }
+
+    #[test]
+    fn rotation_flag6_is_ccw90() {
+        let mut bytes = chicken_info_bytes();
+        bytes[9] = 0x06;
+        let info = PageInfo::parse(&bytes).unwrap();
+        assert_eq!(info.rotation, Rotation::Ccw90);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `rotate_pixmap()` helper to `djvu_render.rs`, apply rotation after composite+gamma in `render_pixmap`, `render_coarse`, `render_progressive`
- Fix `info.rs` rotation parsing: use 3-bit flag mask (`flags & 0x07`) matching DjVuLibre behavior — correctly handles flags 5 (CW90), 2 (180°), 6 (CCW90)
- 7 new tests + 2 updated tests for rotation

## Test plan
- [x] Unit tests for `rotate_pixmap` (None, Cw90, Rot180, Ccw90)
- [x] Fixture-based tests with `boy_jb2_rotate{90,180,270}.djvu` — verify dimension swap
- [x] Info.rs flag parsing tests for flags 1, 2, 5, 6
- [x] Full test suite: 183 passed, 0 failed

https://claude.ai/code/session_01CYMkBz2NY8RZYoWaj6MDnu