### PR TITLE
feat: NAVM bookmark encoder and ANTa/ANTz annotation encoder (#133)

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -493,6 +493,102 @@ fn parse_color(s: &str) -> Result<Color, AnnotationError> {
     Ok(Color { r, g, b })
 }
 
+// ---- Encoder ----------------------------------------------------------------
+
+/// Serialize an [`Annotation`] and a list of [`MapArea`]s to ANTa text bytes.
+///
+/// Produces the plain-text S-expression format consumed by [`parse_annotations`].
+/// Returns an empty `Vec` if there is nothing to encode.
+pub fn encode_annotations(ann: &Annotation, areas: &[MapArea]) -> Vec<u8> {
+    let mut out = String::new();
+
+    if let Some(ref c) = ann.background {
+        out.push_str(&format!(
+            "(background #{:02x}{:02x}{:02x})\n",
+            c.r, c.g, c.b
+        ));
+    }
+    if let Some(z) = ann.zoom {
+        out.push_str(&format!("(zoom {z})\n"));
+    }
+    if let Some(ref m) = ann.mode {
+        out.push_str(&format!("(mode {m})\n"));
+    }
+
+    for ma in areas {
+        out.push_str(&encode_maparea(ma));
+        out.push('\n');
+    }
+
+    out.into_bytes()
+}
+
+/// Serialize an [`Annotation`] and map areas to ANTz bytes (BZZ-compressed ANTa).
+#[cfg(feature = "std")]
+pub fn encode_annotations_bzz(ann: &Annotation, areas: &[MapArea]) -> Vec<u8> {
+    let plain = encode_annotations(ann, areas);
+    if plain.is_empty() {
+        return Vec::new();
+    }
+    crate::bzz_encode::bzz_encode(&plain)
+}
+
+/// Serialize one maparea to its S-expression string (without trailing newline).
+fn encode_maparea(ma: &MapArea) -> String {
+    let mut s = String::from("(maparea ");
+    s.push_str(&quote_str(&ma.url));
+    s.push(' ');
+    s.push_str(&quote_str(&ma.description));
+    s.push(' ');
+    s.push_str(&encode_shape(&ma.shape));
+    if let Some(ref b) = ma.border {
+        s.push_str(&format!(" (border {})", b.style));
+    }
+    if let Some(ref h) = ma.highlight {
+        s.push_str(&format!(
+            " (hilite #{:02x}{:02x}{:02x})",
+            h.color.r, h.color.g, h.color.b
+        ));
+    }
+    s.push(')');
+    s
+}
+
+/// Serialize a [`Shape`] to its S-expression string.
+fn encode_shape(shape: &Shape) -> String {
+    match shape {
+        Shape::Rect(r) => format!("(rect {} {} {} {})", r.x, r.y, r.width, r.height),
+        Shape::Oval(r) => format!("(oval {} {} {} {})", r.x, r.y, r.width, r.height),
+        Shape::Text(r) => format!("(text {} {} {} {})", r.x, r.y, r.width, r.height),
+        Shape::Line(x1, y1, x2, y2) => format!("(line {x1} {y1} {x2} {y2})"),
+        Shape::Poly(pts) => {
+            let mut s = String::from("(poly");
+            for (x, y) in pts {
+                s.push_str(&format!(" {x} {y}"));
+            }
+            s.push(')');
+            s
+        }
+    }
+}
+
+/// Quote a string for use in the ANTa S-expression format.
+///
+/// Produces `"..."` with backslash-escaping for `"` and `\`.
+fn quote_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -693,5 +789,119 @@ mod tests {
         assert_eq!(areas.len(), 2);
         assert_eq!(areas[0].url, "a");
         assert_eq!(areas[1].url, "b");
+    }
+
+    // ── Encoder roundtrips ──────────────────────────────────────────────────
+
+    #[test]
+    fn encode_empty_is_empty() {
+        let ann = Annotation::default();
+        let out = encode_annotations(&ann, &[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn encode_background_roundtrip() {
+        let ann = Annotation {
+            background: Some(Color {
+                r: 255,
+                g: 128,
+                b: 0,
+            }),
+            zoom: None,
+            mode: None,
+        };
+        let bytes = encode_annotations(&ann, &[]);
+        let (dec, _) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec.background, ann.background);
+    }
+
+    #[test]
+    fn encode_zoom_and_mode_roundtrip() {
+        let ann = Annotation {
+            background: None,
+            zoom: Some(150),
+            mode: Some("color".to_string()),
+        };
+        let bytes = encode_annotations(&ann, &[]);
+        let (dec, _) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec.zoom, Some(150));
+        assert_eq!(dec.mode, Some("color".to_string()));
+    }
+
+    #[test]
+    fn encode_maparea_rect_roundtrip() {
+        let ann = Annotation::default();
+        let areas = vec![MapArea {
+            url: "http://example.com".to_string(),
+            description: "a link".to_string(),
+            shape: Shape::Rect(Rect {
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 50,
+            }),
+            border: None,
+            highlight: None,
+        }];
+        let bytes = encode_annotations(&ann, &areas);
+        let (_, dec_areas) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec_areas.len(), 1);
+        assert_eq!(dec_areas[0].url, "http://example.com");
+        assert_eq!(dec_areas[0].description, "a link");
+        assert!(matches!(&dec_areas[0].shape, Shape::Rect(r) if r.x == 10 && r.y == 20));
+    }
+
+    #[test]
+    fn encode_maparea_poly_roundtrip() {
+        let areas = vec![MapArea {
+            url: String::new(),
+            description: String::new(),
+            shape: Shape::Poly(vec![(0, 0), (10, 0), (5, 10)]),
+            border: None,
+            highlight: None,
+        }];
+        let bytes = encode_annotations(&Annotation::default(), &areas);
+        let (_, dec_areas) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec_areas.len(), 1);
+        assert!(matches!(&dec_areas[0].shape, Shape::Poly(pts) if pts == &[(0,0),(10,0),(5,10)]));
+    }
+
+    #[test]
+    fn encode_maparea_with_border_and_hilite_roundtrip() {
+        let areas = vec![MapArea {
+            url: "x".to_string(),
+            description: String::new(),
+            shape: Shape::Rect(Rect {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            }),
+            border: Some(Border {
+                style: "xor".to_string(),
+            }),
+            highlight: Some(Highlight {
+                color: Color { r: 255, g: 0, b: 0 },
+            }),
+        }];
+        let bytes = encode_annotations(&Annotation::default(), &areas);
+        let (_, dec_areas) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec_areas[0].border.as_ref().unwrap().style, "xor");
+        assert_eq!(dec_areas[0].highlight.as_ref().unwrap().color.r, 255);
+    }
+
+    #[test]
+    fn encode_url_with_quotes_roundtrip() {
+        let areas = vec![MapArea {
+            url: r#"has "quotes" and \backslash"#.to_string(),
+            description: String::new(),
+            shape: Shape::Line(0, 0, 1, 1),
+            border: None,
+            highlight: None,
+        }];
+        let bytes = encode_annotations(&Annotation::default(), &areas);
+        let (_, dec_areas) = parse_annotations(&bytes).unwrap();
+        assert_eq!(dec_areas[0].url, r#"has "quotes" and \backslash"#);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,10 @@ pub mod ocr_neural;
 #[cfg(feature = "std")]
 pub mod text_encode;
 
+/// NAVM bookmark encoder — serializes [`djvu_document::DjVuBookmark`] trees to BZZ-compressed binary.
+#[cfg(feature = "std")]
+pub mod navm_encode;
+
 #[cfg(feature = "wasm")]
 pub mod wasm;
 

--- a/src/navm_encode.rs
+++ b/src/navm_encode.rs
@@ -1,0 +1,204 @@
+//! NAVM bookmark encoder.
+//!
+//! Serializes a slice of [`DjVuBookmark`] trees into the BZZ-compressed
+//! binary NAVM chunk format, mirroring the decoder in `djvu_document.rs`.
+//!
+//! ## Binary format (after BZZ decompression)
+//!
+//! ```text
+//! u16be      total_count    — flat count of ALL nodes in the tree
+//! <node>...                 — top-level nodes
+//! ```
+//!
+//! Each `<node>`:
+//! ```text
+//! u8         n_children
+//! u24be      title_len
+//! <title bytes>
+//! u24be      url_len
+//! <url bytes>
+//! <child nodes>...
+//! ```
+
+use crate::bzz_encode::bzz_encode;
+use crate::djvu_document::DjVuBookmark;
+
+/// Encode a list of bookmarks into a NAVM chunk payload (BZZ-compressed).
+///
+/// Returns the bytes suitable for embedding directly as a `NAVM` chunk.
+/// Returns an empty `Vec` if `bookmarks` is empty.
+pub fn encode_navm(bookmarks: &[DjVuBookmark]) -> Vec<u8> {
+    if bookmarks.is_empty() {
+        return Vec::new();
+    }
+
+    let total = count_bookmarks(bookmarks);
+    let mut raw = Vec::new();
+
+    // Total count — u16be
+    raw.push((total >> 8) as u8);
+    raw.push(total as u8);
+
+    for bm in bookmarks {
+        write_bookmark(&mut raw, bm);
+    }
+
+    bzz_encode(&raw)
+}
+
+/// Count all bookmark nodes in the tree (all levels).
+fn count_bookmarks(bookmarks: &[DjVuBookmark]) -> usize {
+    bookmarks
+        .iter()
+        .map(|bm| 1 + count_bookmarks(&bm.children))
+        .sum()
+}
+
+/// Serialize one bookmark node (and its children) into `buf`.
+fn write_bookmark(buf: &mut Vec<u8>, bm: &DjVuBookmark) {
+    let n_children = bm.children.len().min(255) as u8;
+    buf.push(n_children);
+    write_navm_str(buf, &bm.title);
+    write_navm_str(buf, &bm.url);
+    for child in &bm.children {
+        write_bookmark(buf, child);
+    }
+}
+
+/// Write a length-prefixed string: u24be length followed by UTF-8 bytes.
+fn write_navm_str(buf: &mut Vec<u8>, s: &str) {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    buf.push((len >> 16) as u8);
+    buf.push((len >> 8) as u8);
+    buf.push(len as u8);
+    buf.extend_from_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bzz_new::bzz_decode;
+    use crate::djvu_document::DjVuBookmark;
+
+    fn bm(title: &str, url: &str, children: Vec<DjVuBookmark>) -> DjVuBookmark {
+        DjVuBookmark {
+            title: title.to_string(),
+            url: url.to_string(),
+            children,
+        }
+    }
+
+    /// Decode the raw NAVM binary from `encode_navm`, checking correctness.
+    fn decode_raw(compressed: &[u8]) -> (usize, Vec<DjVuBookmark>) {
+        let decoded = bzz_decode(compressed).expect("bzz_decode");
+        assert!(decoded.len() >= 2, "too short: {}", decoded.len());
+        let total = u16::from_be_bytes([decoded[0], decoded[1]]) as usize;
+
+        let mut pos = 2usize;
+        let mut bookmarks = Vec::new();
+        let mut count = 0usize;
+        while count < total {
+            bookmarks.push(decode_bookmark(&decoded, &mut pos, &mut count));
+        }
+        (total, bookmarks)
+    }
+
+    fn decode_bookmark(data: &[u8], pos: &mut usize, count: &mut usize) -> DjVuBookmark {
+        let n_children = data[*pos] as usize;
+        *pos += 1;
+        let title = decode_str(data, pos);
+        let url = decode_str(data, pos);
+        *count += 1;
+        let mut children = Vec::new();
+        for _ in 0..n_children {
+            children.push(decode_bookmark(data, pos, count));
+        }
+        DjVuBookmark {
+            title,
+            url,
+            children,
+        }
+    }
+
+    fn decode_str(data: &[u8], pos: &mut usize) -> String {
+        let len = ((data[*pos] as usize) << 16)
+            | ((data[*pos + 1] as usize) << 8)
+            | (data[*pos + 2] as usize);
+        *pos += 3;
+        let s = core::str::from_utf8(&data[*pos..*pos + len])
+            .unwrap()
+            .to_string();
+        *pos += len;
+        s
+    }
+
+    #[test]
+    fn empty_bookmarks_returns_empty() {
+        assert!(encode_navm(&[]).is_empty());
+    }
+
+    #[test]
+    fn single_bookmark_roundtrip() {
+        let bookmarks = vec![bm("Chapter 1", "#page=1", vec![])];
+        let encoded = encode_navm(&bookmarks);
+        assert!(!encoded.is_empty());
+        let (total, decoded) = decode_raw(&encoded);
+        assert_eq!(total, 1);
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].title, "Chapter 1");
+        assert_eq!(decoded[0].url, "#page=1");
+        assert!(decoded[0].children.is_empty());
+    }
+
+    #[test]
+    fn nested_bookmarks_roundtrip() {
+        let bookmarks = vec![
+            bm(
+                "Part I",
+                "#page=1",
+                vec![
+                    bm("Chapter 1", "#page=5", vec![]),
+                    bm("Chapter 2", "#page=12", vec![]),
+                ],
+            ),
+            bm(
+                "Part II",
+                "#page=20",
+                vec![bm("Chapter 3", "#page=25", vec![])],
+            ),
+        ];
+        let encoded = encode_navm(&bookmarks);
+        let (total, decoded) = decode_raw(&encoded);
+        // total = 2 parts + 3 chapters = 5
+        assert_eq!(total, 5);
+        assert_eq!(decoded.len(), 2);
+        assert_eq!(decoded[0].title, "Part I");
+        assert_eq!(decoded[0].children.len(), 2);
+        assert_eq!(decoded[0].children[0].title, "Chapter 1");
+        assert_eq!(decoded[1].title, "Part II");
+        assert_eq!(decoded[1].children[0].title, "Chapter 3");
+    }
+
+    #[test]
+    fn unicode_title_roundtrip() {
+        let bookmarks = vec![bm("Раздел 1 — Введение", "#page=1", vec![])];
+        let encoded = encode_navm(&bookmarks);
+        let (total, decoded) = decode_raw(&encoded);
+        assert_eq!(total, 1);
+        assert_eq!(decoded[0].title, "Раздел 1 — Введение");
+    }
+
+    #[test]
+    fn total_count_flat_traversal() {
+        // total_count must count ALL nodes at all levels
+        let bookmarks = vec![bm(
+            "A",
+            "#1",
+            vec![bm("B", "#2", vec![bm("C", "#3", vec![])])],
+        )];
+        let encoded = encode_navm(&bookmarks);
+        let (total, _) = decode_raw(&encoded);
+        assert_eq!(total, 3); // A + B + C
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `navm_encode::encode_navm` — serializes `Vec<DjVuBookmark>` trees to BZZ-compressed binary NAVM chunk format, closing the encoding gap from issue #133
- Implements `annotation::encode_annotations` — serializes `Annotation` + `Vec<MapArea>` to ANTa plain-text S-expression format (the inverse of `parse_annotations`)
- Implements `annotation::encode_annotations_bzz` — ANTz variant using the BZZ encoder from #582432f
- Registers `navm_encode` module in `lib.rs` under `#[cfg(feature = "std")]`

## Details

### NAVM encoder (`src/navm_encode.rs`)
Binary format mirrors the decoder in `djvu_document.rs`:
- u16be total node count (all levels flattened)
- Per node: u8 child count, u24be+bytes title, u24be+bytes url, then children
- Encoded with BZZ compression

### ANTa/ANTz encoder (`src/annotation.rs`)
Serializes back to the S-expression format the parser already understands:
```
(background #rrggbb)
(zoom 100)
(mode color)
(maparea "url" "desc" (rect x y w h) (border xor) (hilite #ff0000))
```
Strings are properly quoted with `\"` and `\\` escaping.

## Test plan

- [x] `navm_encode::tests::empty_bookmarks_returns_empty`
- [x] `navm_encode::tests::single_bookmark_roundtrip`
- [x] `navm_encode::tests::nested_bookmarks_roundtrip`
- [x] `navm_encode::tests::total_count_flat_traversal`
- [x] `navm_encode::tests::unicode_title_roundtrip`
- [x] `annotation::tests::encode_empty_is_empty`
- [x] `annotation::tests::encode_background_roundtrip`
- [x] `annotation::tests::encode_zoom_and_mode_roundtrip`
- [x] `annotation::tests::encode_maparea_rect_roundtrip`
- [x] `annotation::tests::encode_maparea_poly_roundtrip`
- [x] `annotation::tests::encode_maparea_with_border_and_hilite_roundtrip`
- [x] `annotation::tests::encode_url_with_quotes_roundtrip`
- [x] All 45 pre-existing navm/annotation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)