### PR TITLE
feat: mask and foreground/background layer extraction API

### DIFF
--- a/src/bin/djvu.rs
+++ b/src/bin/djvu.rs
@@ -33,6 +33,9 @@ enum Cmd {
         /// Output format.
         #[arg(short, long, default_value = "png", value_enum)]
         format: Format,
+        /// Layer to extract: composite (default), mask, foreground, background.
+        #[arg(short, long, default_value = "composite", value_enum)]
+        layer: Layer,
         /// Output file (single page) or directory (--all, PNG only).
         #[arg(short, long)]
         output: PathBuf,
@@ -57,6 +60,18 @@ enum Format {
     Cbz,
 }
 
+#[derive(Clone, ValueEnum)]
+enum Layer {
+    /// Full composite render (default).
+    Composite,
+    /// JB2 bilevel mask only.
+    Mask,
+    /// IW44 foreground layer only.
+    Foreground,
+    /// IW44 background layer only.
+    Background,
+}
+
 fn main() {
     let cli = Cli::parse();
     if let Err(e) = run(cli) {
@@ -74,8 +89,9 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             all,
             dpi,
             format,
+            layer,
             output,
-        } => cmd_render(&file, page, all, dpi, format, &output),
+        } => cmd_render(&file, page, all, dpi, format, layer, &output),
         Cmd::Text { file, page, all } => cmd_text(&file, page, all),
     }
 }
