### PR TITLE
feat(async): progressive stream render API (Issue #81)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ zune-jpeg = { version = "0.5", optional = true }
 tiff = { version = "0.9", optional = true }
 jpeg-encoder = { version = "0.6", optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"], optional = true }
+async-stream = { version = "0.3", optional = true }
+futures-core = { version = "0.3", optional = true }
 rayon = { version = "1", optional = true }
 memmap2 = { version = "0.9", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
@@ -50,7 +52,7 @@ default = ["std"]
 std = ["dep:clap", "dep:png", "dep:zip", "dep:miniz_oxide", "dep:zune-jpeg", "dep:jpeg-encoder"]
 jpeg = ["dep:zune-jpeg"]
 tiff = ["dep:tiff", "std"]
-async = ["dep:tokio", "std"]
+async = ["dep:tokio", "dep:async-stream", "dep:futures-core", "std"]
 parallel = ["dep:rayon", "std"]
 mmap = ["dep:memmap2", "std"]
 serde = ["dep:serde"]
@@ -62,6 +64,7 @@ assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
 serde_json = "1"
+futures = "0.3"
 
 [[bin]]
 name = "djvu"

--- a/src/djvu_async.rs
+++ b/src/djvu_async.rs
@@ -13,6 +13,7 @@
 //!
 //! - [`render_pixmap_async`] — async wrapper around [`djvu_render::render_pixmap`]
 //! - [`render_gray8_async`] — async wrapper around [`djvu_render::render_gray8`]
+//! - [`render_progressive_stream`] — streaming progressive render yielding one frame per BG44 chunk
 //!
 //! ## Example: concurrent multi-page rendering
 //!
@@ -112,6 +113,74 @@ pub async fn render_gray8_async(
     })
     .await
     .map_err(|e| AsyncRenderError::Join(e.to_string()))?
+}
+
+/// Render a `DjVuPage` as a lazy progressive stream of [`Pixmap`] frames.
+///
+/// Yields one frame per BG44 wavelet refinement chunk: the first frame is the
+/// coarsest (fastest to produce), and each subsequent frame adds detail. The
+/// final frame is equivalent to [`render_pixmap`][djvu_render::render_pixmap].
+///
+/// If the page has no BG44 chunks (bilevel JB2-only pages), exactly one frame
+/// is yielded via [`render_pixmap`][djvu_render::render_pixmap].
+///
+/// Each frame is produced via [`tokio::task::spawn_blocking`] just before it is
+/// yielded, so the stream never blocks the async runtime thread.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() {
+/// use djvu_rs::djvu_document::DjVuDocument;
+/// use djvu_rs::djvu_render::RenderOptions;
+/// use djvu_rs::djvu_async::render_progressive_stream;
+/// use futures::StreamExt;
+///
+/// let data = std::fs::read("file.djvu").unwrap();
+/// let doc = DjVuDocument::parse(&data).unwrap();
+/// let page = doc.page(0).unwrap();
+/// let opts = RenderOptions { width: 800, height: 600, ..Default::default() };
+///
+/// let stream = render_progressive_stream(page, opts);
+/// futures::pin_mut!(stream);
+/// while let Some(pixmap) = stream.next().await {
+///     let pixmap = pixmap.unwrap();
+///     println!("{}×{}", pixmap.width, pixmap.height);
+/// }
+/// # }
+/// ```
+pub fn render_progressive_stream(
+    page: &DjVuPage,
+    opts: RenderOptions,
+) -> impl futures_core::Stream<Item = Result<Pixmap, AsyncRenderError>> {
+    let page = page.clone();
+    let n_chunks = page.bg44_chunks().len();
+
+    async_stream::stream! {
+        if n_chunks == 0 {
+            // No BG44 chunks (JB2-only page): yield a single frame.
+            let page = page.clone();
+            let opts = opts.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                djvu_render::render_pixmap(&page, &opts).map_err(AsyncRenderError::Render)
+            })
+            .await
+            .map_err(|e| AsyncRenderError::Join(e.to_string()));
+            yield result.and_then(|r| r);
+        } else {
+            for chunk_n in 0..n_chunks {
+                let page = page.clone();
+                let opts = opts.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    djvu_render::render_progressive(&page, &opts, chunk_n)
+                        .map_err(AsyncRenderError::Render)
+                })
+                .await
+                .map_err(|e| AsyncRenderError::Join(e.to_string()));
+                yield result.and_then(|r| r);
+            }
+        }
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -242,5 +311,95 @@ mod tests {
             s.contains("render error"),
             "error must mention 'render error'"
         );
