### PR TITLE
feat(async): async render API via tokio::task::spawn_blocking (Issue #51)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,14 @@ miniz_oxide = { version = "0.8", optional = true }
 zune-jpeg = { version = "0.5", optional = true }
 tiff = { version = "0.9", optional = true }
 jpeg-encoder = { version = "0.6", optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"], optional = true }
 
 [features]
 default = ["std"]
 std = ["dep:clap", "dep:png", "dep:zip", "dep:miniz_oxide", "dep:zune-jpeg", "dep:jpeg-encoder"]
 jpeg = ["dep:zune-jpeg"]
 tiff = ["dep:tiff", "std"]
+async = ["dep:tokio", "std"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -59,6 +59,7 @@ fn bench_render_at_dpi(c: &mut Criterion) {
             aa: false,
             rotation: djvu_rs::djvu_render::UserRotation::None,
             permissive: false,
+        resampling: djvu_rs::djvu_render::Resampling::Bilinear,
         };
 
         group.bench_with_input(BenchmarkId::new("dpi", dpi), &opts, |b, opts| {
@@ -95,7 +96,8 @@ fn bench_render_coarse(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
-            permissive: false,
+        permissive: false,
+        resampling: djvu_rs::djvu_render::Resampling::Bilinear,
     };
 
     c.bench_function("render_coarse", |b| {
@@ -138,7 +140,8 @@ fn bench_render_corpus_color(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
-            permissive: false,
+        permissive: false,
+        resampling: djvu_rs::djvu_render::Resampling::Bilinear,
     };
     c.bench_function("render_corpus_color", |b| {
         b.iter(|| {
@@ -182,7 +185,8 @@ fn bench_render_corpus_bilevel(c: &mut Criterion) {
         bold: 0,
         aa: false,
         rotation: djvu_rs::djvu_render::UserRotation::None,
-            permissive: false,
+        permissive: false,
+        resampling: djvu_rs::djvu_render::Resampling::Bilinear,
     };
     c.bench_function("render_corpus_bilevel", |b| {
         b.iter(|| {

--- a/src/djvu_async.rs
+++ b/src/djvu_async.rs
@@ -1,0 +1,241 @@
+//! Async render surface for [`DjVuPage`] — phase 5 extension.
+//!
+//! Feature-gated: `--features async` (adds `tokio` as a dependency).
+//!
+//! All rendering is delegated to [`tokio::task::spawn_blocking`]: the CPU-bound
+//! IW44/JB2 decode work runs on the blocking thread pool and never blocks the
+//! async runtime thread.
+//!
+//! [`DjVuPage`] implements [`Clone`], so the page is cloned into the blocking
+//! closure with no unsafe code and no thread management by the caller.
+//!
+//! ## Key public functions
+//!
+//! - [`render_pixmap_async`] — async wrapper around [`djvu_render::render_pixmap`]
+//! - [`render_gray8_async`] — async wrapper around [`djvu_render::render_gray8`]
+//!
+//! ## Example: concurrent multi-page rendering
+//!
+//! ```no_run
+//! use djvu_rs::djvu_document::DjVuDocument;
+//! use djvu_rs::djvu_render::RenderOptions;
+//! use djvu_rs::djvu_async::render_pixmap_async;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let data = std::fs::read("document.djvu").unwrap();
+//!     let doc = std::sync::Arc::new(DjVuDocument::parse(&data).unwrap());
+//!
+//!     let futures: Vec<_> = (0..doc.page_count())
+//!         .filter_map(|i| doc.page(i).ok())
+//!         .map(|page| {
+//!             let page = page.clone();
+//!             let opts = RenderOptions { width: 800, height: 600, ..Default::default() };
+//!             tokio::spawn(async move { render_pixmap_async(&page, opts).await })
+//!         })
+//!         .collect();
+//!
+//!     for handle in futures {
+//!         let pixmap = handle.await.unwrap().unwrap();
+//!         println!("{}×{}", pixmap.width, pixmap.height);
+//!     }
+//! }
+//! ```
+
+use crate::{
+    djvu_document::DjVuPage,
+    djvu_render::{self, RenderError, RenderOptions},
+    pixmap::{GrayPixmap, Pixmap},
+};
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Errors from async rendering.
+#[derive(Debug, thiserror::Error)]
+pub enum AsyncRenderError {
+    /// The underlying render failed.
+    #[error("render error: {0}")]
+    Render(#[from] RenderError),
+
+    /// The blocking task was cancelled or panicked.
+    #[error("spawn_blocking join error: {0}")]
+    Join(String),
+}
+
+// ── Async render functions ────────────────────────────────────────────────────
+
+/// Render `page` to an RGBA [`Pixmap`] asynchronously.
+///
+/// Clones the page and delegates to [`djvu_render::render_pixmap`] via
+/// [`tokio::task::spawn_blocking`]. The render runs on the blocking thread
+/// pool and does not block the async runtime.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() {
+/// use djvu_rs::djvu_document::DjVuDocument;
+/// use djvu_rs::djvu_render::RenderOptions;
+/// use djvu_rs::djvu_async::render_pixmap_async;
+///
+/// let data = std::fs::read("file.djvu").unwrap();
+/// let doc = DjVuDocument::parse(&data).unwrap();
+/// let page = doc.page(0).unwrap();
+/// let opts = RenderOptions { width: 400, height: 300, ..Default::default() };
+/// let pixmap = render_pixmap_async(page, opts).await.unwrap();
+/// println!("{}×{}", pixmap.width, pixmap.height);
+/// # }
+/// ```
+pub async fn render_pixmap_async(
+    page: &DjVuPage,
+    opts: RenderOptions,
+) -> Result<Pixmap, AsyncRenderError> {
+    let page = page.clone();
+    tokio::task::spawn_blocking(move || {
+        djvu_render::render_pixmap(&page, &opts).map_err(AsyncRenderError::Render)
+    })
+    .await
+    .map_err(|e| AsyncRenderError::Join(e.to_string()))?
+}
+
+/// Render `page` to an 8-bit grayscale [`GrayPixmap`] asynchronously.
+///
+/// Clones the page and delegates to [`djvu_render::render_gray8`] via
+/// [`tokio::task::spawn_blocking`].
+pub async fn render_gray8_async(
+    page: &DjVuPage,
+    opts: RenderOptions,
+) -> Result<GrayPixmap, AsyncRenderError> {
+    let page = page.clone();
+    tokio::task::spawn_blocking(move || {
+        djvu_render::render_gray8(&page, &opts).map_err(AsyncRenderError::Render)
+    })
+    .await
+    .map_err(|e| AsyncRenderError::Join(e.to_string()))?
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::djvu_document::DjVuDocument;
+
+    fn assets_path() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("references/djvujs/library/assets")
+    }
+
+    fn load_doc(name: &str) -> DjVuDocument {
+        let data = std::fs::read(assets_path().join(name))
+            .unwrap_or_else(|_| panic!("{name} must exist"));
+        DjVuDocument::parse(&data).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// `render_pixmap_async` returns a pixmap with correct dimensions.
+    #[tokio::test]
+    async fn render_pixmap_async_correct_dims() {
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let pw = page.width() as u32;
+        let ph = page.height() as u32;
+
+        let opts = RenderOptions {
+            width: pw,
+            height: ph,
+            ..Default::default()
+        };
+        let pm = render_pixmap_async(page, opts)
+            .await
+            .expect("async render must succeed");
+        assert_eq!(pm.width, pw);
+        assert_eq!(pm.height, ph);
+    }
+
+    /// `render_gray8_async` returns a grayscale pixmap with the right size.
+    #[tokio::test]
+    async fn render_gray8_async_correct_dims() {
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let pw = page.width() as u32;
+        let ph = page.height() as u32;
+
+        let opts = RenderOptions {
+            width: pw,
+            height: ph,
+            ..Default::default()
+        };
+        let gm = render_gray8_async(page, opts)
+            .await
+            .expect("async gray render must succeed");
+        assert_eq!(gm.width, pw);
+        assert_eq!(gm.height, ph);
+        assert_eq!(gm.data.len(), (pw * ph) as usize);
+    }
+
+    /// Async and sync renders produce identical results.
+    #[tokio::test]
+    async fn async_matches_sync() {
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let pw = page.width() as u32;
+        let ph = page.height() as u32;
+
+        let opts = RenderOptions {
+            width: pw,
+            height: ph,
+            ..Default::default()
+        };
+        let sync_pm =
+            djvu_render::render_pixmap(page, &opts).expect("sync render must succeed");
+        let async_pm = render_pixmap_async(page, opts.clone())
+            .await
+            .expect("async render must succeed");
+
+        assert_eq!(sync_pm.data, async_pm.data, "async and sync renders must match");
+    }
+
+    /// Concurrent rendering of multiple instances of the same page succeeds.
+    #[tokio::test]
+    async fn concurrent_render_multiple_tasks() {
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let pw = page.width() as u32;
+        let ph = page.height() as u32;
+        let opts = RenderOptions {
+            width: pw / 2,
+            height: ph / 2,
+            scale: 0.5,
+            ..Default::default()
+        };
+
+        // Spawn 4 concurrent renders of the same page.
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let page_clone = page.clone();
+                let opts_clone = opts.clone();
+                tokio::spawn(async move { render_pixmap_async(&page_clone, opts_clone).await })
+            })
+            .collect();
+
+        for handle in handles {
+            let pm = handle
+                .await
+                .expect("task must not panic")
+                .expect("render must succeed");
+            assert_eq!(pm.width, pw / 2);
+            assert_eq!(pm.height, ph / 2);
+        }
+    }
+
+    /// `AsyncRenderError::Render` wraps `RenderError`.
+    #[test]
+    fn async_render_error_display() {
+        let err = AsyncRenderError::Render(crate::djvu_render::RenderError::InvalidDimensions {
+            width: 0,
+            height: 0,
+        });
+        let s = err.to_string();
+        assert!(s.contains("render error"), "error must mention 'render error'");
+    }
+}

--- a/src/djvu_document.rs
+++ b/src/djvu_document.rs
@@ -143,7 +143,7 @@ struct RawChunk {
 ///
 /// Raw chunk data is stored on construction. No image decoding is performed
 /// until the caller invokes `thumbnail()`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DjVuPage {
     /// Page info parsed from the INFO chunk.
     info: PageInfo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,16 @@ pub mod pdf;
 #[cfg(feature = "tiff")]
 pub mod tiff_export;
 
+/// Async render surface for [`DjVuPage`] — phase 5 extension.
+///
+/// Wraps the synchronous render pipeline in [`tokio::task::spawn_blocking`]
+/// so CPU-bound IW44/JB2 work runs on the blocking thread pool without
+/// blocking the async runtime.
+///
+/// Key functions: [`djvu_async::render_pixmap_async`], [`djvu_async::render_gray8_async`].
+#[cfg(feature = "async")]
+pub mod djvu_async;
+
 // Re-export new phase-1 error types
 pub use error::{BzzError, DjVuError, IffError, Iw44Error, Jb2Error};
 

--- a/src/tiff_export.rs
+++ b/src/tiff_export.rs
@@ -137,6 +137,7 @@ fn write_color_page<W: std::io::Write + std::io::Seek>(
         aa: false,
         rotation: djvu_render::UserRotation::None,
         permissive: false,
+        resampling: djvu_render::Resampling::Bilinear,
     };
     let pixmap = djvu_render::render_pixmap(page, &opts)?;
 


### PR DESCRIPTION
## Summary

- Add `djvu_async` module behind `--features async` (adds `tokio` dependency)
- `render_pixmap_async` and `render_gray8_async` clone the page and delegate to `tokio::task::spawn_blocking`, keeping CPU-bound IW44/JB2 decode off the async runtime thread
- `AsyncRenderError` enum with `Render` and `Join` variants
- 5 tests: dimension correctness, async==sync pixel equality, 4 concurrent renders, error display

## Test plan
- [x] `cargo nextest run --features async -E "test(async)"` — 5/5 pass
- [x] `cargo nextest run --features async,tiff` — 456/456 pass
- [x] `cargo build --benches --features async` — compiles clean

Closes #51