### PR TITLE
feat(ci): continuous benchmark tracking — PR regression detection (Issue #88)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,16 +1,32 @@
 name: Benchmarks
 
 on:
-  # Run on every release tag — results are the source of truth for BENCHMARKS.md.
+  # Track regressions on every PR that touches code or benchmarks.
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+
+  # Update the baseline on every merge to main (same path filter).
   push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+    # Always run on release tags regardless of paths.
     tags:
       - 'v*'
-  # Allow manual triggering to collect results mid-cycle.
+
+  # Allow manual runs (e.g. to seed the initial baseline).
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,18 +35,16 @@ env:
 
 jobs:
   bench:
-    name: Benchmark (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: Benchmark
+    # Single platform for reproducible comparisons.
+    # (macos-latest numbers are kept separately via workflow_dispatch / tags.)
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write  # needed to post the comparison comment
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Include large corpus files if tracked via LFS or submodules
-          lfs: false
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -38,36 +52,134 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: bench-${{ matrix.os }}
+          key: bench-ubuntu
 
-      # Run codec benchmarks (always available — uses assets/references/)
+      # ── Download baseline from last successful main-branch run (PR only) ────
+      - name: Download baseline
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: bench-baseline
+          branch: main
+          workflow: bench.yml
+          workflow_conclusion: success
+          path: baseline
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      # ── Run benchmarks ───────────────────────────────────────────────────────
       - name: Bench codecs
         run: cargo bench --bench codecs -- --output-format bencher 2>&1 | tee codec_bench.txt
         continue-on-error: true
 
-      # Run render benchmarks (uses references/ assets)
       - name: Bench render
         run: cargo bench --bench render -- --output-format bencher 2>&1 | tee render_bench.txt
         continue-on-error: true
 
-      # Show a readable summary
+      # ── Print summary ────────────────────────────────────────────────────────
       - name: Print results
         run: |
-          echo "=== Platform: ${{ matrix.os }} ==="
           echo "--- Codec benchmarks ---"
           grep "bench:" codec_bench.txt || echo "(no codec results)"
           echo ""
           echo "--- Render benchmarks ---"
           grep "bench:" render_bench.txt || echo "(no render results)"
 
-      # Upload raw Criterion HTML reports and raw output as workflow artifacts.
-      - name: Upload bench artifacts
+      # ── Compare against baseline and generate Markdown table (PR only) ──────
+      - name: Compare benchmarks
+        if: github.event_name == 'pull_request'
+        id: compare
+        run: |
+          python3 scripts/bench_compare.py \
+            baseline/target/criterion \
+            target/criterion \
+            > bench_comment.md
+          echo "regression_exit=$?" >> "$GITHUB_OUTPUT"
+          cat bench_comment.md
+        continue-on-error: true  # don't skip comment posting on failure
+
+      - name: Post benchmark comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bench
+          path: bench_comment.md
+        continue-on-error: true  # comment failure must not hide regression result
+
+      # Fail the job if the compare script reported regressions.
+      - name: Fail on regression
+        if: github.event_name == 'pull_request' && steps.compare.outputs.regression_exit == '1'
+        run: |
+          echo "Benchmark regressions detected — see PR comment for details."
+          exit 1
+
+      # ── Upload baseline (main branch + tags) ─────────────────────────────────
+      - name: Upload baseline
+        if: >
+          github.event_name == 'push' &&
+          (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-artifact@v4
         with:
-          name: bench-results-${{ matrix.os }}
+          name: bench-baseline
+          # Overwrite the previous baseline so PRs always compare against HEAD of main.
+          overwrite: true
+          path: target/criterion/
+          retention-days: 90
+
+      # ── Always archive full results ──────────────────────────────────────────
+      - name: Upload full results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-${{ github.sha }}
+          path: |
+            codec_bench.txt
+            render_bench.txt
+            target/criterion/
+          retention-days: 30
+
+  # ── macOS run: tags and manual only (for BENCHMARKS.md) ─────────────────────
+  bench-macos:
+    name: Benchmark (macOS)
+    runs-on: macos-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: bench-macos
+
+      - name: Bench codecs
+        run: cargo bench --bench codecs -- --output-format bencher 2>&1 | tee codec_bench.txt
+        continue-on-error: true
+
+      - name: Bench render
+        run: cargo bench --bench render -- --output-format bencher 2>&1 | tee render_bench.txt
+        continue-on-error: true
+
+      - name: Print results
+        run: |
+          echo "--- Codec benchmarks (macOS) ---"
+          grep "bench:" codec_bench.txt || echo "(no codec results)"
+          echo ""
+          echo "--- Render benchmarks (macOS) ---"
+          grep "bench:" render_bench.txt || echo "(no render results)"
+
+      - name: Upload full results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-results-macos-${{ github.sha }}
           path: |
             codec_bench.txt
             render_bench.txt
             target/criterion/
           retention-days: 90
-        if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,15 +9,11 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
 
-  # Update the baseline on every merge to main (same path filter).
+  # Update the baseline on every merge to main and on every release tag.
+  # No path filter here — main pushes are infrequent (one per merged PR)
+  # and tags should always produce fresh numbers regardless of what changed.
   push:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'benches/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-    # Always run on release tags regardless of paths.
     tags:
       - 'v*'
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      actions: read         # needed by dawidd6/action-download-artifact to list artifacts
       pull-requests: write  # needed to post the comparison comment
 
     steps:

--- a/scripts/bench_compare.py
+++ b/scripts/bench_compare.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Compare two sets of Criterion benchmark results and report regressions.
+
+Usage:
+    python3 scripts/bench_compare.py <baseline_criterion_dir> <current_criterion_dir>
+
+Exits with code 0 when no regressions exceed the threshold, 1 otherwise.
+Outputs a Markdown table suitable for posting as a PR comment.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REGRESSION_THRESHOLD = 0.05  # 5 %
+
+
+def load_results(criterion_dir: Path) -> dict[str, float]:
+    """Return {bench_path: mean_ns} for every estimates.json under criterion_dir."""
+    results: dict[str, float] = {}
+    for f in sorted(criterion_dir.rglob("*/new/estimates.json")):
+        rel = f.relative_to(criterion_dir)
+        # rel parts: <group>/<bench>/new/estimates.json  → drop last two
+        bench_name = "/".join(rel.parts[:-2])
+        try:
+            data = json.loads(f.read_text())
+            results[bench_name] = data["mean"]["point_estimate"]
+        except (KeyError, json.JSONDecodeError):
+            continue
+    return results
+
+
+def fmt_ns(ns: float) -> str:
+    if ns >= 1_000_000_000:
+        return f"{ns / 1_000_000_000:.3f} s"
+    if ns >= 1_000_000:
+        return f"{ns / 1_000_000:.2f} ms"
+    if ns >= 1_000:
+        return f"{ns / 1_000:.1f} µs"
+    return f"{ns:.0f} ns"
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <baseline_dir> <current_dir>", file=sys.stderr)
+        return 2
+
+    baseline_dir = Path(sys.argv[1])
+    current_dir = Path(sys.argv[2])
+
+    baseline = load_results(baseline_dir) if baseline_dir.exists() else {}
+    current = load_results(current_dir) if current_dir.exists() else {}
+
+    if not current:
+        print("No benchmark results found in current run.")
+        return 0
+
+    if not baseline:
+        print("### Benchmark results (no baseline for comparison)\n")
+        print("| Benchmark | Current |")
+        print("|-----------|---------|")
+        for name, cur in sorted(current.items()):
+            print(f"| `{name}` | {fmt_ns(cur)} |")
+        return 0
+
+    regressions: list[tuple[str, float, float, float]] = []
+    rows: list[str] = []
+
+    all_names = sorted(set(baseline) | set(current))
+    for name in all_names:
+        cur = current.get(name)
+        base = baseline.get(name)
+
+        if cur is None:
+            rows.append(f"| `{name}` | {fmt_ns(base)} | — | removed |")
+            continue
+        if base is None:
+            rows.append(f"| `{name}` | — | {fmt_ns(cur)} | new |")
+            continue
+
+        delta = (cur - base) / base
+        sign = "+" if delta >= 0 else ""
+        badge = ""
+        if delta > REGRESSION_THRESHOLD:
+            regressions.append((name, base, cur, delta))
+            badge = " ⚠️"
+        elif delta < -REGRESSION_THRESHOLD:
+            badge = " ✅"
+        rows.append(
+            f"| `{name}` | {fmt_ns(base)} | {fmt_ns(cur)} | {sign}{delta * 100:.1f}%{badge} |"
+        )
+
+    print("### Benchmark comparison\n")
+    if regressions:
+        print(
+            f"> **{len(regressions)} regression(s) detected** "
+            f"(threshold: {REGRESSION_THRESHOLD * 100:.0f}%)\n"
+        )
+    print("| Benchmark | Baseline | Current | Delta |")
+    print("|-----------|----------|---------|-------|")
+    for row in rows:
+        print(row)
+
+    if regressions:
+        print()
+        for name, base, cur, delta in regressions:
+            print(f"- `{name}`: {fmt_ns(base)} → {fmt_ns(cur)} (+{delta * 100:.1f}%)")
+        return 1
+
+    print(f"\nNo regressions above {REGRESSION_THRESHOLD * 100:.0f}% threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Benchmark workflow now runs on every PR and main push that touches `src/`, `benches/`, `Cargo.toml`, or `Cargo.lock`
- New `scripts/bench_compare.py` parses Criterion JSON, outputs a Markdown diff table, exits 1 on regressions > 5%
- PR jobs download the last successful baseline from `main`, run benches, post a sticky comment, and fail CI if regressions are detected
- Baseline artifact auto-updated on every merge to `main`
- macOS benchmarks remain tag/manual-only (for BENCHMARKS.md accuracy)

## How it works

1. On merge to `main`: `bench` job uploads `target/criterion/` as artifact `bench-baseline`
2. On PR: job downloads `bench-baseline` → runs current benchmarks → `bench_compare.py baseline/target/criterion target/criterion` → sticky comment → fails if exit 1

## Example PR comment

```
### Benchmark comparison

| Benchmark | Baseline | Current | Delta |
|-----------|----------|---------|-------|
| `render_page/dpi/300` | 4.61 ms | 4.95 ms | +7.4% ⚠️ |
| `jb2_decode` | 189.3 µs | 185.1 µs | -2.2% |

> **1 regression(s) detected** (threshold: 5%)
```

Closes #88

🤖 Generated with [Claude Code](https://claude.ai/code)