### PR TITLE
feat(python): Python bindings via PyO3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "djvu-py"]
+
 [package]
 name = "djvu-rs"
 version = "0.9.0"

--- a/djvu-py/Cargo.toml
+++ b/djvu-py/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "djvu-py"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+description = "Python bindings for djvu-rs — pure-Rust DjVu decoder"
+publish = false
+
+[lib]
+name = "djvu_rs_python"
+crate-type = ["cdylib"]
+
+[dependencies]
+djvu-rs = { path = "..", features = ["std"] }
+pyo3 = { version = "0.23", features = ["extension-module"] }
+
+[build-dependencies]
+pyo3-build-config = "0.23"

--- a/djvu-py/README.md
+++ b/djvu-py/README.md
@@ -1,0 +1,34 @@
+# djvu-rs Python bindings
+
+Python bindings for [djvu-rs](https://github.com/matyushkin/djvu-rs), a pure-Rust DjVu decoder.
+
+## Install
+
+```bash
+pip install djvu-rs
+```
+
+## Usage
+
+```python
+import djvu_rs_python as djvu
+
+doc = djvu.Document.open('scan.djvu')
+print(f'{doc.page_count()} pages')
+
+page = doc.page(0)
+print(f'{page.width}x{page.height} @ {page.dpi} dpi')
+
+# Render to PIL Image
+img = page.render(dpi=150).to_pil()
+img.save('page.png')
+
+# Render to numpy array
+arr = page.render(dpi=150).to_numpy()
+print(arr.shape)  # (height, width, 4)
+
+# Extract text
+text = page.text()
+if text:
+    print(text)
+```

--- a/djvu-py/pyproject.toml
+++ b/djvu-py/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "djvu-rs"
+version = "0.1.0"
+description = "Python bindings for djvu-rs — pure-Rust DjVu decoder"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+numpy = ["numpy"]
+pillow = ["Pillow"]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/djvu-py/src/lib.rs
+++ b/djvu-py/src/lib.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use pyo3::exceptions::{PyIOError, PyIndexError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+/// A DjVu document.
+#[pyclass]
+struct Document {
+    inner: Arc<djvu_rs::Document>,
+}
+
+#[pymethods]
+impl Document {
+    /// Open a DjVu document from a file path.
+    #[staticmethod]
+    fn open(path: &str) -> PyResult<Self> {
+        let data = std::fs::read(path).map_err(|e| PyIOError::new_err(format!("{e}")))?;
+        let doc = djvu_rs::Document::from_bytes(data)
+            .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        Ok(Document {
+            inner: Arc::new(doc),
+        })
+    }
+
+    /// Open a DjVu document from bytes.
+    #[staticmethod]
+    fn from_bytes(data: &[u8]) -> PyResult<Self> {
+        let doc = djvu_rs::Document::from_bytes(data.to_vec())
+            .map_err(|e| PyValueError::new_err(format!("{e}")))?;
+        Ok(Document {
+            inner: Arc::new(doc),
+        })
+    }
+
+    /// Number of pages in the document.
+    fn page_count(&self) -> usize {
+        self.inner.page_count()
+    }
+
+    /// Get a page by index (0-based).
+    fn page(&self, index: usize) -> PyResult<Page> {
+        let p = self
+            .inner
+            .page(index)
+            .map_err(|e| PyIndexError::new_err(format!("{e}")))?;
+        Ok(Page {
+            width: p.width(),
+            height: p.height(),
+            dpi: p.dpi(),
+            doc: Arc::clone(&self.inner),
+            index,
+        })
+    }
+}
+
+/// A page within a DjVu document.
+#[pyclass]
+struct Page {
+    width: u32,
+    height: u32,
+    dpi: u16,
+    doc: Arc<djvu_rs::Document>,
+    index: usize,
+}
+
+#[pymethods]
+impl Page {
+    /// Page width in pixels.
+    #[getter]
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Page height in pixels.
+    #[getter]
+    fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Page DPI.
+    #[getter]
+    fn dpi(&self) -> u16 {
+        self.dpi
+    }
+
+    /// Render the page as RGBA bytes.
+    ///
+    /// Args:
+    ///     dpi: Target DPI. If not specified, renders at native DPI.
+    ///
+    /// Returns:
+    ///     Pixmap with width, height, and RGBA data.
+    #[pyo3(signature = (dpi=None))]
+    fn render(&self, dpi: Option<f32>) -> PyResult<Pixmap> {
+        let page = self
+            .doc
+            .page(self.index)
+            .map_err(|e| PyIndexError::new_err(format!("{e}")))?;
+
+        let pixmap = if let Some(target_dpi) = dpi {
+            let scale = target_dpi / self.dpi as f32;
+            let w = ((self.width as f32 * scale).round() as u32).max(1);
+            let h = ((self.height as f32 * scale).round() as u32).max(1);
+            page.render_to_size(w, h)
+        } else {
+            page.render()
+        }
+        .map_err(|e| PyValueError::new_err(format!("render failed: {e}")))?;
+
+        Ok(Pixmap {
+            width: pixmap.width,
+            height: pixmap.height,
+            data: pixmap.data,
+        })
+    }
+
+    /// Extract the text layer from this page.
+    ///
+    /// Returns None if no text layer is present.
+    fn text(&self) -> PyResult<Option<String>> {
+        let page = self
+            .doc
+            .page(self.index)
+            .map_err(|e| PyIndexError::new_err(format!("{e}")))?;
+        page.text()
+            .map_err(|e| PyValueError::new_err(format!("{e}")))
+    }
+}
+
+/// An RGBA pixel buffer.
+#[pyclass]
+struct Pixmap {
+    width: u32,
+    height: u32,
+    data: Vec<u8>,
+}
+
+#[pymethods]
+impl Pixmap {
+    /// Image width in pixels.
+    #[getter]
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Image height in pixels.
+    #[getter]
+    fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// RGBA pixel data as bytes (length = width * height * 4).
+    fn data<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new(py, &self.data)
+    }
+
+    /// Convert to a numpy array (requires numpy).
+    ///
+    /// Returns a numpy.ndarray with shape (height, width, 4) and dtype uint8.
+    fn to_numpy<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let numpy = py.import("numpy")?;
+        let frombuffer = numpy.getattr("frombuffer")?;
+        let bytes = PyBytes::new(py, &self.data);
+        let arr = frombuffer.call1((bytes, numpy.getattr("uint8")?))?;
+        arr.call_method1("reshape", ((self.height, self.width, 4u32),))
+    }
+
+    /// Convert to a PIL Image (requires Pillow).
+    ///
+    /// Returns a PIL.Image.Image in RGBA mode.
+    fn to_pil<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let pil = py.import("PIL.Image")?;
+        let frombytes = pil.getattr("frombytes")?;
+        let size = (self.width, self.height);
+        let bytes = PyBytes::new(py, &self.data);
+        frombytes.call1(("RGBA", size, bytes))
+    }
+}
+
+/// Python module definition.
+#[pymodule]
+fn djvu_rs_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Document>()?;
+    m.add_class::<Page>()?;
+    m.add_class::<Pixmap>()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- New `djvu-py/` crate with PyO3 bindings for Python
- `Document.open()` / `from_bytes()` for opening DjVu files
- `Page.render(dpi=)` with `.to_numpy()` and `.to_pil()` output
- `Page.text()` for text layer extraction
- Maturin build system, PyPI-ready as `djvu-rs`

## Test plan
- [x] `cargo check` in djvu-py/ passes
- [x] Main crate tests unaffected
- [x] Pre-commit hooks pass (fmt, clippy, no_std)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)