### PR TITLE
feat(text): TextLayer::transform — rotate + scale zone rects for rendered pages (Issue #46)

### DIFF
--- a/src/djvu_document.rs
+++ b/src/djvu_document.rs
@@ -261,6 +261,29 @@ impl DjVuPage {
         Ok(None)
     }
 
+    /// Parse the text layer and transform all zone rectangles to match a
+    /// rendered page of size `render_w × render_h`.
+    ///
+    /// This is a convenience wrapper around [`Self::text_layer`] followed by
+    /// [`TextLayer::transform`].  It applies the page's own rotation (from the
+    /// INFO chunk) and scales coordinates proportionally to the requested
+    /// render size, so callers can use the returned rects directly for text
+    /// selection / copy-paste overlays without any additional maths.
+    ///
+    /// Returns `Ok(None)` if the page has no text layer.
+    pub fn text_layer_at_size(
+        &self,
+        render_w: u32,
+        render_h: u32,
+    ) -> Result<Option<TextLayer>, DocError> {
+        let page_w = self.info.width as u32;
+        let page_h = self.info.height as u32;
+        let rotation = self.info.rotation;
+        Ok(self
+            .text_layer()?
+            .map(|tl| tl.transform(page_w, page_h, rotation, render_w, render_h)))
+    }
+
     /// Extract the plain text content of the page (convenience wrapper).
     ///
     /// Returns `Ok(None)` if the page has no text layer.

--- a/src/text.rs
+++ b/src/text.rs
@@ -27,7 +27,7 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::{bzz_new::bzz_decode, error::BzzError};
+use crate::{bzz_new::bzz_decode, error::BzzError, info::Rotation};
 
 // ---- Error ------------------------------------------------------------------
 
@@ -102,6 +102,120 @@ pub struct TextLayer {
     pub text: String,
     /// Top-level zone nodes (usually a single `Page` zone).
     pub zones: Vec<TextZone>,
+}
+
+impl TextLayer {
+    /// Return a copy of this text layer with all zone rectangles transformed to
+    /// match a rendered page of size `render_w × render_h`.
+    ///
+    /// - `page_w`, `page_h` — native page dimensions from the INFO chunk.
+    /// - `rotation` — page rotation from the INFO chunk.
+    /// - `render_w`, `render_h` — the pixel size of the rendered output.
+    ///
+    /// Applies rotation first (in native pixel space), then scales the result
+    /// proportionally to the requested render size.  The text content is
+    /// preserved unchanged.
+    pub fn transform(
+        &self,
+        page_w: u32,
+        page_h: u32,
+        rotation: Rotation,
+        render_w: u32,
+        render_h: u32,
+    ) -> Self {
+        let (disp_w, disp_h) = match rotation {
+            Rotation::Cw90 | Rotation::Ccw90 => (page_h, page_w),
+            _ => (page_w, page_h),
+        };
+        let t = ZoneTransform {
+            page_w,
+            page_h,
+            rotation,
+            disp_w,
+            disp_h,
+            render_w,
+            render_h,
+        };
+        let zones = self.zones.iter().map(|z| transform_zone(z, &t)).collect();
+        TextLayer {
+            text: self.text.clone(),
+            zones,
+        }
+    }
+}
+
+// ---- Coordinate helpers -----------------------------------------------------
+
+impl Rect {
+    /// Rotate this rectangle within a `page_w × page_h` native coordinate space.
+    ///
+    /// Coordinates are in top-left origin.  Returns the transformed rect in the
+    /// rotated display space (which has dimensions `page_h × page_w` for 90°
+    /// rotations and `page_w × page_h` for 0°/180°).
+    pub fn rotate(&self, page_w: u32, page_h: u32, rotation: Rotation) -> Self {
+        match rotation {
+            Rotation::None => self.clone(),
+            Rotation::Rot180 => Rect {
+                x: page_w.saturating_sub(self.x.saturating_add(self.width)),
+                y: page_h.saturating_sub(self.y.saturating_add(self.height)),
+                width: self.width,
+                height: self.height,
+            },
+            // Clockwise 90°: displayed page is page_h wide × page_w tall.
+            // (x, y, w, h) → (page_h - y - h,  x,  h,  w)
+            Rotation::Cw90 => Rect {
+                x: page_h.saturating_sub(self.y.saturating_add(self.height)),
+                y: self.x,
+                width: self.height,
+                height: self.width,
+            },
+            // Counter-clockwise 90°: displayed page is page_h wide × page_w tall.
+            // (x, y, w, h) → (y,  page_w - x - w,  h,  w)
+            Rotation::Ccw90 => Rect {
+                x: self.y,
+                y: page_w.saturating_sub(self.x.saturating_add(self.width)),
+                width: self.height,
+                height: self.width,
+            },
+        }
+    }
+
+    /// Scale this rectangle from a `from_w × from_h` space to `to_w × to_h`.
+    pub fn scale(&self, from_w: u32, from_h: u32, to_w: u32, to_h: u32) -> Self {
+        if from_w == 0 || from_h == 0 {
+            return self.clone();
+        }
+        Rect {
+            x: (self.x as u64 * to_w as u64 / from_w as u64) as u32,
+            y: (self.y as u64 * to_h as u64 / from_h as u64) as u32,
+            width: (self.width as u64 * to_w as u64 / from_w as u64) as u32,
+            height: (self.height as u64 * to_h as u64 / from_h as u64) as u32,
+        }
+    }
+}
+
+/// Parameters for `transform_zone` — groups the 7 invariants so we stay
+/// under clippy's `too_many_arguments` limit.
+struct ZoneTransform {
+    page_w: u32,
+    page_h: u32,
+    rotation: Rotation,
+    disp_w: u32,
+    disp_h: u32,
+    render_w: u32,
+    render_h: u32,
+}
+
+fn transform_zone(zone: &TextZone, t: &ZoneTransform) -> TextZone {
+    let rotated = zone.rect.rotate(t.page_w, t.page_h, t.rotation);
+    let scaled = rotated.scale(t.disp_w, t.disp_h, t.render_w, t.render_h);
+    let children = zone.children.iter().map(|c| transform_zone(c, t)).collect();
+    TextZone {
+        kind: zone.kind,
+        rect: scaled,
+        text: zone.text.clone(),
+        children,
+    }
 }
 
 // ---- Entry points -----------------------------------------------------------
@@ -506,6 +620,144 @@ mod tests {
         let result = parse_text_layer(&data, 100).unwrap();
         assert_eq!(result.text, "Hello");
         assert!(result.zones.is_empty());
+    }
+
+    // ── TextLayer::transform ─────────────────────────────────────────────────
+
+    fn make_layer(x: u32, y: u32, w: u32, h: u32) -> TextLayer {
+        TextLayer {
+            text: "test".to_string(),
+            zones: vec![TextZone {
+                kind: TextZoneKind::Page,
+                rect: Rect {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                },
+                text: "test".to_string(),
+                children: vec![],
+            }],
+        }
+    }
+
+    fn rect0(layer: &TextLayer) -> &Rect {
+        &layer.zones[0].rect
+    }
+
+    #[test]
+    fn transform_none_identity() {
+        // No rotation, 1:1 scale — rects unchanged
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::None, 100, 200);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 10,
+                y: 20,
+                width: 30,
+                height: 40
+            }
+        );
+    }
+
+    #[test]
+    fn transform_none_scale_2x() {
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::None, 200, 400);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 20,
+                y: 40,
+                width: 60,
+                height: 80
+            }
+        );
+    }
+
+    #[test]
+    fn transform_rot180() {
+        // page 100×200, rect (10, 20, 30, 40)
+        // new_x = 100 - 10 - 30 = 60
+        // new_y = 200 - 20 - 40 = 140
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::Rot180, 100, 200);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 60,
+                y: 140,
+                width: 30,
+                height: 40
+            }
+        );
+    }
+
+    #[test]
+    fn transform_cw90() {
+        // page 100×200, rect (x=10, y=20, w=30, h=40)
+        // displayed: 200 wide × 100 tall
+        // new_x = page_h - y - h = 200 - 20 - 40 = 140
+        // new_y = x = 10
+        // new_w = h = 40,  new_h = w = 30
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::Cw90, 200, 100);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 140,
+                y: 10,
+                width: 40,
+                height: 30
+            }
+        );
+    }
+
+    #[test]
+    fn transform_ccw90() {
+        // page 100×200, rect (x=10, y=20, w=30, h=40)
+        // displayed: 200 wide × 100 tall
+        // new_x = y = 20
+        // new_y = page_w - x - w = 100 - 10 - 30 = 60
+        // new_w = h = 40,  new_h = w = 30
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::Ccw90, 200, 100);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 20,
+                y: 60,
+                width: 40,
+                height: 30
+            }
+        );
+    }
+
+    #[test]
+    fn transform_cw90_then_scale() {
+        // page 100×200, rect (10, 20, 30, 40), render at 2× (400×200)
+        // After Cw90: (140, 10, 40, 30) in 200×100 space
+        // Scale ×2: (280, 20, 80, 60)
+        let layer = make_layer(10, 20, 30, 40);
+        let out = layer.transform(100, 200, Rotation::Cw90, 400, 200);
+        assert_eq!(
+            *rect0(&out),
+            Rect {
+                x: 280,
+                y: 20,
+                width: 80,
+                height: 60
+            }
+        );
+    }
+
+    #[test]
+    fn transform_text_preserved() {
+        let layer = make_layer(0, 0, 10, 10);
+        let out = layer.transform(100, 100, Rotation::Cw90, 100, 100);
+        assert_eq!(out.text, "test");
+        assert_eq!(out.zones[0].text, "test");
     }
 
     #[test]

