### PR TITLE
feat: JB2 bilevel image encoder — Sjbz chunk encoding (issue #132)

### DIFF
--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -1,0 +1,386 @@
+//! JB2 bilevel image encoder — produces Sjbz chunk payloads.
+//!
+//! Encodes a [`Bitmap`] into a JB2 stream decodable by [`crate::jb2_new::decode`].
+//!
+//! ## Encoding strategy
+//!
+//! The encoder emits the entire image as a single **record type 3** ("new symbol,
+//! direct, blit only") record.  This produces valid output without requiring
+//! connected-component analysis or a symbol dictionary.
+//!
+//! ## Binary format summary (see jb2_new.rs for full spec)
+//!
+//! ```text
+//! encode_num(record_type_ctx, [0,11], 0)  — start-of-image
+//! encode_num(image_size_ctx,  [0,262142], width)
+//! encode_num(image_size_ctx,  [0,262142], height)
+//! encode_bit(flag_ctx, false)             — reserved flag
+//! encode_num(record_type_ctx, [0,11], 3)  — new-symbol, direct, blit-only
+//! encode_num(symbol_width_ctx, [0,262142], width)
+//! encode_num(symbol_height_ctx,[0,262142], height)
+//! encode_bitmap_direct(...)               — 10-bit context bitmap
+//! encode_bit(offset_type_ctx, true)       — new-line positioning
+//! encode_num(hoff_ctx, [-262143,262142], 1)
+//! encode_num(voff_ctx, [-262143,262142], 0)
+//! encode_num(record_type_ctx, [0,11], 11) — end-of-data
+//! ```
+
+use crate::bitmap::Bitmap;
+use crate::zp_impl::encoder::ZpEncoder;
+
+// ── NumContext: binary-tree arena for variable-length integer encoding ─────────
+
+/// Binary-tree context store used to encode variable-length integers with ZP.
+///
+/// Mirrors the decoder's `NumContext` exactly.  Nodes are allocated lazily;
+/// index 0 is unused sentinel, index 1 is the root.
+struct NumContext {
+    ctx: Vec<u8>,
+    left: Vec<u32>,
+    right: Vec<u32>,
+}
+
+impl NumContext {
+    fn new() -> Self {
+        NumContext {
+            ctx: vec![0, 0],
+            left: vec![0, 0],
+            right: vec![0, 0],
+        }
+    }
+
+    fn root(&self) -> usize {
+        1
+    }
+
+    fn get_left(&mut self, node: usize) -> usize {
+        if self.left[node] == 0 {
+            let idx = self.ctx.len() as u32;
+            self.ctx.push(0);
+            self.left.push(0);
+            self.right.push(0);
+            self.left[node] = idx;
+        }
+        self.left[node] as usize
+    }
+
+    fn get_right(&mut self, node: usize) -> usize {
+        if self.right[node] == 0 {
+            let idx = self.ctx.len() as u32;
+            self.ctx.push(0);
+            self.left.push(0);
+            self.right.push(0);
+            self.right[node] = idx;
+        }
+        self.right[node] as usize
+    }
+}
+
+/// Encode integer `val` in `[low, high]` using the same binary-tree traversal
+/// as the decoder's `decode_num`.
+///
+/// Emits a ZP bit at each "free" decision point (where neither `low >= cutoff`
+/// nor `high < cutoff`).  Forced decisions traverse the tree without emitting.
+fn encode_num(zp: &mut ZpEncoder, ctx: &mut NumContext, low: i32, high: i32, val: i32) {
+    let mut low = low;
+    let mut high = high;
+    let mut val_inner = val;
+    let mut cutoff: i32 = 0;
+    let mut phase: u32 = 1;
+    let mut range: u32 = 0xffff_ffff;
+    let mut node = ctx.root();
+
+    while range != 1 {
+        // Determine decision (mirrors decode_num's decision logic).
+        // Emit a bit only when the decision is "free" (not forced by low/high).
+        let decision = if low >= cutoff {
+            // Forced true — traverse right without emitting.
+            let child = ctx.get_right(node);
+            node = child;
+            true
+        } else if high >= cutoff {
+            // Free — decision is (val_inner >= cutoff).
+            let bit = val_inner >= cutoff;
+            let child = if bit {
+                ctx.get_right(node)
+            } else {
+                ctx.get_left(node)
+            };
+            zp.encode_bit(&mut ctx.ctx[node], bit);
+            node = child;
+            bit
+        } else {
+            // Forced false — traverse left without emitting.
+            let child = ctx.get_left(node);
+            node = child;
+            false
+        };
+
+        match phase {
+            1 => {
+                let negative = !decision;
+                if negative {
+                    let temp = -low - 1;
+                    low = -high - 1;
+                    high = temp;
+                    val_inner = -val_inner - 1;
+                }
+                phase = 2;
+                cutoff = 1;
+            }
+            2 => {
+                if !decision {
+                    phase = 3;
+                    range = ((cutoff + 1) / 2) as u32;
+                    if range <= 1 {
+                        range = 1;
+                        cutoff = 0;
+                    } else {
+                        cutoff -= (range / 2) as i32;
+                    }
+                } else {
+                    cutoff = cutoff * 2 + 1;
+                }
+            }
+            3 => {
+                range /= 2;
+                if range == 0 {
+                    range = 1;
+                }
+                if range != 1 {
+                    if !decision {
+                        cutoff -= (range / 2) as i32;
+                    } else {
+                        cutoff += (range / 2) as i32;
+                    }
+                } else if !decision {
+                    cutoff -= 1;
+                }
+            }
+            _ => {
+                range = range.saturating_sub(1);
+            }
+        }
+    }
+}
+
+// ── Bitmap pixel helper ────────────────────────────────────────────────────────
+
+/// Return the pixel value (1 = black, 0 = white) at bitmap coordinates (col, y).
+/// Out-of-bounds → 0.
+#[inline(always)]
+fn pix_bm(bm: &Bitmap, col: i32, y: i32) -> u32 {
+    if col < 0 || y < 0 || col >= bm.width as i32 || y >= bm.height as i32 {
+        return 0;
+    }
+    bm.get(col as u32, y as u32) as u32
+}
+
+// ── Direct bitmap encoding (10-bit context) ───────────────────────────────────
+
+/// Encode a bitmap using the direct 10-pixel-context method.
+///
+/// Mirrors `decode_bitmap_direct` in `jb2_new` exactly.  Iterates rows
+/// top-to-bottom (jbm_row = height-1 down to 0), which corresponds to
+/// Bitmap y = 0 (top) up to height-1 (bottom).
+fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
+    debug_assert_eq!(ctx.len(), 1024);
+    let w = bm.width as i32;
+    let h = bm.height as i32;
+
+    for jbm_row in (0..h).rev() {
+        // Map JB2 internal row (0=bottom) to Bitmap y (0=top).
+        let bm_y = h - 1 - jbm_row; // current row in Bitmap space
+        let bm_y_p1 = bm_y - 1; // jbm_row+1 in Bitmap space (one row above = smaller y)
+        let bm_y_p2 = bm_y - 2; // jbm_row+2 in Bitmap space
+
+        // Initialise rolling windows at col=0 (col-1 and col-2 are OOB → 0).
+        //
+        // r2 = 3 bits: (jbm_row+2, col-1), (col), (col+1)
+        //            = 0, pix(0, bm_y_p2), pix(1, bm_y_p2)
+        let mut r2 = pix_bm(bm, 0, bm_y_p2) << 1 | pix_bm(bm, 1, bm_y_p2);
+        // r1 = 5 bits: (jbm_row+1, col-2..col+2) = 0,0, pix(0), pix(1), pix(2)
+        let mut r1 =
+            pix_bm(bm, 0, bm_y_p1) << 2 | pix_bm(bm, 1, bm_y_p1) << 1 | pix_bm(bm, 2, bm_y_p1);
+        // r0 = 2 bits from already-encoded pixels in current row: col-2, col-1 → 0,0
+        let mut r0: u32 = 0;
+
+        for col in 0..w {
+            let idx = ((r2 << 7) | (r1 << 2) | r0) as usize;
+            let bit = pix_bm(bm, col, bm_y) != 0;
+            zp.encode_bit(&mut ctx[idx], bit);
+
+            // Advance rolling windows (same as decoder).
+            r2 = ((r2 << 1) & 0b111) | pix_bm(bm, col + 2, bm_y_p2);
+            r1 = ((r1 << 1) & 0b11111) | pix_bm(bm, col + 3, bm_y_p1);
+            r0 = ((r0 << 1) & 0b11) | bit as u32;
+        }
+    }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/// Encode a bilevel [`Bitmap`] into a JB2 stream (Sjbz chunk payload).
+///
+/// The returned bytes can be embedded directly in a `Sjbz` IFF chunk.
+/// Decoding with [`crate::jb2_new::decode`] will reconstruct the original bitmap.
+///
+/// ## Encoding
+///
+/// The entire image is encoded as a single direct-bitmap record (type 3).
+/// No connected-component analysis or symbol dictionary is used.
+pub fn encode_jb2(bitmap: &Bitmap) -> Vec<u8> {
+    let w = bitmap.width as i32;
+    let h = bitmap.height as i32;
+
+    let mut zp = ZpEncoder::new();
+
+    // ── Contexts (mirrors decode_image_with_pool) ──────────────────────────
+    let mut record_type_ctx = NumContext::new();
+    let mut image_size_ctx = NumContext::new();
+    let mut symbol_width_ctx = NumContext::new();
+    let mut symbol_height_ctx = NumContext::new();
+    let mut hoff_ctx = NumContext::new();
+    let mut voff_ctx = NumContext::new();
+    let mut direct_bitmap_ctx = vec![0u8; 1024];
+    let mut offset_type_ctx: u8 = 0;
+    let mut flag_ctx: u8 = 0;
+
+    // ── Preamble ───────────────────────────────────────────────────────────
+    // Record type 0: start-of-image.
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 0);
+
+    // Image dimensions (0 is treated as 200 by the decoder, so always encode real dims).
+    let enc_w = if w == 0 { 1 } else { w };
+    let enc_h = if h == 0 { 1 } else { h };
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, enc_w);
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, enc_h);
+
+    // Reserved flag bit — must be 0.
+    zp.encode_bit(&mut flag_ctx, false);
+
+    // ── Single direct-bitmap record ────────────────────────────────────────
+    // Record type 3: new symbol, direct, blit to page, NOT stored in dict.
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 3);
+
+    // Symbol dimensions.
+    encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, enc_w);
+    encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, enc_h);
+
+    // Bitmap data.
+    if enc_w > 0 && enc_h > 0 {
+        encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, bitmap);
+    }
+
+    // Coordinates: new_line=true, hoff=1, voff=0.
+    //
+    // Decoder initial state: first_left=-1, first_bottom=image_height-1.
+    // new_line=true:
+    //   x = first_left + hoff = -1 + 1 = 0
+    //   y = first_bottom + voff - h + 1 = (image_height-1) + 0 - h + 1 = 0
+    // So the symbol lands at (0, 0) — bottom-left of the JB2 page. ✓
+    zp.encode_bit(&mut offset_type_ctx, true); // new_line = true
+    encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, 1);
+    encode_num(&mut zp, &mut voff_ctx, -262143, 262142, 0);
+
+    // ── End-of-data ────────────────────────────────────────────────────────
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 11);
+
+    zp.finish()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitmap::Bitmap;
+    use crate::jb2_new;
+
+    fn make_bitmap(w: u32, h: u32, f: impl Fn(u32, u32) -> bool) -> Bitmap {
+        let mut bm = Bitmap::new(w, h);
+        for y in 0..h {
+            for x in 0..w {
+                bm.set(x, y, f(x, y));
+            }
+        }
+        bm
+    }
+
+    fn roundtrip(bm: &Bitmap) -> Bitmap {
+        let encoded = encode_jb2(bm);
+        jb2_new::decode(&encoded, None).expect("decode failed")
+    }
+
+    #[test]
+    fn all_white_roundtrip() {
+        let src = Bitmap::new(32, 32);
+        let decoded = roundtrip(&src);
+        assert_eq!(decoded.width, 32);
+        assert_eq!(decoded.height, 32);
+        for y in 0..32u32 {
+            for x in 0..32u32 {
+                assert!(!decoded.get(x, y), "expected white at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn all_black_roundtrip() {
+        let src = make_bitmap(32, 32, |_, _| true);
+        let decoded = roundtrip(&src);
+        for y in 0..32u32 {
+            for x in 0..32u32 {
+                assert!(decoded.get(x, y), "expected black at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn checkerboard_roundtrip() {
+        let src = make_bitmap(16, 16, |x, y| (x + y) % 2 == 0);
+        let decoded = roundtrip(&src);
+        for y in 0..16u32 {
+            for x in 0..16u32 {
+                assert_eq!(decoded.get(x, y), (x + y) % 2 == 0, "mismatch at ({x},{y})");
+            }
+        }
+    }
+
+    #[test]
+    fn single_pixel_roundtrip() {
+        // A 1×1 bitmap with a single black pixel.
+        let src = make_bitmap(1, 1, |_, _| true);
+        let decoded = roundtrip(&src);
+        assert_eq!(decoded.width, 1);
+        assert_eq!(decoded.height, 1);
+        assert!(decoded.get(0, 0));
+    }
+
+    #[test]
+    fn larger_image_roundtrip() {
+        let src = make_bitmap(64, 64, |x, y| (x * 17 + y * 31) % 5 != 0);
+        let decoded = roundtrip(&src);
+        assert_eq!(decoded.width, 64);
+        assert_eq!(decoded.height, 64);
+        let mut mismatches = 0u32;
+        for y in 0..64u32 {
+            for x in 0..64u32 {
+                if decoded.get(x, y) != src.get(x, y) {
+                    mismatches += 1;
+                }
+            }
+        }
+        assert_eq!(
+            mismatches, 0,
+            "{mismatches} pixel mismatches in 64×64 roundtrip"
+        );
+    }
+
+    #[test]
+    fn encoded_is_nonempty() {
+        let src = Bitmap::new(8, 8);
+        let encoded = encode_jb2(&src);
+        assert!(!encoded.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,12 @@ pub mod iw44_new;
 #[cfg(feature = "std")]
 pub mod iw44_encode;
 
+/// JB2 bilevel image encoder — produces Sjbz chunk payloads.
+///
+/// Provides [`jb2_encode::encode_jb2`].
+#[cfg(feature = "std")]
+pub mod jb2_encode;
+
 /// New document model — phase 3.
 ///
 /// Provides [`DjVuDocument`] (high-level document API built on the new IFF/BZZ/IW44


### PR DESCRIPTION
## Summary

- Adds `encode_jb2(bitmap: &Bitmap) -> Vec<u8>` that produces a JB2 stream decodable by the existing `jb2_new::decode`
- Implements `encode_num()` mirroring `decode_num`'s binary-tree traversal
- Implements `encode_bitmap_direct()` with the same 10-bit rolling-window context as the decoder

## Encoding strategy

The entire image is encoded as a single **record type 3** ("new symbol, direct, blit-only") record. This avoids connected-component analysis and symbol dictionary construction while producing correct, decodable output. The result is valid Sjbz data — not dictionary-compressed, but functionally complete.

## Key implementation notes

**`encode_num()`**: Mirrors `decode_num`'s binary-tree traversal exactly. At each node:
- If `low >= cutoff`: forced-right (no bit emitted)
- If `high < cutoff`: forced-left (no bit emitted)  
- Otherwise: free decision — emit `val >= cutoff`, traverse right if true, left if false

The adaptive `NumContext` tree evolves identically to the decoder's tree, ensuring context state stays in sync.

**`encode_bitmap_direct()`**: Iterates `jbm_row` from `height-1` to `0` (JB2 internal: row 0 = bottom), mapping to Bitmap y = `0` to `height-1` (Bitmap: row 0 = top). Uses identical 10-bit sliding-window context update as the decoder.

**Coordinates**: `new_line=true, hoff=1, voff=0` places the symbol at (0, 0) — bottom-left of JB2 page — for any image dimensions.

## Test plan

- [x] `all_white_roundtrip`: encode/decode preserves all-white image
- [x] `all_black_roundtrip`: encode/decode preserves all-black image  
- [x] `checkerboard_roundtrip`: pixel-perfect roundtrip of alternating pattern
- [x] `single_pixel_roundtrip`: 1×1 black bitmap
- [x] `larger_image_roundtrip`: 64×64 complex pattern, zero mismatches
- [x] `encoded_is_nonempty`: output is non-empty

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)