@@ -107,11 +123,17 @@ fn cmd_render(
     all: bool,
     dpi: u32,
     format: Format,
+    layer: Layer,
     output: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // PDF uses the new DjVuDocument API directly (preserves text, bookmarks, links)
     if matches!(format, Format::Pdf) {
         return render_pdf_structured(path, output);
+    }
+
+    // Layer extraction uses the DjVuDocument API
+    if !matches!(layer, Layer::Composite) {
+        return render_layer(path, page, all, layer, output);
     }
 
     let doc = open(path)?;
@@ -122,6 +144,96 @@ fn cmd_render(
         Format::Pdf => unreachable!(),
         Format::Cbz => render_cbz(&doc, page, all, dpi, count, output),
     }
+}
+
+fn render_layer(
+    path: &Path,
+    page: usize,
+    all: bool,
+    layer: Layer,
+    output: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let data = std::fs::read(path)?;
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&data)?;
+    let count = doc.page_count();
+
+    let pages: Vec<usize> = if all {
+        (0..count).collect()
+    } else {
+        vec![page_idx(page, count)?]
+    };
+
+    if all {
+        std::fs::create_dir_all(output)?;
+    } else if let Some(parent) = output.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    for idx in pages {
+        let pg = doc.page(idx)?;
+        let out_path = if all {
+            output.join(format!("page_{:04}.png", idx + 1))
+        } else {
+            output.to_path_buf()
+        };
+
+        match layer {
+            Layer::Mask => {
+                let bm = pg.extract_mask()?.ok_or("page has no JB2 mask layer")?;
+                // Convert 1-bit bitmap to RGBA (black/white)
+                let w = bm.width;
+                let h = bm.height;
+                let mut rgba = vec![255u8; (w * h * 4) as usize];
+                for y in 0..h {
+                    for x in 0..w {
+                        if bm.get(x, y) {
+                            let off = ((y * w + x) * 4) as usize;
+                            rgba[off] = 0;
+                            rgba[off + 1] = 0;
+                            rgba[off + 2] = 0;
+                        }
+                    }
+                }
+                let file = std::fs::File::create(&out_path)?;
+                let mut writer = std::io::BufWriter::new(file);
+                encode_png(&mut writer, w, h, &rgba)?;
+            }
+            Layer::Foreground => {
+                let pm = pg
+                    .extract_foreground()?
+                    .ok_or("page has no foreground layer")?;
+                let rgba = pixmap_to_rgba(&pm);
+                let file = std::fs::File::create(&out_path)?;
+                let mut writer = std::io::BufWriter::new(file);
+                encode_png(&mut writer, pm.width, pm.height, &rgba)?;
+            }
+            Layer::Background => {
+                let pm = pg
+                    .extract_background()?
+                    .ok_or("page has no background layer")?;
+                let rgba = pixmap_to_rgba(&pm);
+                let file = std::fs::File::create(&out_path)?;
+                let mut writer = std::io::BufWriter::new(file);
+                encode_png(&mut writer, pm.width, pm.height, &rgba)?;
+            }
+            Layer::Composite => unreachable!(),
+        }
+    }
+    Ok(())
+}
+
+/// Convert an RGB Pixmap to RGBA bytes.
+fn pixmap_to_rgba(pm: &djvu_rs::Pixmap) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity((pm.width * pm.height * 4) as usize);
+    for y in 0..pm.height {
+        for x in 0..pm.width {
+            let (r, g, b) = pm.get_rgb(x, y);
+            rgba.extend_from_slice(&[r, g, b, 255]);
+        }
+    }
+    rgba
 }
 
 fn render_png(

--- a/src/djvu_document.rs
+++ b/src/djvu_document.rs
@@ -33,7 +33,7 @@ use alloc::{
 use crate::{
     annotation::{Annotation, AnnotationError, MapArea},
     bzz_new::bzz_decode,
-    error::{BzzError, IffError, Iw44Error},
+    error::{BzzError, IffError, Iw44Error, Jb2Error},
     iff::{IffChunk, parse_form},
     info::PageInfo,
     iw44_new::Iw44Image,
@@ -57,6 +57,10 @@ pub enum DocError {
     /// IW44 wavelet decoding error.
     #[error("IW44 error: {0}")]
     Iw44(#[from] Iw44Error),
+
+    /// JB2 bilevel image decoding error.
+    #[error("JB2 error: {0}")]
+    Jb2(#[from] Jb2Error),
 
     /// The file is not a supported DjVu format.
     #[error("not a DjVu file: found form type {0:?}")]
@@ -293,6 +297,58 @@ impl DjVuPage {
             None => Ok(Vec::new()),
             Some((_, mapareas)) => Ok(mapareas.into_iter().filter(|m| !m.url.is_empty()).collect()),
         }
+    }
+
+    /// Decode the JB2 foreground mask as a 1-bit [`Bitmap`](crate::bitmap::Bitmap).
+    ///
+    /// Returns `Ok(None)` if the page has no Sjbz (JB2 mask) chunk.
+    pub fn extract_mask(&self) -> Result<Option<crate::bitmap::Bitmap>, DocError> {
+        let sjbz = match self.find_chunk(b"Sjbz") {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let dict = match self.find_chunk(b"Djbz") {
+            Some(djbz) => Some(crate::jb2_new::decode_dict(djbz, None)?),
+            None => None,
+        };
+
+        let bm = crate::jb2_new::decode(sjbz, dict.as_ref())?;
+        Ok(Some(bm))
+    }
+
+    /// Decode the IW44 foreground layer (FG44 chunks) if present.
+    ///
+    /// Returns `Ok(None)` if the page has no FG44 chunks.
+    pub fn extract_foreground(&self) -> Result<Option<Pixmap>, DocError> {
+        let chunks = self.fg44_chunks();
+        if chunks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut img = Iw44Image::new();
+        for chunk_data in &chunks {
+            img.decode_chunk(chunk_data)?;
+        }
+        let pixmap = img.to_rgb()?;
+        Ok(Some(pixmap))
+    }
+
+    /// Decode the IW44 background layer (BG44 chunks) if present.
+    ///
+    /// Returns `Ok(None)` if the page has no BG44 chunks.
+    pub fn extract_background(&self) -> Result<Option<Pixmap>, DocError> {
+        let chunks = self.bg44_chunks();
+        if chunks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut img = Iw44Image::new();
+        for chunk_data in &chunks {
+            img.decode_chunk(chunk_data)?;
+        }
+        let pixmap = img.to_rgb()?;
+        Ok(Some(pixmap))
     }
 
     /// Render this page into a pre-allocated RGBA buffer using the given options.

--- a/tests/document_and_render.rs
+++ b/tests/document_and_render.rs
@@ -261,6 +261,91 @@ fn iff_error_implements_error_trait() {
     requires_error::<IffError>();
 }
 
+// ── Layer extraction (#16) ───────────────────────────────────────────────────
+
+/// extract_mask on a bilevel page returns a Bitmap matching page dimensions.
+#[test]
+fn extract_mask_bilevel_page() {
+    let data = std::fs::read("tests/fixtures/boy_jb2.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let mask = page.extract_mask().expect("extract_mask must not error");
+    assert!(mask.is_some(), "boy_jb2 must have a JB2 mask");
+    let bm = mask.unwrap();
+    assert_eq!(bm.width as u16, page.width());
+    assert_eq!(bm.height as u16, page.height());
+}
+
+/// extract_mask returns None when there is no Sjbz chunk (IW44-only page).
+#[test]
+fn extract_mask_no_sjbz_returns_none() {
+    let data = std::fs::read("tests/fixtures/chicken.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    // chicken.djvu is IW44-only (no JB2 mask)
+    let mask = page.extract_mask().expect("must not error");
+    assert!(mask.is_none(), "IW44-only page should have no mask");
+}
+
+/// extract_foreground on a 3-layer page returns a Pixmap.
+#[test]
+fn extract_foreground_3layer() {
+    let data = std::fs::read("tests/fixtures/colorbook.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let fg = page
+        .extract_foreground()
+        .expect("extract_foreground must not error");
+    assert!(
+        fg.is_some(),
+        "colorbook.djvu should have a foreground layer"
+    );
+    let pm = fg.unwrap();
+    assert!(pm.width > 0 && pm.height > 0);
+}
+
+/// extract_foreground returns None when there are no FG44 chunks.
+#[test]
+fn extract_foreground_no_fg44_returns_none() {
+    let data = std::fs::read("tests/fixtures/boy_jb2.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let fg = page.extract_foreground().expect("must not error");
+    assert!(fg.is_none(), "bilevel page should have no foreground layer");
+}
+
+/// extract_background on a color page returns a Pixmap with correct dimensions.
+#[test]
+fn extract_background_color_page() {
+    let data = std::fs::read("tests/fixtures/chicken.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let bg = page
+        .extract_background()
+        .expect("extract_background must not error");
+    assert!(bg.is_some(), "chicken.djvu should have a background");
+    let pm = bg.unwrap();
+    assert!(pm.width > 0 && pm.height > 0);
+}
+
+/// extract_background returns None on a bilevel (JB2-only) page.
+#[test]
+fn extract_background_no_bg44_returns_none() {
+    let data = std::fs::read("tests/fixtures/boy_jb2.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let bg = page.extract_background().expect("must not error");
+    assert!(bg.is_none(), "bilevel page should have no background");
+}
+
+// ── IFF parse_form ──────────────────────────────────────────────────────────
+
 /// find_first returns the first matching chunk.
 #[test]
 fn iff_find_first_existing_chunk() {


### PR DESCRIPTION
## Summary
- Add `DjVuPage::extract_mask()` — decode JB2 bilevel mask as `Bitmap`
- Add `DjVuPage::extract_foreground()` — decode FG44 IW44 foreground as `Pixmap`
- Add `DjVuPage::extract_background()` — decode BG44 IW44 background as `Pixmap`
- Add `Jb2Error` variant to `DocError` for proper JB2 error propagation
- CLI: `djvu render --layer mask|foreground|background -o out.png`

Closes #16

## Example
```rust
let page = doc.page(0)?;
let mask = page.extract_mask()?;      // Option<Bitmap>
let fg = page.extract_foreground()?;   // Option<Pixmap>
let bg = page.extract_background()?;   // Option<Pixmap>
```

## Test plan
- [x] 6 new integration tests: mask on bilevel, mask none on IW44-only, foreground on 3-layer, foreground none on bilevel, background on color, background none on bilevel
- [x] All 268 lib + 29 integration tests pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean

https://claude.ai/code/session_01CYMkBz2NY8RZYoWaj6MDnu