### PR TITLE
feat(render): permissive render mode — skip corrupted chunks

### DIFF
--- a/benches/render.rs
+++ b/benches/render.rs
@@ -58,6 +58,7 @@ fn bench_render_at_dpi(c: &mut Criterion) {
             bold: 0,
             aa: false,
             rotation: djvu_rs::djvu_render::UserRotation::None,
+            permissive: false,
         };
 
         group.bench_with_input(BenchmarkId::new("dpi", dpi), &opts, |b, opts| {
@@ -94,6 +95,7 @@ fn bench_render_coarse(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
+            permissive: false,
     };
 
     c.bench_function("render_coarse", |b| {
@@ -136,6 +138,7 @@ fn bench_render_corpus_color(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
+            permissive: false,
     };
     c.bench_function("render_corpus_color", |b| {
         b.iter(|| {
@@ -179,6 +182,7 @@ fn bench_render_corpus_bilevel(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
+            permissive: false,
     };
     c.bench_function("render_corpus_bilevel", |b| {
         b.iter(|| {

--- a/src/djvu_render.rs
+++ b/src/djvu_render.rs
@@ -107,6 +107,7 @@ pub enum UserRotation {
 ///     bold: 0,
 ///     aa: true,
 ///     rotation: UserRotation::None,
+///     permissive: false,
 /// };
 /// ```
 #[derive(Debug, Clone, PartialEq)]
@@ -123,6 +124,18 @@ pub struct RenderOptions {
     pub aa: bool,
     /// User-requested rotation, combined with the INFO chunk rotation.
     pub rotation: UserRotation,
+    /// When `true`, tolerate corrupted chunks instead of returning an error.
+    ///
+    /// - BG44: decodes chunks until the first decode error; uses whatever
+    ///   was decoded so far (may be empty / blurry).
+    /// - JB2 mask: if decoding fails, renders the background without a mask
+    ///   rather than returning `Err`.
+    ///
+    /// Returns `Ok(pixmap)` even when chunks are skipped. Useful for document
+    /// viewers where a partial render is better than a blank page.
+    ///
+    /// Default: `false` (strict — any decode error propagates as `Err`).
+    pub permissive: bool,
 }
 
 impl Default for RenderOptions {
@@ -134,6 +147,7 @@ impl Default for RenderOptions {
             bold: 0,
             aa: false,
             rotation: UserRotation::None,
+            permissive: false,
         }
     }
 }
@@ -608,6 +622,29 @@ fn decode_background_chunks(
     Ok(Some(pm))
 }
 
+/// Permissive variant: decode BG44 chunks until the first error, then stop.
+///
+/// Returns whatever was decoded so far (may be blurry / incomplete).
+/// Returns `None` only when there are no BG44 chunks at all or even the
+/// first chunk fails to produce a valid image.
+fn decode_background_chunks_permissive(
+    page: &DjVuPage,
+    max_chunks: usize,
+) -> Option<Pixmap> {
+    let bg44_chunks = page.bg44_chunks();
+    if bg44_chunks.is_empty() {
+        return None;
+    }
+
+    let mut img = Iw44Image::new();
+    for chunk_data in bg44_chunks.iter().take(max_chunks) {
+        if img.decode_chunk(chunk_data).is_err() {
+            break; // stop on first error, use what we have
+        }
+    }
+    img.to_rgb().ok()
+}
+
 /// Decode the JB2 mask (Sjbz chunk) without blit tracking.
 fn decode_mask(page: &DjVuPage) -> Result<Option<crate::bitmap::Bitmap>, RenderError> {
     let sjbz = match page.find_chunk(b"Sjbz") {
@@ -960,17 +997,50 @@ pub fn render_pixmap(page: &DjVuPage, opts: &RenderOptions) -> Result<Pixmap, Re
 
     let gamma_lut = build_gamma_lut(page.gamma());
 
-    let bg = decode_background_chunks(page, usize::MAX)?;
-    let fg_palette = decode_fg_palette_full(page)?;
+    // Decode all layers, respecting permissive mode.
+    let bg;
+    let fg_palette;
+    let mask;
+    let blit_map;
+    let fg44;
 
-    let (mask, blit_map) = if fg_palette.is_some() {
-        match decode_mask_indexed(page)? {
-            Some((bm, bm_map)) => (Some(bm), Some(bm_map)),
-            None => (None, None),
+    if opts.permissive {
+        bg = decode_background_chunks_permissive(page, usize::MAX);
+        fg_palette = decode_fg_palette_full(page).ok().flatten();
+        let indexed = if fg_palette.is_some() {
+            decode_mask_indexed(page).ok().flatten()
+        } else {
+            None
+        };
+        if let Some((bm, bm_map)) = indexed {
+            mask = Some(bm);
+            blit_map = Some(bm_map);
+        } else {
+            mask = decode_mask(page).ok().flatten();
+            blit_map = None;
         }
+        fg44 = decode_fg44(page).ok().flatten();
     } else {
-        (decode_mask(page)?, None)
-    };
+        bg = decode_background_chunks(page, usize::MAX)?;
+        fg_palette = decode_fg_palette_full(page)?;
+        let indexed_result = if fg_palette.is_some() {
+            decode_mask_indexed(page)?
+        } else {
+            None
+        };
+        if let Some((bm, bm_map)) = indexed_result {
+            mask = Some(bm);
+            blit_map = Some(bm_map);
+        } else {
+            mask = if fg_palette.is_none() {
+                decode_mask(page)?
+            } else {
+                None
+            };
+            blit_map = None;
+        }
+        fg44 = decode_fg44(page)?;
+    }
 
     let mask = if opts.bold > 0 {
         mask.map(|m| {
@@ -983,7 +1053,6 @@ pub fn render_pixmap(page: &DjVuPage, opts: &RenderOptions) -> Result<Pixmap, Re
     } else {
         mask
     };
-    let fg44 = decode_fg44(page)?;
 
     let mut pm = Pixmap::white(w, h);
 
@@ -1213,6 +1282,7 @@ mod tests {
             bold: 1,
             aa: true,
             rotation: UserRotation::Cw90,
+            permissive: false,
         };
         assert_eq!(opts.width, 400);
         assert_eq!(opts.height, 300);

--- a/tests/document_and_render.rs
+++ b/tests/document_and_render.rs
@@ -422,6 +422,79 @@ fn pixmap_to_gray8_luminance_values() {
     assert!((110..=118).contains(&lum), "luminance should be ~114, got {lum}");
 }
 
+// ── permissive render mode ───────────────────────────────────────────────────
+
+/// Build a DjVu byte buffer with the BG44 chunk data deliberately truncated
+/// to half its original size. Used to test permissive render mode.
+///
+/// DjVu file layout: `AT&T` (4) + `FORM` (4) + form_len (4 BE) + `DJVU` (4) + chunks…
+/// We patch both the BG44 chunk length and the outer FORM chunk length.
+fn make_truncated_bg44_djvu() -> Vec<u8> {
+    let data = std::fs::read("tests/fixtures/boy.djvu").unwrap();
+    // Find BG44 chunk id
+    let bg44_pos = data
+        .windows(4)
+        .position(|w| w == b"BG44")
+        .expect("boy.djvu must have a BG44 chunk");
+    let chunk_len = u32::from_be_bytes(data[bg44_pos + 4..bg44_pos + 8].try_into().unwrap());
+    // Truncate aggressively (keep only 4 bytes) so the IW44 decoder definitely errors.
+    let truncated_len = 4u32;
+    let reduction = chunk_len - truncated_len;
+
+    // Patch the outer FORM length (at offset 8, after AT&T=4 + FORM=4)
+    let form_len = u32::from_be_bytes(data[8..12].try_into().unwrap());
+    let new_form_len = form_len - reduction;
+
+    let header_end = bg44_pos + 8; // after BG44 id + length
+    let mut out = data[..8].to_vec(); // AT&T + FORM
+    out.extend_from_slice(&new_form_len.to_be_bytes()); // patched FORM length
+    out.extend_from_slice(&data[12..bg44_pos + 4]); // DJVU + chunks up to BG44 id
+    out.extend_from_slice(&truncated_len.to_be_bytes()); // patched BG44 length
+    out.extend_from_slice(&data[header_end..header_end + truncated_len as usize]);
+    out
+}
+
+/// Strict mode must return an error on a truncated BG44 chunk.
+#[test]
+fn permissive_strict_fails_on_truncated_bg44() {
+    let corrupted = make_truncated_bg44_djvu();
+    let doc = DjVuDocument::parse(&corrupted).unwrap();
+    let page = doc.page(0).unwrap();
+    let opts = RenderOptions {
+        width: page.width() as u32,
+        height: page.height() as u32,
+        permissive: false,
+        ..RenderOptions::default()
+    };
+    let result = render_pixmap(&page, &opts);
+    assert!(
+        result.is_err(),
+        "strict mode must return Err on corrupted BG44"
+    );
+}
+
+/// Permissive mode must return Ok with a non-empty pixmap on the same file.
+#[test]
+fn permissive_render_returns_ok_on_truncated_bg44() {
+    let corrupted = make_truncated_bg44_djvu();
+    let doc = DjVuDocument::parse(&corrupted).unwrap();
+    let page = doc.page(0).unwrap();
+    let opts = RenderOptions {
+        width: page.width() as u32,
+        height: page.height() as u32,
+        permissive: true,
+        ..RenderOptions::default()
+    };
+    let pm = render_pixmap(&page, &opts)
+        .expect("permissive mode must return Ok even for corrupted BG44");
+    assert!(!pm.data.is_empty(), "pixmap must not be empty");
+    assert_eq!(
+        pm.data.len(),
+        pm.width as usize * pm.height as usize * 4,
+        "pixmap must have correct RGBA size"
+    );
+}
+
 // ── IFF parse_form ──────────────────────────────────────────────────────────
 
 /// find_first returns the first matching chunk.


### PR DESCRIPTION
Closes #19

## Summary

- New `RenderOptions::permissive: bool` field (default `false`)
- When `true`: decode what we can, return `Ok(pixmap)` instead of `Err`
  - BG44: stop on first chunk error, use partial background
  - JB2 mask: failure → render background only (no compositing)
  - FGbz / FG44: errors silently ignored
- When `false`: unchanged strict behaviour

## Tests

Two integration tests using `boy.djvu` with the BG44 chunk data truncated to 4 bytes (FORM length patched to keep the IFF parser happy):
- `permissive_strict_fails_on_truncated_bg44` — strict mode returns `Err`
- `permissive_render_returns_ok_on_truncated_bg44` — permissive mode returns `Ok` with correct RGBA dimensions

All 381 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)