+    }
+
+    // ── render_progressive_stream tests ──────────────────────────────────────
+
+    /// Last frame from the progressive stream matches `render_pixmap`.
+    #[tokio::test]
+    async fn progressive_stream_last_frame_matches_pixmap() {
+        use futures::StreamExt;
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let opts = RenderOptions {
+            width: 100,
+            height: 80,
+            ..Default::default()
+        };
+
+        let stream = render_progressive_stream(page, opts.clone());
+        futures::pin_mut!(stream);
+
+        let mut frames: Vec<Pixmap> = Vec::new();
+        while let Some(result) = stream.next().await {
+            frames.push(result.expect("frame should succeed"));
+        }
+
+        assert!(!frames.is_empty(), "stream must yield at least one frame");
+
+        let expected = djvu_render::render_pixmap(page, &opts).expect("render_pixmap must succeed");
+        assert_eq!(
+            frames.last().unwrap().data,
+            expected.data,
+            "last frame must match render_pixmap"
+        );
+    }
+
+    /// Each successive frame has the same dimensions.
+    #[tokio::test]
+    async fn progressive_stream_consistent_dimensions() {
+        use futures::StreamExt;
+        let doc = load_doc("chicken.djvu");
+        let page = doc.page(0).unwrap();
+        let n_chunks = page.bg44_chunks().len();
+        let opts = RenderOptions {
+            width: 100,
+            height: 80,
+            ..Default::default()
+        };
+
+        let stream = render_progressive_stream(page, opts);
+        futures::pin_mut!(stream);
+
+        let mut count = 0usize;
+        while let Some(result) = stream.next().await {
+            let frame = result.expect("frame should succeed");
+            assert_eq!(frame.width, 100);
+            assert_eq!(frame.height, 80);
+            count += 1;
+        }
+
+        let expected_count = if n_chunks == 0 { 1 } else { n_chunks };
+        assert_eq!(
+            count, expected_count,
+            "frame count must equal BG44 chunk count"
+        );
+    }
+
+    /// A JB2-only page (no BG44 chunks) yields exactly one frame.
+    #[tokio::test]
+    async fn progressive_stream_jb2_only_yields_one_frame() {
+        use futures::StreamExt;
+        let doc = load_doc("boy_jb2.djvu");
+        let page = doc.page(0).unwrap();
+        if !page.bg44_chunks().is_empty() {
+            // Page is not JB2-only; skip
+            return;
+        }
+        let opts = RenderOptions {
+            width: 80,
+            height: 60,
+            ..Default::default()
+        };
+
+        let stream = render_progressive_stream(page, opts);
+        futures::pin_mut!(stream);
+
+        let mut count = 0;
+        while let Some(result) = stream.next().await {
+            result.expect("frame should succeed");
+            count += 1;
+        }
+        assert_eq!(count, 1, "JB2-only page must yield exactly one frame");
     }
 }

--- a/src/djvu_render.rs
+++ b/src/djvu_render.rs
@@ -1694,6 +1694,26 @@ pub fn render_progressive(
         composite_into(&ctx, &mut pm.data)?;
     }
 
+    // Apply Lanczos-3 post-processing when requested (same logic as render_pixmap).
+    if opts.resampling == Resampling::Lanczos3 {
+        let need_scale = page.width() as u32 != w || page.height() as u32 != h;
+        if need_scale {
+            let native_opts = RenderOptions {
+                width: page.width() as u32,
+                height: page.height() as u32,
+                scale: 1.0,
+                bold: opts.bold,
+                aa: false,
+                rotation: UserRotation::None,
+                permissive: opts.permissive,
+                resampling: Resampling::Bilinear,
+            };
+            if let Ok(native_pm) = render_progressive(page, &native_opts, chunk_n) {
+                pm = scale_lanczos3(&native_pm, w, h);
+            }
+        }
+    }
+
     Ok(rotate_pixmap(
         pm,
         combine_rotations(page.rotation(), opts.rotation),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub mod tiff_export;
 /// so CPU-bound IW44/JB2 work runs on the blocking thread pool without
 /// blocking the async runtime.
 ///
-/// Key functions: [`djvu_async::render_pixmap_async`], [`djvu_async::render_gray8_async`].
+/// Key functions: [`djvu_async::render_pixmap_async`], [`djvu_async::render_gray8_async`], [`djvu_async::render_progressive_stream`].
 #[cfg(feature = "async")]
 pub mod djvu_async;
 


### PR DESCRIPTION
## Summary

- Add `render_progressive_stream(page, opts)` to `djvu_async` — returns `impl Stream<Item = Result<Pixmap, AsyncRenderError>>`
- Yields one frame per BG44 wavelet chunk, from coarsest to sharpest; final frame equals `render_pixmap` output
- Each frame runs in `spawn_blocking` — async runtime thread is never blocked
- JB2-only pages (no BG44 chunks) yield exactly one frame via `render_pixmap`
- New optional deps: `async-stream 0.3` and `futures-core 0.3` (both behind the `async` feature flag); `futures 0.3` as dev-dep for `StreamExt` in tests

## Acceptance criteria

- [x] Returns `impl Stream<Item = Result<Pixmap, AsyncRenderError>>`
- [x] First item after first BG44 chunk decoded
- [x] Final frame matches `render_pixmap` output (tested)
- [x] Works with tokio runtime (spawn_blocking)
- [x] Test: last frame matches `render_pixmap`; frame count equals chunk count; JB2-only yields 1 frame

## Test plan

- [x] `progressive_stream_last_frame_matches_pixmap` — last frame == render_pixmap
- [x] `progressive_stream_consistent_dimensions` — all frames have correct dimensions; frame count == BG44 chunk count
- [x] `progressive_stream_jb2_only_yields_one_frame` — JB2 page yields exactly 1 frame

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)