### PR TITLE
refactor: eliminate ouroboros — make Document fully owned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 thiserror = "2"
-ouroboros = { version = "0.18", optional = true }
 # Used by the djvu CLI binary. Will move to a separate djvu-cli crate in v0.2.
 clap = { version = "4", features = ["derive"], optional = true }
 png = { version = "0.17", optional = true }
@@ -37,7 +36,7 @@ miniz_oxide = { version = "0.8", optional = true }
 
 [features]
 default = ["std"]
-std = ["dep:ouroboros", "dep:clap", "dep:png", "dep:zip", "dep:miniz_oxide"]
+std = ["dep:clap", "dep:png", "dep:zip", "dep:miniz_oxide"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benches/codecs.rs
+++ b/benches/codecs.rs
@@ -17,14 +17,11 @@ fn corpus_path() -> PathBuf {
 }
 
 /// Search legacy IFF chunks recursively for the first chunk with the given id.
-fn find_chunk_legacy<'a>(
-    chunks: &'a [djvu_rs::iff::Chunk<'a>],
-    target: &[u8; 4],
-) -> Option<Vec<u8>> {
+fn find_chunk_legacy(chunks: &[djvu_rs::iff::Chunk], target: &[u8; 4]) -> Option<Vec<u8>> {
     for chunk in chunks {
         match chunk {
             djvu_rs::iff::Chunk::Leaf { id, data } if id == target => {
-                return Some(data.to_vec());
+                return Some(data.clone());
             }
             djvu_rs::iff::Chunk::Form { children, .. } => {
                 if let Some(found) = find_chunk_legacy(children, target) {

--- a/src/document.rs
+++ b/src/document.rs
@@ -110,8 +110,8 @@ struct DirmEntry {
 }
 
 /// A parsed DjVu document (single-page or multi-page bundled).
-pub struct Document<'a> {
-    file: DjvuFile<'a>,
+pub struct Document {
+    file: DjvuFile,
     /// For DJVM: DIRM entries and FORM children (indexed by order in DIRM).
     dirm_entries: Vec<DirmEntry>,
     /// Indices into dirm_entries for page-type components only.
@@ -120,9 +120,9 @@ pub struct Document<'a> {
     is_single_page: bool,
 }
 
-impl<'a> Document<'a> {
+impl Document {
     /// Parse a DjVu document from raw bytes.
-    pub fn parse(data: &'a [u8]) -> Result<Self, Error> {
+    pub fn parse(data: &[u8]) -> Result<Self, Error> {
         let file = crate::iff::parse(data)?;
         match &file.root {
             Chunk::Form {
@@ -148,7 +148,7 @@ impl<'a> Document<'a> {
                         Chunk::Leaf {
                             id: [b'D', b'I', b'R', b'M'],
                             data,
-                        } => Some(*data),
+                        } => Some(data.as_slice()),
                         _ => None,
                     })
                     .ok_or(Error::MissingChunk("DIRM"))?;
@@ -203,8 +203,8 @@ impl<'a> Document<'a> {
 
     /// Get the FORM chunk for a DIRM component by its dirm index.
     /// In bundled documents, FORM children after DIRM/NAVM correspond to DIRM entries in order.
-    fn get_component_form(&self, dirm_index: usize) -> Result<&Chunk<'a>, Error> {
-        let forms: Vec<&Chunk<'a>> = self
+    fn get_component_form(&self, dirm_index: usize) -> Result<&Chunk, Error> {
+        let forms: Vec<&Chunk> = self
             .file
             .root
             .children()
@@ -307,7 +307,7 @@ impl<'a> Document<'a> {
     }
 
     /// Resolve an INCL reference to a shared DJVI component's children.
-    fn resolve_incl(&self, ref_id: &str) -> Result<&Chunk<'a>, Error> {
+    fn resolve_incl(&self, ref_id: &str) -> Result<&Chunk, Error> {
         if self.is_single_page {
             return Err(Error::FormatError("INCL in single-page document".into()));
         }
@@ -328,12 +328,12 @@ impl<'a> Document<'a> {
 /// A single page within a DjVu document.
 pub struct Page<'a> {
     pub info: PageInfo,
-    form: &'a Chunk<'a>,
-    doc: &'a Document<'a>,
+    form: &'a Chunk,
+    doc: &'a Document,
 }
 
 impl<'a> Page<'a> {
-    fn from_form(form: &'a Chunk<'a>, doc: &'a Document<'a>) -> Result<Self, Error> {
+    fn from_form(form: &'a Chunk, doc: &'a Document) -> Result<Self, Error> {
         let info_chunk = form
             .find_first(b"INFO")
             .ok_or(Error::MissingChunk("INFO"))?;

--- a/src/iff.rs
+++ b/src/iff.rs
@@ -38,7 +38,7 @@ pub type ChunkId = [u8; 4];
 
 /// A parsed IFF chunk — either a FORM container or a leaf data chunk.
 #[derive(Debug, Clone)]
-pub enum Chunk<'a> {
+pub enum Chunk {
     /// A FORM container with a secondary ID and child chunks.
     Form {
         /// The secondary ID (e.g., b"DJVU", b"DJVM", b"DJVI", b"THUM").
@@ -47,20 +47,20 @@ pub enum Chunk<'a> {
         #[allow(dead_code)]
         length: u32,
         /// Child chunks within this FORM.
-        children: Vec<Chunk<'a>>,
+        children: Vec<Chunk>,
     },
     /// A leaf chunk with raw data.
     Leaf {
         /// The chunk ID (e.g., b"INFO", b"Sjbz", b"BG44").
         id: ChunkId,
-        /// The raw chunk payload bytes (zero-copy slice of input).
-        data: &'a [u8],
+        /// The raw chunk payload bytes.
+        data: Vec<u8>,
     },
 }
 
-impl<'a> Chunk<'a> {
+impl Chunk {
     /// For leaf chunks, return the data slice. For FORM chunks, returns empty slice.
-    pub fn data(&self) -> &'a [u8] {
+    pub fn data(&self) -> &[u8] {
         match self {
             Chunk::Form { .. } => &[],
             Chunk::Leaf { data, .. } => data,
@@ -68,7 +68,7 @@ impl<'a> Chunk<'a> {
     }
 
     /// For FORM chunks, return children. For leaf chunks, returns empty slice.
-    pub fn children(&self) -> &[Chunk<'a>] {
+    pub fn children(&self) -> &[Chunk] {
         match self {
             Chunk::Form { children, .. } => children,
             Chunk::Leaf { .. } => &[],
@@ -76,7 +76,7 @@ impl<'a> Chunk<'a> {
     }
 
     /// Find the first leaf chunk with the given ID in direct children.
-    pub fn find_first(&self, target_id: &[u8; 4]) -> Option<&Chunk<'a>> {
+    pub fn find_first(&self, target_id: &[u8; 4]) -> Option<&Chunk> {
         self.children().iter().find(|c| match c {
             Chunk::Leaf { id, .. } => id == target_id,
             _ => false,
@@ -84,7 +84,7 @@ impl<'a> Chunk<'a> {
     }
 
     /// Find all leaf chunks with the given ID in direct children.
-    pub fn find_all(&self, target_id: &[u8; 4]) -> Vec<&Chunk<'a>> {
+    pub fn find_all(&self, target_id: &[u8; 4]) -> Vec<&Chunk> {
         self.children()
             .iter()
             .filter(|c| match c {
@@ -97,14 +97,14 @@ impl<'a> Chunk<'a> {
 
 /// A parsed DjVu document (the root FORM chunk).
 #[derive(Debug, Clone)]
-pub struct DjvuFile<'a> {
-    pub root: Chunk<'a>,
+pub struct DjvuFile {
+    pub root: Chunk,
 }
 
 /// Parse a DjVu file from raw bytes (legacy tree-based parser).
 ///
 /// Expects the file to begin with "AT&T" magic followed by a root FORM chunk.
-pub fn parse(data: &[u8]) -> Result<DjvuFile<'_>, Error> {
+pub fn parse(data: &[u8]) -> Result<DjvuFile, Error> {
     if data.len() < 4 {
         return Err(Error::UnexpectedEof);
     }
@@ -123,7 +123,7 @@ pub fn parse(data: &[u8]) -> Result<DjvuFile<'_>, Error> {
 
 /// Parse a single chunk starting at `offset` within `data`.
 /// Returns the parsed chunk and the number of bytes consumed (including padding).
-fn parse_chunk(data: &[u8], offset: usize) -> Result<(Chunk<'_>, usize), Error> {
+fn parse_chunk(data: &[u8], offset: usize) -> Result<(Chunk, usize), Error> {
     if offset + 8 > data.len() {
         return Err(Error::UnexpectedEof);
     }
@@ -175,7 +175,7 @@ fn parse_chunk(data: &[u8], offset: usize) -> Result<(Chunk<'_>, usize), Error> 
             padded_total,
         ))
     } else {
-        let chunk_data = &data[payload_start..payload_end];
+        let chunk_data = data[payload_start..payload_end].to_vec();
         Ok((
             Chunk::Leaf {
                 id,
@@ -187,7 +187,7 @@ fn parse_chunk(data: &[u8], offset: usize) -> Result<(Chunk<'_>, usize), Error> 
 }
 
 /// Parse sequential chunks within a range of bytes.
-fn parse_children(data: &[u8], start: usize, end: usize) -> Result<Vec<Chunk<'_>>, Error> {
+fn parse_children(data: &[u8], start: usize, end: usize) -> Result<Vec<Chunk>, Error> {
     let mut chunks = Vec::new();
     let mut pos = start;
 
@@ -348,14 +348,14 @@ fn read_u32_be(data: &[u8], offset: usize) -> Result<u32, IffError> {
 
 /// Produce a structural dump of the chunk tree.
 #[cfg(test)]
-pub fn dump(file: &DjvuFile<'_>) -> String {
+pub fn dump(file: &DjvuFile) -> String {
     let mut out = String::new();
     dump_chunk(&file.root, 1, &mut out);
     out
 }
 
 #[cfg(test)]
-fn dump_chunk(chunk: &Chunk<'_>, depth: usize, out: &mut String) {
+fn dump_chunk(chunk: &Chunk, depth: usize, out: &mut String) {
     let indent = "  ".repeat(depth);
     match chunk {
         Chunk::Form {

--- a/src/iw44.rs
+++ b/src/iw44.rs
@@ -934,8 +934,8 @@ mod tests {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/golden/iw44")
     }
 
-    fn extract_bg44_chunks<'a>(file: &'a crate::iff::DjvuFile<'a>) -> Vec<&'a [u8]> {
-        fn collect_from_djvu_form<'a>(chunk: &'a crate::iff::Chunk<'a>) -> Option<Vec<&'a [u8]>> {
+    fn extract_bg44_chunks(file: &crate::iff::DjvuFile) -> Vec<&[u8]> {
+        fn collect_from_djvu_form(chunk: &crate::iff::Chunk) -> Option<Vec<&[u8]>> {
             match chunk {
                 crate::iff::Chunk::Form {
                     secondary_id,
@@ -949,7 +949,7 @@ mod tests {
                                 crate::iff::Chunk::Leaf {
                                     id: [b'B', b'G', b'4', b'4'],
                                     data,
-                                } => Some(*data),
+                                } => Some(data.as_slice()),
                                 _ => None,
                             })
                             .collect::<Vec<_>>();

--- a/src/iw44_new.rs
+++ b/src/iw44_new.rs
@@ -893,8 +893,8 @@ mod tests {
     }
 
     /// Extract all BG44 chunk payloads from the first DJVU form in the file.
-    fn extract_bg44_chunks<'a>(file: &'a crate::iff::DjvuFile<'a>) -> Vec<&'a [u8]> {
-        fn collect<'a>(chunk: &'a crate::iff::Chunk<'a>) -> Option<Vec<&'a [u8]>> {
+    fn extract_bg44_chunks(file: &crate::iff::DjvuFile) -> Vec<&[u8]> {
+        fn collect(chunk: &crate::iff::Chunk) -> Option<Vec<&[u8]>> {
             match chunk {
                 crate::iff::Chunk::Form {
                     secondary_id,
@@ -908,7 +908,7 @@ mod tests {
                                 crate::iff::Chunk::Leaf {
                                     id: [b'B', b'G', b'4', b'4'],
                                     data,
-                                } => Some(*data),
+                                } => Some(data.as_slice()),
                                 _ => None,
                             })
                             .collect::<Vec<_>>();

--- a/src/jb2.rs
+++ b/src/jb2.rs
@@ -1080,17 +1080,17 @@ mod tests {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/golden/jb2")
     }
 
-    fn extract_sjbz(djvu_data: &[u8]) -> &[u8] {
+    fn extract_sjbz(djvu_data: &[u8]) -> Vec<u8> {
         let file = crate::iff::parse(djvu_data).unwrap();
         let sjbz = file.root.find_first(b"Sjbz").unwrap();
-        sjbz.data()
+        sjbz.data().to_vec()
     }
 
     #[test]
     fn jb2_decode_boy_jb2_mask() {
         let djvu = std::fs::read(assets_path().join("boy_jb2.djvu")).unwrap();
         let sjbz = extract_sjbz(&djvu);
-        let bitmap = decode(sjbz, None).unwrap();
+        let bitmap = decode(&sjbz, None).unwrap();
         let actual_pbm = bitmap.to_pbm();
         let expected_pbm = std::fs::read(golden_path().join("boy_jb2_mask.pbm")).unwrap();
         assert_eq!(
@@ -1127,10 +1127,10 @@ mod tests {
     }
 
     /// Find the Nth DJVU page form (0-indexed) in a bundled DJVM.
-    fn find_page_form<'a>(
-        file: &'a crate::iff::DjvuFile<'a>,
+    fn find_page_form(
+        file: &crate::iff::DjvuFile,
         page: usize,
-    ) -> Result<&'a crate::iff::Chunk<'a>, crate::error::DjVuError> {
+    ) -> Result<&crate::iff::Chunk, crate::error::DjVuError> {
         let mut idx = 0;
         for chunk in file.root.children() {
             if matches!(chunk, crate::iff::Chunk::Form { secondary_id, .. } if secondary_id == b"DJVU")
@@ -1145,10 +1145,10 @@ mod tests {
     }
 
     /// Find a DJVI form by its component name (from INCL chunk).
-    fn find_djvi_djbz<'a>(
-        file: &'a crate::iff::DjvuFile<'a>,
+    fn find_djvi_djbz(
+        file: &crate::iff::DjvuFile,
         _name: &[u8],
-    ) -> Result<&'a [u8], crate::error::DjVuError> {
+    ) -> Result<Vec<u8>, crate::error::DjVuError> {
         for chunk in file.root.children() {
             if let crate::iff::Chunk::Form { secondary_id, .. } = chunk
                 && secondary_id == b"DJVI"
@@ -1156,7 +1156,7 @@ mod tests {
                 // Check if this DJVI's component name matches
                 // The component name is in the DIRM, but we can match by trying to find the Djbz
                 if let Some(djbz) = chunk.find_first(b"Djbz") {
-                    return Ok(djbz.data());
+                    return Ok(djbz.data().to_vec());
                 }
             }
         }
@@ -1194,7 +1194,7 @@ mod tests {
 
         // Get shared dict from the DJVI component
         let djbz_data = find_djvi_djbz(&file, b"dict0020.iff").unwrap();
-        let shared_dict = decode_dict(djbz_data, None).unwrap();
+        let shared_dict = decode_dict(&djbz_data, None).unwrap();
 
         // Get page 2's Sjbz (page index 1)
         let page_form = find_page_form(&file, 1).unwrap();
@@ -1218,7 +1218,7 @@ mod tests {
         let file = crate::iff::parse(&djvu).unwrap();
 
         let djbz_data = find_djvi_djbz(&file, b"dict0006.iff").unwrap();
-        let shared_dict = decode_dict(djbz_data, None).unwrap();
+        let shared_dict = decode_dict(&djbz_data, None).unwrap();
 
         let page_form = find_page_form(&file, 0).unwrap();
         let sjbz_data = page_form.find_first(b"Sjbz").unwrap().data();

--- a/src/jb2_new.rs
+++ b/src/jb2_new.rs
@@ -1464,7 +1464,7 @@ mod tests {
 
         // Inline Djbz in page 1
         let mut idx = 0usize;
-        let mut page_form_opt: Option<&crate::iff::Chunk<'_>> = None;
+        let mut page_form_opt: Option<&crate::iff::Chunk> = None;
         for chunk in file.root.children() {
             if matches!(chunk, crate::iff::Chunk::Form { secondary_id, .. }
                 if secondary_id == b"DJVU")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,25 +198,13 @@ pub use document::{Bookmark, TextLayer, TextZone, TextZoneKind};
 #[cfg(feature = "std")]
 pub use error::LegacyError as Error;
 
-#[cfg(feature = "std")]
-use ouroboros::self_referencing;
-
-#[cfg(feature = "std")]
-#[self_referencing]
-struct DocumentInner {
-    data: Box<[u8]>,
-    #[borrows(data)]
-    #[covariant]
-    doc: document::Document<'this>,
-}
-
-/// A parsed DjVu document. Owns its data and the parsed structure.
+/// A parsed DjVu document. Owns the parsed structure.
 #[cfg(feature = "std")]
 ///
 /// Parsing happens once at construction time. All subsequent `page()` and
 /// `render()` calls reuse the parsed chunk tree with zero re-parsing overhead.
 pub struct Document {
-    inner: DocumentInner,
+    doc: document::Document,
 }
 
 #[cfg(feature = "std")]
@@ -240,27 +228,23 @@ impl Document {
 
     /// Parse a DjVu document from owned bytes.
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, Error> {
-        let inner = DocumentInnerTryBuilder {
-            data: data.into_boxed_slice(),
-            doc_builder: |bytes| document::Document::parse(bytes),
-        }
-        .try_build()?;
-        Ok(Document { inner })
+        let doc = document::Document::parse(&data)?;
+        Ok(Document { doc })
     }
 
     /// Parse the NAVM bookmarks (table of contents).
     pub fn bookmarks(&self) -> Result<Vec<Bookmark>, Error> {
-        self.inner.borrow_doc().bookmarks()
+        self.doc.bookmarks()
     }
 
     /// Number of pages.
     pub fn page_count(&self) -> usize {
-        self.inner.borrow_doc().page_count()
+        self.doc.page_count()
     }
 
     /// Access a page by 0-based index.
     pub fn page(&self, index: usize) -> Result<Page<'_>, Error> {
-        let inner = self.inner.borrow_doc().page(index)?;
+        let inner = self.doc.page(index)?;
         Ok(Page {
             width: inner.info.width,
             height: inner.info.height,
@@ -328,19 +312,19 @@ impl<'a> Page<'a> {
 
     /// Render the page to an RGBA pixmap at native resolution.
     pub fn render(&self) -> Result<Pixmap, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render(&page)
     }
 
     /// Render the page to an RGBA pixmap at a target size.
     pub fn render_to_size(&self, width: u32, height: u32) -> Result<Pixmap, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size(&page, width, height)
     }
 
     /// Render the page at native resolution with mask dilation for bolder text.
     pub fn render_bold(&self, dilate_passes: u32) -> Result<Pixmap, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size_bold(
             &page,
             page.info.width as u32,
@@ -356,24 +340,24 @@ impl<'a> Page<'a> {
         height: u32,
         dilate_passes: u32,
     ) -> Result<Pixmap, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size_bold(&page, width, height, dilate_passes)
     }
 
     /// Render the page at a target size with anti-aliased downscaling.
     pub fn render_aa(&self, width: u32, height: u32, boldness: f32) -> Result<Pixmap, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_aa(&page, width, height, boldness)
     }
 
     /// Decode the page thumbnail, if available.
     pub fn thumbnail(&self) -> Result<Option<Pixmap>, Error> {
-        self.doc.inner.borrow_doc().thumbnail(self.index)
+        self.doc.doc.thumbnail(self.index)
     }
 
     /// Extract the text layer (TXTz/TXTa) with zone hierarchy.
     pub fn text_layer(&self) -> Result<Option<TextLayer>, Error> {
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         page.text_layer()
     }
 
@@ -392,7 +376,7 @@ impl<'a> Page<'a> {
             document::Rotation::Cw90 | document::Rotation::Cw270 => (h, w),
             _ => (w, h),
         };
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size_coarse(&page, tw, th)
     }
 
@@ -406,7 +390,7 @@ impl<'a> Page<'a> {
             document::Rotation::Cw90 | document::Rotation::Cw270 => (h, w),
             _ => (w, h),
         };
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size_progressive(&page, tw, th)
     }
 
@@ -420,7 +404,7 @@ impl<'a> Page<'a> {
             document::Rotation::Cw90 | document::Rotation::Cw270 => (h, w),
             _ => (w, h),
         };
-        let page = self.doc.inner.borrow_doc().page(self.index)?;
+        let page = self.doc.doc.page(self.index)?;
         render::render_to_size(&page, tw, th)
     }
 }


### PR DESCRIPTION
## Summary
- Remove `ouroboros` dependency by making the legacy IFF `Chunk` store owned `Vec<u8>` instead of borrowed `&'a [u8]`
- `document::Document` no longer has a lifetime parameter — it's a plain owned struct
- `lib.rs` `Document` is now a simple wrapper, no self-referential pattern needed
- Zero-copy `IffChunk<'a>` / `Form<'a>` (new API) remain unchanged

Closes #21

## Changes
- `Chunk::Leaf { data }` — `&'a [u8]` → `Vec<u8>`
- `DjvuFile`, `Document`, removed lifetime parameters
- `ouroboros` removed from `Cargo.toml` and `std` feature
- Net -20 lines, simpler code

## Test plan
- [x] All 256 lib tests pass
- [x] All integration tests pass (366 total)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo build --no-default-features` (no_std) works
- [x] `cargo fmt` clean

https://claude.ai/code/session_01CYMkBz2NY8RZYoWaj6MDnu