--- a/tests/document_and_render.rs
+++ b/tests/document_and_render.rs
@@ -4,7 +4,9 @@
 
 use djvu_rs::IffError;
 use djvu_rs::djvu_document::{DjVuDocument, DocError};
-use djvu_rs::djvu_render::{RenderOptions, render_coarse, render_gray8, render_pixmap, render_progressive};
+use djvu_rs::djvu_render::{
+    RenderOptions, render_coarse, render_gray8, render_pixmap, render_progressive,
+};
 use djvu_rs::iff::parse_form;
 
 // ── DjVuDocument — parse ──────────────────────────────────────────────────────
@@ -358,7 +360,7 @@ fn render_gray8_bilevel_only_black_and_white() {
         height: page.height() as u32,
         ..RenderOptions::default()
     };
-    let gray = render_gray8(&page, &opts).expect("render_gray8 must succeed");
+    let gray = render_gray8(page, &opts).expect("render_gray8 must succeed");
 
     assert_eq!(
         gray.data.len(),
@@ -394,7 +396,7 @@ fn render_gray8_color_page_correct_size() {
         height: page.height() as u32,
         ..RenderOptions::default()
     };
-    let gray = render_gray8(&page, &opts).expect("render_gray8 must succeed for colour page");
+    let gray = render_gray8(page, &opts).expect("render_gray8 must succeed for colour page");
 
     assert_eq!(
         gray.data.len(),
@@ -409,9 +411,9 @@ fn pixmap_to_gray8_luminance_values() {
     use djvu_rs::Pixmap;
 
     let mut pm = Pixmap::white(3, 1);
-    pm.set_rgb(0, 0, 0, 0, 0);     // black → 0
+    pm.set_rgb(0, 0, 0, 0, 0); // black → 0
     pm.set_rgb(1, 0, 255, 255, 255); // white → 255
-    pm.set_rgb(2, 0, 76, 150, 29);  // approx equal-luminance green (~0.299*76+0.587*150+0.114*29 ≈ 113)
+    pm.set_rgb(2, 0, 76, 150, 29); // approx equal-luminance green (~0.299*76+0.587*150+0.114*29 ≈ 113)
 
     let gray = pm.to_gray8();
     assert_eq!(gray.data.len(), 3);
@@ -419,7 +421,10 @@ fn pixmap_to_gray8_luminance_values() {
     assert_eq!(gray.get(1, 0), 255, "white must map to 255");
     // 0.299*76 + 0.587*150 + 0.114*29 = 22.7 + 88.1 + 3.3 = 114.1 → 114
     let lum = gray.get(2, 0);
-    assert!((110..=118).contains(&lum), "luminance should be ~114, got {lum}");
+    assert!(
+        (110..=118).contains(&lum),
+        "luminance should be ~114, got {lum}"
+    );
 }
 
 // ── permissive render mode ───────────────────────────────────────────────────
@@ -466,7 +471,7 @@ fn permissive_strict_fails_on_truncated_bg44() {
         permissive: false,
         ..RenderOptions::default()
     };
-    let result = render_pixmap(&page, &opts);
+    let result = render_pixmap(page, &opts);
     assert!(
         result.is_err(),
         "strict mode must return Err on corrupted BG44"
@@ -485,8 +490,8 @@ fn permissive_render_returns_ok_on_truncated_bg44() {
         permissive: true,
         ..RenderOptions::default()
     };
-    let pm = render_pixmap(&page, &opts)
-        .expect("permissive mode must return Ok even for corrupted BG44");
+    let pm =
+        render_pixmap(page, &opts).expect("permissive mode must return Ok even for corrupted BG44");
     assert!(!pm.data.is_empty(), "pixmap must not be empty");
     assert_eq!(
         pm.data.len(),


### PR DESCRIPTION
## Summary

- Adds `TextLayer::transform(page_w, page_h, rotation, render_w, render_h)` — applies rotation (all 4 DjVu variants) then proportional scaling to every zone rect in the tree
- Adds `DjVuPage::text_layer_at_size(render_w, render_h)` convenience wrapper that reads rotation from the INFO chunk automatically
- Adds `Rect::rotate` and `Rect::scale` helper methods (public for downstream use)
- Fixes pre-existing `clippy::needless_borrow` warnings in integration tests
- 7 new unit tests covering identity, 2× scale, Rot180, Cw90, Ccw90, combined rotation+scale, and text preservation

## Test plan

- [x] `cargo test --lib` — 281 unit tests pass
- [x] `cargo test --test document_and_render` — 34 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)