### PR TITLE
fix(ci): core::mem::take for no_std + clippy redundant-Some

### DIFF
--- a/src/jb2_new.rs
+++ b/src/jb2_new.rs
@@ -214,7 +214,7 @@ impl Jbm {
         }
         // Zero the portion we will use (including any bytes reused from a previous symbol).
         pool[..pixels].fill(0u8);
-        let mut data = std::mem::take(pool);
+        let mut data = core::mem::take(pool);
         data.truncate(pixels);
         Jbm {
             width,

--- a/tests/ocr_export.rs
+++ b/tests/ocr_export.rs
@@ -18,7 +18,7 @@ mod tests {
         // The chicken.djvu may or may not have a text layer.
         // Find any test file that does.
         let data = std::fs::read(chicken_path()).ok()?;
-        Some(DjVuDocument::parse(&data).ok()?)
+        DjVuDocument::parse(&data).ok()
     }
 
     // ---- hOCR tests ---------------------------------------------------------


### PR DESCRIPTION
Two CI failures introduced by issue #90 and #75 agents:

- `src/jb2_new.rs`: `std::mem::take` → `core::mem::take` — jb2_new compiles in no_std mode; using `std::` breaks `cargo build --no-default-features`
- `tests/ocr_export.rs:21`: `Some(x.ok()?)\ is flagged by clippy as redundant enclosing Some; simplified to `x.ok()`