### PR TITLE
ci(bench): public gh-pages dashboard + DjVuLibre overlay + IW44 PSNR harness (#197)

### DIFF
--- a/.github/workflows/bench-dashboard.yml
+++ b/.github/workflows/bench-dashboard.yml
@@ -59,6 +59,32 @@ jobs:
       - name: Bench document
         run: cargo bench --bench document -- --output-format bencher 2>&1 | tee -a bench_output.txt
 
+      # ── DjVuLibre baseline (overlay on the same dashboard) ───────────────
+      # Compiles libdjvulibre's render benchmark and emits one bencher line
+      # per DPI so github-action-benchmark plots a parallel timeline next to
+      # djvu-rs's render_page series. This satisfies the "DjVuLibre ratio
+      # overlay" item of #197's DoD. The asset (colorbook.djvu) is checked
+      # into references/djvujs/ so no fetch step is needed.
+      - name: Run DjVuLibre render benchmark
+        id: djvulibre
+        continue-on-error: true
+        run: |
+          mkdir -p target/djvulibre-bench
+          bash scripts/bench_djvulibre.sh target/djvulibre-bench
+          # Parse `render_only : X.XXX ms ...` → bencher ns line per DPI.
+          # bench_djvulibre.sh defaults to 150 dpi; if more DPIs are added
+          # there, extend this loop to track each one.
+          python3 - <<'PYEOF' >> bench_output.txt
+          import re, pathlib
+          txt = pathlib.Path("target/djvulibre-bench/djvulibre_bench.txt").read_text()
+          current_dpi = 150
+          for line in txt.splitlines():
+              m = re.match(r"render_only\s*:\s*([\d.]+)\s*ms", line)
+              if m:
+                  ns = int(float(m.group(1)) * 1_000_000)
+                  print(f"test djvulibre_render_dpi_{current_dpi} ... bench: {ns} ns/iter (+/- 0)")
+          PYEOF
+
       # ── Publish history + dashboard to gh-pages ─────────────────────────
       - name: Push to gh-pages dashboard
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/bench-dashboard.yml
+++ b/.github/workflows/bench-dashboard.yml
@@ -1,0 +1,79 @@
+name: Benchmark dashboard
+
+# Publishes Criterion benchmark history to a public dashboard on the gh-pages
+# branch via benchmark-action/github-action-benchmark. Runs only on main-branch
+# pushes that touch source/benches and on release tags, so PR runs in
+# bench.yml stay fast and the public timeline only records merged commits.
+#
+# Output: https://matyushkin.github.io/djvu-rs/dev/bench/
+#
+# See #197 for design rationale.
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v*'
+    paths:
+      - 'src/**'
+      - 'benches/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: write          # push to gh-pages
+  deployments: write       # github-action-benchmark stores deployment markers
+
+concurrency:
+  group: bench-dashboard
+  cancel-in-progress: false  # don't drop history points
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  publish:
+    name: Publish dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: bench-dashboard-ubuntu
+
+      # ── Run all Criterion benchmarks in bencher format ───────────────────
+      # github-action-benchmark consumes the `bencher` (libtest) format.
+      - name: Bench codecs
+        run: cargo bench --bench codecs -- --output-format bencher 2>&1 | tee bench_output.txt
+
+      - name: Bench render
+        run: cargo bench --bench render -- --output-format bencher 2>&1 | tee -a bench_output.txt
+
+      - name: Bench document
+        run: cargo bench --bench document -- --output-format bencher 2>&1 | tee -a bench_output.txt
+
+      # ── Publish history + dashboard to gh-pages ─────────────────────────
+      - name: Push to gh-pages dashboard
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: djvu-rs benchmarks
+          tool: 'cargo'
+          output-file-path: bench_output.txt
+          # Persist on the gh-pages branch under dev/bench/ → published page.
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # 10 % regression alert on any benchmark; comment on the commit that
+          # introduced it (see #197 DoD).
+          alert-threshold: '110%'
+          fail-on-alert: false
+          comment-on-alert: true
+          alert-comment-cc-users: '@matyushkin'

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -251,6 +251,65 @@ Contributions with measurements for other libraries are welcome — see **Contri
 
 ---
 
+## Encoder quality (vs DjVuLibre)
+
+Quality benchmarks compare djvu-rs's encoder output size to the original DjVu
+file (typically produced by `cjb2`/`c44` from DjVuLibre) on `tests/corpus/*`.
+Run with `cargo run --release --example encode_quality_jb2 -- tests/corpus/*.djvu`.
+
+### JB2 — Sjbz payload size (553 pages across 4 books)
+
+| Encoder | Total bytes | bpp | Ratio vs cjb2 | Round-trip |
+|---------|-------------|-----|---------------|------------|
+| `cjb2` (original) | 25 032 792 | 0.0288 | 1.00× | — |
+| `encode_jb2` (tiled direct) | 42 809 783 | 0.0492 | **1.71×** | 553 / 553 ok |
+| `encode_jb2_dict` (CC + rec 1+7) | 35 301 664 | 0.0406 | **1.41×** | 483 / 553 ok |
+
+- `encode_jb2` (#198): direct-blit, tiled into ≤ 1024×1024 records to stay
+  under the decoder's 1 MP per-symbol cap. 100% round-trip across all corpus
+  pages including 4267×6853 (29 MP) scans.
+- `encode_jb2_dict` (#188 phase 1): connected-component extraction + exact-match
+  symbol dictionary. **1.41×** total ratio is mostly recovered already; the
+  remaining gap closes with refinement matching (#188 phase 2/3) and shared
+  Djbz across pages (#194). Round-trip fails on 70 dense scans whose CC
+  extraction yields a single component > 1 MP (large halftone / contiguous
+  artwork region) — the dict path needs to fall back to tiled direct-blit
+  for such CCs (tracked under #188 phase 2).
+
+Per-book ratios:
+
+| Corpus | Pages | dict bytes | orig bytes | dict ratio | direct ratio |
+|--------|-------|------------|------------|------------|--------------|
+| `cable_1973_100133.djvu` | 2 | 10 082 | 8 020 | 1.257× | 3.886× |
+| `conquete_paix.djvu` | 22 | 54 919 | 52 007 | 1.056× | 1.906× |
+| `pathogenic_bacteria_1896.djvu` | 517 | 35 092 640 | 24 849 842 | 1.412× | 1.696× |
+| `watchmaker.djvu` | 12 | 144 023 | 122 923 | 1.172× | 4.349× |
+
+### IW44 — BG44 payload size + PSNR (23 colour pages, 4 books)
+
+Re-encoded via `cargo run --release --example encode_quality_iw44 --
+tests/corpus/*.djvu`. Reference for PSNR is djvu-rs's own decode of the
+original BG44 (the encoder is the unit under test).
+
+| Metric | Value |
+|--------|-------|
+| Total pages | 23 |
+| Total orig BG44 size | 1 607 509 B |
+| Total djvu-rs BG44 size | 1 834 621 B (1.14× orig) |
+| Avg PSNR (luma) | 19.52 dB |
+| Min PSNR (luma) | 9.75 dB |
+| `watchmaker.djvu` pages (small bg) | 45–47 dB ✓ |
+| `conquete_paix.djvu` pages | 9–17 dB ✗ |
+
+`watchmaker.djvu` results are near-perfect (45+ dB on a near-empty bg).
+`conquete_paix.djvu` results are catastrophic — sub-20 dB indicates the
+encoder loses substantial structure on those pages. Worth opening a follow-up
+to investigate; the harness exists now to track it.
+
+Apple M1 Max, 2026-04-26.
+
+---
+
 ## Notes
 
 - `bzz_decode` is slow (82 ms) because the NAVM chunk in navm_fgbz.djvu is large (~6 KB compressed). BZZ is inherently sequential (BWT inverse requires a full-block sort).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/djvu-rs.svg)](https://crates.io/crates/djvu-rs)
 [![docs.rs](https://docs.rs/djvu-rs/badge.svg)](https://docs.rs/djvu-rs)
 [![CI](https://github.com/matyushkin/djvu-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/matyushkin/djvu-rs/actions/workflows/ci.yml)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-dashboard-blue)](https://matyushkin.github.io/djvu-rs/dev/bench/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Pure-Rust DjVu codec — decode and encode DjVu documents. MIT licensed, no GPL dependencies. Written from the DjVu v3 public specification.

--- a/examples/encode_quality_iw44.rs
+++ b/examples/encode_quality_iw44.rs
@@ -1,0 +1,195 @@
+//! IW44 encoder quality benchmark — re-encodes the BG44 background of every
+//! page in the supplied DjVu file(s), then measures PSNR (luminance) of the
+//! re-decoded pixmap against djvu-rs's own decode of the original BG44.
+//!
+//! Output: one JSON line per page (jsonl), plus a final summary on stderr.
+//!
+//! Usage:
+//!     cargo run --release --features=std --example encode_quality_iw44 -- <file.djvu> [...]
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use djvu_rs::{
+    DjVuDocument, Pixmap,
+    iw44_encode::{Iw44EncodeOptions, encode_iw44_color},
+    iw44_new::Iw44Image,
+};
+
+#[derive(Clone, Copy, Debug)]
+struct PageResult {
+    page: usize,
+    width: u32,
+    height: u32,
+    orig_bg44_bytes: usize,
+    rs_bg44_bytes: usize,
+    psnr_db: f64,
+}
+
+/// PSNR of `b` against reference `a` over a luminance channel.
+/// Uses ITU-R BT.601 luma coefficients on RGBA8 pixmaps.
+fn psnr_rgba(a: &Pixmap, b: &Pixmap) -> f64 {
+    assert_eq!(a.width, b.width);
+    assert_eq!(a.height, b.height);
+    let n = (a.width as usize) * (a.height as usize);
+    let mut mse = 0.0f64;
+    for i in 0..n {
+        let off = i * 4;
+        let ay = 0.299 * a.data[off] as f64
+            + 0.587 * a.data[off + 1] as f64
+            + 0.114 * a.data[off + 2] as f64;
+        let by = 0.299 * b.data[off] as f64
+            + 0.587 * b.data[off + 1] as f64
+            + 0.114 * b.data[off + 2] as f64;
+        let d = ay - by;
+        mse += d * d;
+    }
+    mse /= n as f64;
+    if mse == 0.0 {
+        return f64::INFINITY;
+    }
+    10.0 * (255.0 * 255.0 / mse).log10()
+}
+
+/// Decode an entire BG44 chunk stream into a Pixmap.
+fn decode_bg44_chunks(chunks: &[&[u8]]) -> Option<Pixmap> {
+    let mut img = Iw44Image::new();
+    for c in chunks {
+        img.decode_chunk(c).ok()?;
+    }
+    img.to_rgb().ok()
+}
+
+/// Same, for `Vec<Vec<u8>>` (encoder output).
+fn decode_bg44_owned(chunks: &[Vec<u8>]) -> Option<Pixmap> {
+    let mut img = Iw44Image::new();
+    for c in chunks {
+        img.decode_chunk(c).ok()?;
+    }
+    img.to_rgb().ok()
+}
+
+fn process_file(path: &Path) -> Vec<PageResult> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skip {}: {}", path.display(), e);
+            return vec![];
+        }
+    };
+    let doc = match DjVuDocument::parse(&data) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skip {}: parse failed: {}", path.display(), e);
+            return vec![];
+        }
+    };
+
+    let mut out = Vec::new();
+    for page_idx in 0..doc.page_count() {
+        let page = match doc.page(page_idx) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let bg44_chunks: Vec<&[u8]> = page.bg44_chunks();
+        if bg44_chunks.is_empty() {
+            continue;
+        }
+
+        let orig_bytes: usize = bg44_chunks.iter().map(|d| d.len()).sum();
+        let orig_pixmap = match decode_bg44_chunks(&bg44_chunks) {
+            Some(p) => p,
+            None => continue,
+        };
+
+        // Re-encode with the same chunking strategy as DjVuLibre's c44 default
+        // (10 slices/chunk × 10 chunks = 100 slices total).
+        let opts = Iw44EncodeOptions::default();
+        let rs_chunks = encode_iw44_color(&orig_pixmap, &opts);
+        let rs_bytes: usize = rs_chunks.iter().map(|v| v.len()).sum();
+
+        let rs_pixmap = match decode_bg44_owned(&rs_chunks) {
+            Some(p) => p,
+            None => continue,
+        };
+        let psnr = psnr_rgba(&orig_pixmap, &rs_pixmap);
+
+        out.push(PageResult {
+            page: page_idx,
+            width: orig_pixmap.width,
+            height: orig_pixmap.height,
+            orig_bg44_bytes: orig_bytes,
+            rs_bg44_bytes: rs_bytes,
+            psnr_db: psnr,
+        });
+    }
+    out
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!(
+            "usage: encode_quality_iw44 <file.djvu> [<file2.djvu> ...]\n\
+             \n\
+             Re-encodes every BG44 background and measures PSNR vs djvu-rs's\n\
+             decode of the original BG44 (the encoder is the unit under test;\n\
+             the original decode is the reference)."
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut total_orig = 0usize;
+    let mut total_rs = 0usize;
+    let mut total_pages = 0usize;
+    let mut psnr_sum = 0.0f64;
+    let mut psnr_min = f64::INFINITY;
+
+    for arg in &args {
+        let path = Path::new(arg);
+        for r in process_file(path) {
+            println!(
+                "{{\"file\":\"{}\",\"page\":{},\"width\":{},\"height\":{},\
+                 \"orig_bg44_bytes\":{},\"rs_bg44_bytes\":{},\"psnr_db\":{:.3}}}",
+                path.display(),
+                r.page,
+                r.width,
+                r.height,
+                r.orig_bg44_bytes,
+                r.rs_bg44_bytes,
+                r.psnr_db
+            );
+            total_orig += r.orig_bg44_bytes;
+            total_rs += r.rs_bg44_bytes;
+            total_pages += 1;
+            if r.psnr_db.is_finite() {
+                psnr_sum += r.psnr_db;
+                if r.psnr_db < psnr_min {
+                    psnr_min = r.psnr_db;
+                }
+            }
+        }
+    }
+
+    if total_pages == 0 {
+        eprintln!("no IW44/BG44 pages processed");
+        return ExitCode::from(1);
+    }
+
+    eprintln!();
+    eprintln!("=== IW44 encoder quality summary ===");
+    eprintln!("pages:          {}", total_pages);
+    eprintln!("orig BG44 size: {:>10} bytes", total_orig);
+    eprintln!(
+        "rs   BG44 size: {:>10} bytes  ({:.3}× orig)",
+        total_rs,
+        total_rs as f64 / total_orig.max(1) as f64
+    );
+    eprintln!(
+        "PSNR (luma):    avg {:.2} dB,  min {:.2} dB",
+        psnr_sum / total_pages as f64,
+        psnr_min
+    );
+
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary
- Add `bench-dashboard.yml` workflow publishing Criterion results to gh-pages via `benchmark-action`.
- Add DjVuLibre overlay series for visual regression tracking.
- Add `examples/encode_quality_iw44.rs` PSNR harness with corpus baseline written to `BENCHMARKS.md`.
- Closes #197.

## Test plan
- [ ] First scheduled run publishes dashboard
- [ ] PSNR harness reproducible locally on `tests/corpus/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)