### PR TITLE
feat(epub): EPUB 3 export — page images, text overlay, navigation (Issue #74)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ mmap = ["dep:memmap2", "std"]
 serde = ["dep:serde"]
 image = ["dep:image", "std"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "std"]
+epub = ["std"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -71,6 +72,7 @@ predicates = "3"
 tempfile = "3"
 serde_json = "1"
 futures = "0.3"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [[bin]]
 name = "djvu"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,15 @@ pub mod metadata;
 #[cfg(feature = "std")]
 pub mod pdf;
 
+/// DjVu to EPUB 3 exporter.
+///
+/// Converts DjVu documents to EPUB 3 while preserving page images,
+/// invisible text overlay for search/copy, and NAVM bookmarks as navigation.
+///
+/// Key function: [`epub::djvu_to_epub`].
+#[cfg(feature = "epub")]
+pub mod epub;
+
 /// DjVu to TIFF exporter — phase 4 format extension.
 ///
 /// Converts DjVu documents to multi-page TIFF files in color (RGB8) or

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -111,6 +111,18 @@ impl WasmPage {
             .unwrap_or(1)
     }
 
+    /// Extract the plain text content of this page from the TXTz/TXTa layer.
+    ///
+    /// Returns `undefined` (JS `None`) if the page has no text layer.
+    /// Throws a JavaScript `Error` on decode failure.
+    pub fn text(&self) -> Result<Option<String>, JsError> {
+        let page = self
+            .doc
+            .page(self.index)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        page.text().map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Render the page at `target_dpi` and return raw RGBA pixels
     /// (`Uint8ClampedArray`, suitable for `new ImageData(pixels, w, h)`).
     ///


### PR DESCRIPTION
## Summary

- `djvu_to_epub()` produces a valid EPUB 3 ZIP archive (new `epub` feature flag)
- Each DjVu page → XHTML with embedded PNG + invisible CSS text overlay for search/copy
- NAVM bookmarks → `nav.xhtml` table of contents with nested structure
- OPF package document with manifest and spine in page order
- CLI: `djvu render file.djvu --format epub --output book.epub`
- 14 integration tests covering ZIP structure, mimetype, container.xml, OPF, nav, page images, text infrastructure, bookmarks, spine order

## Test plan

- [x] `cargo nextest run --features epub -E 'test(epub)'` — 14/14 pass
- [x] `cargo clippy --features epub` — clean
- [x] `cargo fmt --check` — clean
- [x] pre-commit hook passes

Closes #74

🤖 Generated with [Claude Code](https://claude.ai/code)