### PR TITLE
feat(render): grayscale output mode — GrayPixmap + render_gray8

### DIFF
--- a/src/djvu_render.rs
+++ b/src/djvu_render.rs
@@ -41,7 +41,7 @@ use alloc::{vec, vec::Vec};
 use crate::djvu_document::DjVuPage;
 use crate::iw44_new::Iw44Image;
 use crate::jb2_new;
-use crate::pixmap::Pixmap;
+use crate::pixmap::{GrayPixmap, Pixmap};
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 
@@ -1010,6 +1010,18 @@ pub fn render_pixmap(page: &DjVuPage, opts: &RenderOptions) -> Result<Pixmap, Re
         pm,
         combine_rotations(page.rotation(), opts.rotation),
     ))
+}
+
+/// Render a `DjVuPage` to an 8-bit grayscale image.
+///
+/// Equivalent to calling [`render_pixmap`] and converting the result with
+/// [`Pixmap::to_gray8`]. Returns a [`GrayPixmap`] where `data.len() ==
+/// width * height`.
+///
+/// For bilevel (JB2-only) pages this produces only `0` and `255` values.
+/// For colour pages, luminance is computed with ITU-R BT.601 weights.
+pub fn render_gray8(page: &DjVuPage, opts: &RenderOptions) -> Result<GrayPixmap, RenderError> {
+    Ok(render_pixmap(page, opts)?.to_gray8())
 }
 
 /// Coarse render: decode only the first BG44 chunk for a fast blurry preview.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub mod zp;
 
 // Re-export types needed by both legacy and new phase modules
 pub use bitmap::Bitmap;
-pub use pixmap::Pixmap;
+pub use pixmap::{GrayPixmap, Pixmap};
 
 // Re-export legacy types (only with std feature)
 #[cfg(feature = "std")]

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -116,6 +116,49 @@ impl Pixmap {
         }
         out
     }
+
+    /// Convert to 8-bit grayscale using ITU-R BT.601 luminance weights.
+    ///
+    /// `Y = 0.299·R + 0.587·G + 0.114·B`
+    ///
+    /// Returns a [`GrayPixmap`] with `data.len() == width * height`.
+    pub fn to_gray8(&self) -> GrayPixmap {
+        let pixel_count = self.data.len() / 4;
+        let mut data = Vec::with_capacity(pixel_count);
+        for chunk in self.data.chunks_exact(4) {
+            let r = chunk[0] as u32;
+            let g = chunk[1] as u32;
+            let b = chunk[2] as u32;
+            // Fixed-point: weights × 1024 → 306 + 601 + 117 = 1024
+            let y = (r * 306 + g * 601 + b * 117) >> 10;
+            data.push(y.min(255) as u8);
+        }
+        GrayPixmap {
+            width: self.width,
+            height: self.height,
+            data,
+        }
+    }
+}
+
+/// An 8-bit grayscale image, 1 byte per pixel.
+///
+/// Row-major, top-to-bottom. `data.len() == width * height`.
+/// Produced by [`Pixmap::to_gray8`] or [`crate::djvu_render::render_gray8`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GrayPixmap {
+    pub width: u32,
+    pub height: u32,
+    /// Grayscale pixel data, row-major. Length = `width * height`.
+    pub data: Vec<u8>,
+}
+
+impl GrayPixmap {
+    /// Get the luminance value at pixel (x, y).
+    #[inline]
+    pub fn get(&self, x: u32, y: u32) -> u8 {
+        self.data[(y as usize * self.width as usize) + x as usize]
+    }
 }
 
 #[cfg(test)]

--- a/tests/document_and_render.rs
+++ b/tests/document_and_render.rs
@@ -4,7 +4,7 @@
 
 use djvu_rs::IffError;
 use djvu_rs::djvu_document::{DjVuDocument, DocError};
-use djvu_rs::djvu_render::{RenderOptions, render_coarse, render_pixmap, render_progressive};
+use djvu_rs::djvu_render::{RenderOptions, render_coarse, render_gray8, render_pixmap, render_progressive};
 use djvu_rs::iff::parse_form;
 
 // ── DjVuDocument — parse ──────────────────────────────────────────────────────
