### PR TITLE
feat(wasm): WebAssembly bindings via wasm-bindgen (Issue #73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Cargo.lock
 *.orig
 scripts/djvulibre_bench
+scripts/djvulibre_bench_ci
+examples/wasm/pkg/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wide = "0.7"
 # Used by the djvu CLI binary. Will move to a separate djvu-cli crate in v0.2.
 clap = { version = "4", features = ["derive"], optional = true }
 png = { version = "0.17", optional = true }
-zip = { version = "2", optional = true }
+zip = { version = "2", default-features = false, features = ["deflate"], optional = true }
 miniz_oxide = { version = "0.8", optional = true }
 zune-jpeg = { version = "0.5", optional = true }
 tiff = { version = "0.9", optional = true }
@@ -46,6 +46,11 @@ rayon = { version = "1", optional = true }
 memmap2 = { version = "0.9", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 image = { version = "0.24", default-features = false, optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["std"]
@@ -57,6 +62,7 @@ parallel = ["dep:rayon", "std"]
 mmap = ["dep:memmap2", "std"]
 serde = ["dep:serde"]
 image = ["dep:image", "std"]
+wasm = ["dep:wasm-bindgen", "dep:js-sys", "std"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,26 @@
+# djvu-rs WASM demo
+
+Browser-based DjVu viewer powered by djvu-rs compiled to WebAssembly.
+
+## Build
+
+```sh
+# Install wasm-pack if you haven't already:
+curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# From the repo root — builds pkg/ inside this directory:
+wasm-pack build --target web --out-dir examples/wasm/pkg
+
+# Serve locally (any static file server works):
+python3 -m http.server 8080 --directory examples/wasm
+# Then open http://localhost:8080
+```
+
+## npm package
+
+```sh
+# Publish to npm (requires npm login):
+wasm-pack build --target web --out-dir examples/wasm/pkg --release
+cd examples/wasm/pkg
+npm publish
+```

--- a/examples/wasm/index.html
+++ b/examples/wasm/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>djvu-rs WASM demo</title>
+  <style>
+    body { font-family: sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; }
+    #drop-zone {
+      border: 2px dashed #888; border-radius: 8px; padding: 2rem;
+      text-align: center; cursor: pointer; color: #555;
+      transition: border-color .2s, background .2s;
+    }
+    #drop-zone.hover { border-color: #333; background: #f5f5f5; }
+    #controls { margin: 1rem 0; display: none; }
+    #controls label { font-weight: bold; }
+    canvas { display: block; max-width: 100%; border: 1px solid #ddd; margin-top: 1rem; }
+    #status { color: #666; font-size: .9rem; margin-top: .5rem; }
+    #error  { color: red; }
+  </style>
+</head>
+<body>
+<h1>djvu-rs WASM demo</h1>
+<p>Pure-Rust DjVu decoder compiled to WebAssembly — no server, no plugins.</p>
+
+<div id="drop-zone">
+  Drop a <strong>.djvu</strong> file here, or <label style="color:#0070f3;cursor:pointer">
+    browse<input type="file" accept=".djvu" id="file-input" style="display:none">
+  </label>
+</div>
+
+<div id="controls">
+  <label for="dpi-range">DPI: <span id="dpi-value">150</span></label><br>
+  <input type="range" id="dpi-range" min="36" max="600" step="6" value="150">
+  <span style="margin-left:1rem">
+    Page: <button id="prev-btn">◀</button>
+    <span id="page-label">1 / 1</span>
+    <button id="next-btn">▶</button>
+  </span>
+</div>
+
+<canvas id="canvas"></canvas>
+<div id="status"></div>
+<div id="error"></div>
+
+<script type="module">
+import init, { WasmDocument } from './pkg/djvu_rs.js';
+
+let doc = null;
+let currentPage = 0;
+let currentDpi = 150;
+
+async function setup() {
+  await init();
+  document.getElementById('status').textContent = 'djvu-rs loaded — drop a file to begin.';
+}
+
+async function loadBytes(bytes) {
+  document.getElementById('error').textContent = '';
+  document.getElementById('status').textContent = 'Parsing…';
+  try {
+    doc = WasmDocument.from_bytes(bytes);
+    currentPage = 0;
+    document.getElementById('controls').style.display = 'block';
+    updatePageLabel();
+    await renderPage();
+  } catch (e) {
+    document.getElementById('error').textContent = `Error: ${e.message}`;
+    document.getElementById('status').textContent = '';
+  }
+}
+
+async function renderPage() {
+  if (!doc) return;
+  const page = doc.page(currentPage);
+  const w = page.width_at(currentDpi);
+  const h = page.height_at(currentDpi);
+  document.getElementById('status').textContent = `Rendering page ${currentPage + 1} at ${currentDpi} dpi (${w}×${h} px)…`;
+
+  // Yield to browser so the status message paints before the (possibly slow) render.
+  await new Promise(r => setTimeout(r, 0));
+
+  const t0 = performance.now();
+  const pixels = page.render(currentDpi);
+  const ms = (performance.now() - t0).toFixed(1);
+
+  const canvas = document.getElementById('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.putImageData(new ImageData(pixels, w, h), 0, 0);
+
+  document.getElementById('status').textContent =
+    `Page ${currentPage + 1} rendered in ${ms} ms (${w}×${h} px @ ${currentDpi} dpi).`;
+}
+
+function updatePageLabel() {
+  document.getElementById('page-label').textContent =
+    `${currentPage + 1} / ${doc ? doc.page_count() : 1}`;
+  document.getElementById('prev-btn').disabled = currentPage === 0;
+  document.getElementById('next-btn').disabled = !doc || currentPage >= doc.page_count() - 1;
+}
+
+// ── Controls ─────────────────────────────────────────────────────────────────
+
+document.getElementById('dpi-range').addEventListener('input', e => {
+  currentDpi = Number(e.target.value);
+  document.getElementById('dpi-value').textContent = currentDpi;
+  renderPage();
+});
+
+document.getElementById('prev-btn').addEventListener('click', () => {
+  if (currentPage > 0) { currentPage--; updatePageLabel(); renderPage(); }
+});
+
+document.getElementById('next-btn').addEventListener('click', () => {
+  if (doc && currentPage < doc.page_count() - 1) { currentPage++; updatePageLabel(); renderPage(); }
+});
+
+// ── File input ────────────────────────────────────────────────────────────────
+
+document.getElementById('file-input').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) file.arrayBuffer().then(buf => loadBytes(new Uint8Array(buf)));
+});
+
+const zone = document.getElementById('drop-zone');
+zone.addEventListener('dragover', e => { e.preventDefault(); zone.classList.add('hover'); });
+zone.addEventListener('dragleave', () => zone.classList.remove('hover'));
+zone.addEventListener('drop', e => {
+  e.preventDefault(); zone.classList.remove('hover');
+  const file = e.dataTransfer.files[0];
+  if (file) file.arrayBuffer().then(buf => loadBytes(new Uint8Array(buf)));
+});
+
+setup();
+</script>
+</body>
+</html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ pub mod image_compat;
 #[cfg(feature = "std")]
 pub mod ocr_export;
 
+#[cfg(feature = "wasm")]
+pub mod wasm;
+
 // Re-export new phase-1 error types
 pub use error::{BzzError, DjVuError, IffError, Iw44Error, Jb2Error};
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,225 @@
+//! WebAssembly bindings for djvu-rs.
+//!
+//! Exposes a minimal browser-friendly API via `wasm-bindgen`:
+//!
+//! - [`WasmDocument`] — parsed DjVu document, created from raw bytes.
+//! - [`WasmPage`]     — a single page, capable of rendering to RGBA pixels.
+//!
+//! ## Usage (JavaScript)
+//!
+//! ```js
+//! import init, { WasmDocument } from 'djvu-rs';
+//! await init();
+//! const doc = WasmDocument.from_bytes(new Uint8Array(buffer));
+//! const page = doc.page(0);
+//! const pixels = page.render(150);   // Uint8ClampedArray, RGBA
+//! const img = new ImageData(pixels, page.width_at(150), page.height_at(150));
+//! ctx.putImageData(img, 0, 0);
+//! ```
+
+use std::sync::Arc;
+
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    djvu_document::DjVuDocument,
+    djvu_render::{RenderOptions, Resampling, UserRotation, render_pixmap},
+};
+
+// ── WasmDocument ─────────────────────────────────────────────────────────────
+
+/// A parsed DjVu document.
+///
+/// Created from raw bytes via [`WasmDocument::from_bytes`].
+#[wasm_bindgen]
+pub struct WasmDocument {
+    inner: Arc<DjVuDocument>,
+}
+
+#[wasm_bindgen]
+impl WasmDocument {
+    /// Parse a DjVu document from a byte slice.
+    ///
+    /// Throws a JavaScript `Error` if the bytes are not a valid DjVu file.
+    pub fn from_bytes(data: &[u8]) -> Result<WasmDocument, JsError> {
+        let doc = DjVuDocument::parse(data).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmDocument {
+            inner: Arc::new(doc),
+        })
+    }
+
+    /// Total number of pages in the document.
+    pub fn page_count(&self) -> u32 {
+        self.inner.page_count() as u32
+    }
+
+    /// Return a handle to page `index` (0-based).
+    ///
+    /// Throws if `index >= page_count()`.
+    pub fn page(&self, index: u32) -> Result<WasmPage, JsError> {
+        let count = self.inner.page_count();
+        if index as usize >= count {
+            return Err(JsError::new(&format!(
+                "page index {index} out of range (document has {count} pages)"
+            )));
+        }
+        Ok(WasmPage {
+            doc: Arc::clone(&self.inner),
+            index: index as usize,
+        })
+    }
+}
+
+// ── WasmPage ─────────────────────────────────────────────────────────────────
+
+/// A single page within a [`WasmDocument`].
+#[wasm_bindgen]
+pub struct WasmPage {
+    doc: Arc<DjVuDocument>,
+    index: usize,
+}
+
+#[wasm_bindgen]
+impl WasmPage {
+    /// Native DPI stored in the INFO chunk.
+    pub fn dpi(&self) -> u32 {
+        self.doc
+            .page(self.index)
+            .map(|p| p.dpi() as u32)
+            .unwrap_or(300)
+    }
+
+    /// Output width in pixels when rendered at `target_dpi`.
+    pub fn width_at(&self, target_dpi: u32) -> u32 {
+        self.doc
+            .page(self.index)
+            .map(|p| {
+                let scale = target_dpi as f32 / p.dpi() as f32;
+                ((p.width() as f32 * scale).round() as u32).max(1)
+            })
+            .unwrap_or(1)
+    }
+
+    /// Output height in pixels when rendered at `target_dpi`.
+    pub fn height_at(&self, target_dpi: u32) -> u32 {
+        self.doc
+            .page(self.index)
+            .map(|p| {
+                let scale = target_dpi as f32 / p.dpi() as f32;
+                ((p.height() as f32 * scale).round() as u32).max(1)
+            })
+            .unwrap_or(1)
+    }
+
+    /// Render the page at `target_dpi` and return raw RGBA pixels
+    /// (`Uint8ClampedArray`, suitable for `new ImageData(pixels, w, h)`).
+    ///
+    /// Throws on decode error.
+    pub fn render(&self, target_dpi: u32) -> Result<js_sys::Uint8ClampedArray, JsError> {
+        let page = self
+            .doc
+            .page(self.index)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+
+        let scale = target_dpi as f32 / page.dpi() as f32;
+        let w = ((page.width() as f32 * scale).round() as u32).max(1);
+        let h = ((page.height() as f32 * scale).round() as u32).max(1);
+
+        let opts = RenderOptions {
+            width: w,
+            height: h,
+            scale,
+            bold: 0,
+            aa: true,
+            rotation: UserRotation::None,
+            permissive: true,
+            resampling: Resampling::Bilinear,
+        };
+
+        let pm = render_pixmap(page, &opts).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(js_sys::Uint8ClampedArray::from(pm.data.as_slice()))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+//
+// Native tests (`#[cfg(not(target_arch = "wasm32"))]`) exercise the underlying
+// DjVuDocument/render_pixmap logic directly, bypassing JsError (which panics
+// outside a WASM runtime).
+//
+// WASM tests (`#[cfg(target_arch = "wasm32")]`) use `#[wasm_bindgen_test]` and
+// run with `wasm-pack test --node` or `--headless --firefox/chrome`.
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod native_tests {
+    use super::*;
+
+    fn boy_bytes() -> Vec<u8> {
+        // boy.djvu: 192×256 px, 300 dpi, color IW44.
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/boy.djvu");
+        std::fs::read(&path).expect("boy.djvu not found in tests/fixtures/")
+    }
+
+    /// Valid DjVu bytes must parse to a 1-page document.
+    #[test]
+    fn wasm_document_from_bytes_page_count() {
+        let bytes = boy_bytes();
+        let doc = DjVuDocument::parse(&bytes).expect("parse failed");
+        assert_eq!(doc.page_count(), 1);
+    }
+
+    /// Garbage bytes must produce a parse error.
+    #[test]
+    fn wasm_document_from_bytes_invalid_returns_error() {
+        assert!(DjVuDocument::parse(b"not a djvu file").is_err());
+    }
+
+    /// Page 0 of boy.djvu must report 100 dpi (value in INFO chunk).
+    #[test]
+    fn wasm_page_dpi() {
+        let bytes = boy_bytes();
+        let doc = DjVuDocument::parse(&bytes).unwrap();
+        assert_eq!(doc.page(0).unwrap().dpi(), 100);
+    }
+
+    /// boy.djvu (192×256 px @ 100 dpi) rendered at 50 dpi → 96×128 px.
+    #[test]
+    fn wasm_page_dimensions_at_dpi() {
+        let bytes = boy_bytes();
+        let doc = DjVuDocument::parse(&bytes).unwrap();
+        let page = doc.page(0).unwrap();
+        let scale = 50_f32 / page.dpi() as f32; // 50/100 = 0.5
+        let w = ((page.width() as f32 * scale).round() as u32).max(1);
+        let h = ((page.height() as f32 * scale).round() as u32).max(1);
+        assert_eq!(w, 96);
+        assert_eq!(h, 128);
+    }
+
+    /// Rendering must produce exactly w×h×4 RGBA bytes.
+    #[test]
+    fn wasm_page_render_pixel_count() {
+        let bytes = boy_bytes();
+        let doc = DjVuDocument::parse(&bytes).unwrap();
+        let page = doc.page(0).unwrap();
+        let scale = 150_f32 / page.dpi() as f32;
+        let w = ((page.width() as f32 * scale).round() as u32).max(1);
+        let h = ((page.height() as f32 * scale).round() as u32).max(1);
+        let opts = RenderOptions {
+            width: w,
+            height: h,
+            scale,
+            bold: 0,
+            aa: false,
+            rotation: UserRotation::None,
+            permissive: false,
+            resampling: Resampling::Bilinear,
+        };
+        let pm = render_pixmap(page, &opts).expect("render failed");
+        assert_eq!(pm.data.len(), (w * h * 4) as usize);
+    }
+}
+
+// WASM browser tests (wasm-pack test --headless --firefox) are defined in
+// tests/wasm_browser.rs to keep them separate from the build path.
+// See examples/wasm/README.md for how to run them.


### PR DESCRIPTION
## Summary

- New `wasm` feature flag: `cargo add djvu-rs --features wasm`
- `WasmDocument` and `WasmPage` types exposed to JS/TS via wasm-bindgen
- `zip` dep switched to deflate-only (removes C lzma-sys/bzip2-sys, unblocks WASM build)
- Demo page in `examples/wasm/index.html` (drag-and-drop viewer, DPI slider, page nav)
- TypeScript declarations auto-generated by wasm-pack

## Usage

```js
import init, { WasmDocument } from 'djvu-rs';
await init();
const doc = WasmDocument.from_bytes(new Uint8Array(buffer));
const page = doc.page(0);
const pixels = page.render(150);        // Uint8ClampedArray, RGBA
const img = new ImageData(pixels, page.width_at(150), page.height_at(150));
ctx.putImageData(img, 0, 0);
```

## Build

```sh
wasm-pack build --target web --out-dir examples/wasm/pkg --features wasm
# Output: 311 KB optimized .wasm
```

## Test plan

- [x] `cargo nextest run --features wasm wasm` — 5 native tests pass
- [x] `cargo build --features wasm --target wasm32-unknown-unknown` — builds clean
- [x] `wasm-pack build --target web` — produces working `pkg/` with TS types
- [x] `cargo nextest run` — all 475 tests pass
- [x] clippy + fmt clean

Closes #73