@@ -342,6 +342,84 @@ fn extract_background_no_bg44_returns_none() {
 
     let bg = page.extract_background().expect("must not error");
     assert!(bg.is_none(), "bilevel page should have no background");
+}
+
+// ── render_gray8 ────────────────────────────────────────────────────────────
+
+/// Grayscale render of a bilevel page must return only 0 and 255 values.
+#[test]
+fn render_gray8_bilevel_only_black_and_white() {
+    let data = std::fs::read("tests/fixtures/boy_jb2.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let opts = RenderOptions {
+        width: page.width() as u32,
+        height: page.height() as u32,
+        ..RenderOptions::default()
+    };
+    let gray = render_gray8(&page, &opts).expect("render_gray8 must succeed");
+
+    assert_eq!(
+        gray.data.len(),
+        gray.width as usize * gray.height as usize,
+        "grayscale buffer must have exactly width*height bytes"
+    );
+    assert_eq!(gray.width, opts.width);
+    assert_eq!(gray.height, opts.height);
+
+    // Bilevel page: all pixels must be exactly 0 (black) or 255 (white).
+    let unexpected: Vec<u8> = gray
+        .data
+        .iter()
+        .copied()
+        .filter(|&v| v != 0 && v != 255)
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "bilevel grayscale must contain only 0/255, found: {:?}",
+        &unexpected[..unexpected.len().min(10)]
+    );
+}
+
+/// Grayscale render of a colour page must have correct buffer size.
+#[test]
+fn render_gray8_color_page_correct_size() {
+    let data = std::fs::read("tests/fixtures/boy.djvu").unwrap();
+    let doc = DjVuDocument::parse(&data).unwrap();
+    let page = doc.page(0).unwrap();
+
+    let opts = RenderOptions {
+        width: page.width() as u32,
+        height: page.height() as u32,
+        ..RenderOptions::default()
+    };
+    let gray = render_gray8(&page, &opts).expect("render_gray8 must succeed for colour page");
+
+    assert_eq!(
+        gray.data.len(),
+        gray.width as usize * gray.height as usize,
+        "grayscale buffer must have exactly width*height bytes"
+    );
+}
+
+/// `Pixmap::to_gray8` must produce correct luminance values.
+#[test]
+fn pixmap_to_gray8_luminance_values() {
+    use djvu_rs::Pixmap;
+
+    let mut pm = Pixmap::white(3, 1);
+    pm.set_rgb(0, 0, 0, 0, 0);     // black → 0
+    pm.set_rgb(1, 0, 255, 255, 255); // white → 255
+    pm.set_rgb(2, 0, 76, 150, 29);  // approx equal-luminance green (~0.299*76+0.587*150+0.114*29 ≈ 113)
+
+    let gray = pm.to_gray8();
+    assert_eq!(gray.data.len(), 3);
+    assert_eq!(gray.get(0, 0), 0, "black must map to 0");
+    assert_eq!(gray.get(1, 0), 255, "white must map to 255");
+    // 0.299*76 + 0.587*150 + 0.114*29 = 22.7 + 88.1 + 3.3 = 114.1 → 114
+    let lum = gray.get(2, 0);
+    assert!((110..=118).contains(&lum), "luminance should be ~114, got {lum}");
 }
 
 // ── IFF parse_form ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #15

## Summary

- New `GrayPixmap` type (`pixmap.rs`) — 1 byte/pixel, `data.len() == width × height`
- `Pixmap::to_gray8() -> GrayPixmap` — ITU-R BT.601 luminance: `Y = 0.299R + 0.587G + 0.114B` (fixed-point, no floats)
- `djvu_render::render_gray8(page, opts)` — public API that renders RGBA then converts; zero extra decode passes
- `GrayPixmap` re-exported from crate root

## Usage

```rust
use djvu_rs::djvu_render::{render_gray8, RenderOptions};

let opts = RenderOptions::fit_to_width(&page, 800);
let gray = render_gray8(&page, &opts)?;
// gray.data: Vec<u8>, len == gray.width * gray.height
```

For bilevel (JB2-only) pages, output contains only `0` and `255` values.

## Tests

- Bilevel page: assert all pixels are exactly 0 or 255
- Colour page: assert buffer length == width × height  
- Unit: luminance values for black, white, neutral green

All 382 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)