### PR TITLE
perf(jb2-enc): eliminate bounds checks from JB2 encode hot loop

### DIFF
--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -172,6 +172,7 @@ fn encode_num(zp: &mut ZpEncoder, ctx: &mut NumContext, low: i32, high: i32, val
 /// The bitmap is first expanded to a flat byte-per-pixel array with 2 zero rows
 /// above the image and 4 zero columns to the right of each row.  This eliminates
 /// all per-pixel bounds checking and bit-manipulation in the inner loop.
+#[allow(unsafe_code)]
 fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
     debug_assert_eq!(ctx.len(), 1024);
     let w = bm.width as usize;
@@ -207,7 +208,10 @@ fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
         for col in 0..w {
             let idx = ((r2 << 7) | (r1 << 2) | r0) as usize;
             let bit = row_cur[col] != 0;
-            zp.encode_bit(&mut ctx[idx], bit);
+            // Safety: r2 ≤ 7, r1 ≤ 31, r0 ≤ 3 by the & masks above,
+            // so idx ≤ (7<<7)|(31<<2)|3 = 1023 < ctx.len() = 1024.
+            let ctx_byte = unsafe { ctx.get_unchecked_mut(idx) };
+            zp.encode_bit(ctx_byte, bit);
 
             // Advance rolling windows — no bounds checks: col+2 < w+2 < pw, col+3 < w+3 < pw.
             r2 = ((r2 << 1) & 0b111) | row_p2[col + 2] as u32;

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -162,55 +162,56 @@ fn encode_num(zp: &mut ZpEncoder, ctx: &mut NumContext, low: i32, high: i32, val
     }
 }
 
-// ── Bitmap pixel helper ────────────────────────────────────────────────────────
-
-/// Return the pixel value (1 = black, 0 = white) at bitmap coordinates (col, y).
-/// Out-of-bounds → 0.
-#[inline(always)]
-fn pix_bm(bm: &Bitmap, col: i32, y: i32) -> u32 {
-    if col < 0 || y < 0 || col >= bm.width as i32 || y >= bm.height as i32 {
-        return 0;
-    }
-    bm.get(col as u32, y as u32) as u32
-}
-
 // ── Direct bitmap encoding (10-bit context) ───────────────────────────────────
 
 /// Encode a bitmap using the direct 10-pixel-context method.
 ///
 /// Mirrors `decode_bitmap_direct` in `jb2` exactly.  Iterates rows
-/// top-to-bottom (jbm_row = height-1 down to 0), which corresponds to
-/// Bitmap y = 0 (top) up to height-1 (bottom).
+/// top-to-bottom, which corresponds to Bitmap y = 0 (top) up to height-1 (bottom).
+///
+/// The bitmap is first expanded to a flat byte-per-pixel array with 2 zero rows
+/// above the image and 4 zero columns to the right of each row.  This eliminates
+/// all per-pixel bounds checking and bit-manipulation in the inner loop.
 fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
     debug_assert_eq!(ctx.len(), 1024);
-    let w = bm.width as i32;
-    let h = bm.height as i32;
+    let w = bm.width as usize;
+    let h = bm.height as usize;
+    // Row stride with 4 zero-padding columns so col+2 and col+3 are always in-bounds.
+    let pw = w + 4;
 
-    for jbm_row in (0..h).rev() {
-        // Map JB2 internal row (0=bottom) to Bitmap y (0=top).
-        let bm_y = h - 1 - jbm_row; // current row in Bitmap space
-        let bm_y_p1 = bm_y - 1; // jbm_row+1 in Bitmap space (one row above = smaller y)
-        let bm_y_p2 = bm_y - 2; // jbm_row+2 in Bitmap space
+    // Expand bitmap to byte-per-pixel (0 or 1).
+    // Layout: rows 0..2 are zero (padding for bm_y_p2/bm_y_p1 when bm_y < 2),
+    //         rows 2..h+2 hold image rows 0..h.
+    // Mapping: padded_index(bm_y_p2) = bm_y, padded_index(bm_y_p1) = bm_y+1,
+    //          padded_index(cur) = bm_y+2.
+    let mut pixels = vec![0u8; (h + 2) * pw];
+    for y in 0..h {
+        for x in 0..w {
+            pixels[(y + 2) * pw + x] = bm.get(x as u32, y as u32) as u8;
+        }
+    }
 
-        // Initialise rolling windows at col=0 (col-1 and col-2 are OOB → 0).
+    for bm_y in 0..h {
+        let row_p2 = &pixels[bm_y * pw..(bm_y + 1) * pw];
+        let row_p1 = &pixels[(bm_y + 1) * pw..(bm_y + 2) * pw];
+        let row_cur = &pixels[(bm_y + 2) * pw..(bm_y + 3) * pw];
+
+        // Initialise rolling windows at col=0 (col-1 and col-2 are OOB → 0 via padding).
         //
-        // r2 = 3 bits: (jbm_row+2, col-1), (col), (col+1)
-        //            = 0, pix(0, bm_y_p2), pix(1, bm_y_p2)
-        let mut r2 = pix_bm(bm, 0, bm_y_p2) << 1 | pix_bm(bm, 1, bm_y_p2);
-        // r1 = 5 bits: (jbm_row+1, col-2..col+2) = 0,0, pix(0), pix(1), pix(2)
-        let mut r1 =
-            pix_bm(bm, 0, bm_y_p1) << 2 | pix_bm(bm, 1, bm_y_p1) << 1 | pix_bm(bm, 2, bm_y_p1);
-        // r0 = 2 bits from already-encoded pixels in current row: col-2, col-1 → 0,0
+        // r2 = 3 bits: (bm_y_p2, col-1=0), (col=0), (col+1=1)
+        let mut r2 = (row_p2[0] as u32) << 1 | row_p2[1] as u32;
+        // r1 = 5 bits: (bm_y_p1, col-2=0), (col-1=0), (col=0), (col+1=1), (col+2=2)
+        let mut r1 = (row_p1[0] as u32) << 2 | (row_p1[1] as u32) << 1 | row_p1[2] as u32;
         let mut r0: u32 = 0;
 
         for col in 0..w {
             let idx = ((r2 << 7) | (r1 << 2) | r0) as usize;
-            let bit = pix_bm(bm, col, bm_y) != 0;
+            let bit = row_cur[col] != 0;
             zp.encode_bit(&mut ctx[idx], bit);
 
-            // Advance rolling windows (same as decoder).
-            r2 = ((r2 << 1) & 0b111) | pix_bm(bm, col + 2, bm_y_p2);
-            r1 = ((r1 << 1) & 0b11111) | pix_bm(bm, col + 3, bm_y_p1);
+            // Advance rolling windows — no bounds checks: col+2 < w+2 < pw, col+3 < w+3 < pw.
+            r2 = ((r2 << 1) & 0b111) | row_p2[col + 2] as u32;
+            r1 = ((r1 << 1) & 0b11111) | row_p1[col + 3] as u32;
             r0 = ((r0 << 1) & 0b11) | bit as u32;
         }
     }

--- a/src/zp/tables.rs
+++ b/src/zp/tables.rs
@@ -5,16 +5,20 @@
 //! <https://www.sndjvu.org/spec.html>.
 //!
 //! Key public types (all `pub(crate)` constants):
-//! - [`PROB`] — probability estimates (251 entries, u16)
-//! - [`THRESHOLD`] — adaptation thresholds (251 entries, u16)
-//! - [`MPS_NEXT`] — state transitions on MPS (most probable symbol) (251 entries, u8)
-//! - [`LPS_NEXT`] — state transitions on LPS (least probable symbol) (251 entries, u8)
+//! - [`PROB`] — probability estimates (256 entries, u16)
+//! - [`THRESHOLD`] — adaptation thresholds (256 entries, u16)
+//! - [`MPS_NEXT`] — state transitions on MPS (most probable symbol) (256 entries, u8)
+//! - [`LPS_NEXT`] — state transitions on LPS (least probable symbol) (256 entries, u8)
+//!
+//! Each table has 256 entries (5 padding entries at indices 251–255) so that LLVM
+//! can prove `state < 256` for any `u8`-derived index and eliminate bounds checks.
 
-/// Probability estimates `p[state]` for each ZP coder state (251 entries).
+/// Probability estimates `p[state]` for each ZP coder state.
 ///
+/// 251 valid entries + 5 padding entries (indices 251–255, never accessed).
 /// Each entry gives the probability that the next decoded bit is the MPS (most
 /// probable symbol). Values are unsigned 16-bit fractions in the range [0, 0x8000].
-pub(crate) const PROB: [u16; 251] = [
+pub(crate) const PROB: [u16; 256] = [
     0x8000, 0x8000, 0x8000, 0x6bbd, 0x6bbd, 0x5d45, 0x5d45, 0x51b9, 0x51b9, 0x4813, 0x4813, 0x3fd5,
     0x3fd5, 0x38b1, 0x38b1, 0x3275, 0x3275, 0x2cfd, 0x2cfd, 0x2825, 0x2825, 0x23ab, 0x23ab, 0x1f87,
     0x1f87, 0x1bbb, 0x1bbb, 0x1845, 0x1845, 0x1523, 0x1523, 0x1253, 0x1253, 0x0fcf, 0x0fcf, 0x0d95,
@@ -36,13 +40,17 @@ pub(crate) const PROB: [u16; 251] = [
     0x24ef, 0x00e1, 0x320e, 0x0094, 0x432a, 0x0188, 0x447d, 0x0252, 0x5ece, 0x0383, 0x8000, 0x0547,
     0x481a, 0x07e2, 0x3579, 0x0bc0, 0x24ef, 0x1178, 0x1978, 0x19da, 0x2865, 0x24ef, 0x3987, 0x320e,
     0x2c99, 0x432a, 0x3b5f, 0x447d, 0x5695, 0x5ece, 0x8000, 0x8000, 0x5695, 0x481a, 0x481a,
+    // 5 padding entries (indices 251–255, never accessed during correct operation)
+    0x8000, 0x8000, 0x8000, 0x8000, 0x8000,
 ];
 
-/// Adaptation threshold `m[state]` for each ZP coder state (251 entries).
+/// Adaptation threshold `m[state]` for each ZP coder state.
+///
+/// 251 valid entries + 5 padding entries (indices 251–255, never accessed).
 ///
 /// When `a >= m[state]`, the MPS transition updates the context state using
 /// [`MPS_NEXT`]. Entries beyond state 82 are 0 (no threshold-based update).
-pub(crate) const THRESHOLD: [u16; 251] = [
+pub(crate) const THRESHOLD: [u16; 256] = [
     0x0000, 0x0000, 0x0000, 0x10a5, 0x10a5, 0x1f28, 0x1f28, 0x2bd3, 0x2bd3, 0x36e3, 0x36e3, 0x408c,
     0x408c, 0x48fd, 0x48fd, 0x505d, 0x505d, 0x56d0, 0x56d0, 0x5c71, 0x5c71, 0x615b, 0x615b, 0x65a5,
     0x65a5, 0x6962, 0x6962, 0x6ca2, 0x6ca2, 0x6f74, 0x6f74, 0x71e6, 0x71e6, 0x7404, 0x7404, 0x75d6,
@@ -64,13 +72,15 @@ pub(crate) const THRESHOLD: [u16; 251] = [
     0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
     0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
     0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+    // 5 padding entries (indices 251–255, never accessed during correct operation)
+    0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
 ];
 
 /// Next state on MPS (most probable symbol) occurrence.
 ///
 /// When the decoded bit matches the MPS and `a >= m[state]`, the context is
 /// updated to `MPS_NEXT[state]`.
-pub(crate) const MPS_NEXT: [u8; 251] = [
+pub(crate) const MPS_NEXT: [u8; 256] = [
     84, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
     51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
@@ -83,13 +93,15 @@ pub(crate) const MPS_NEXT: [u8; 251] = [
     58, 205, 54, 207, 50, 209, 46, 211, 40, 213, 36, 215, 30, 217, 26, 219, 20, 71, 14, 61, 14, 57,
     8, 53, 228, 49, 230, 45, 232, 39, 234, 35, 138, 29, 24, 25, 240, 19, 22, 13, 16, 13, 10, 7,
     244, 249, 10, 89, 230,
+    // 5 padding entries (indices 251–255, never accessed during correct operation)
+    0, 0, 0, 0, 0,
 ];
 
 /// Next state on LPS (least probable symbol) occurrence.
 ///
 /// When the decoded bit does not match the MPS, the context is updated to
 /// `LPS_NEXT[state]`.
-pub(crate) const LPS_NEXT: [u8; 251] = [
+pub(crate) const LPS_NEXT: [u8; 256] = [
     145, 4, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
     24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
     48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
@@ -102,6 +114,8 @@ pub(crate) const LPS_NEXT: [u8; 251] = [
     64, 239, 56, 237, 52, 235, 48, 233, 44, 231, 38, 229, 34, 227, 28, 225, 22, 223, 16, 221, 220,
     63, 8, 55, 224, 51, 2, 47, 87, 43, 246, 37, 244, 33, 238, 27, 236, 21, 16, 15, 8, 241, 242, 7,
     10, 245, 2, 1, 83, 250, 2, 143, 246,
+    // 5 padding entries (indices 251–255, never accessed during correct operation)
+    0, 0, 0, 0, 0,
 ];
 
 #[cfg(test)]
@@ -110,10 +124,10 @@ mod tests {
 
     #[test]
     fn tables_have_correct_length() {
-        assert_eq!(PROB.len(), 251);
-        assert_eq!(THRESHOLD.len(), 251);
-        assert_eq!(MPS_NEXT.len(), 251);
-        assert_eq!(LPS_NEXT.len(), 251);
+        assert_eq!(PROB.len(), 256);
+        assert_eq!(THRESHOLD.len(), 256);
+        assert_eq!(MPS_NEXT.len(), 256);
+        assert_eq!(LPS_NEXT.len(), 256);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Pre-expand `Bitmap` to byte-per-pixel array with 2 zero rows above + 4 zero columns right; eliminates `pix_bm` (4 bounds comparisons + bit-unpack per call, 3 calls/pixel) in `encode_bitmap_direct`.
- Pad `PROB`/`THRESHOLD`/`MPS_NEXT`/`LPS_NEXT` from 251 to 256 entries so LLVM proves `state < 256` for any `u8`-cast index, eliminating the `cmp x8, #250; b.hi` PROB bounds check from both encoder and decoder hot loops.
- `get_unchecked_mut(idx)` for ctx array in `encode_bitmap_direct` (idx provably ≤ 1023 < 1024 by mask construction).

Assembly verified: encoding inner loop now has zero bounds-check branches; only legitimate ZP arithmetic branches remain.

## Test plan
- [x] All existing tests pass (488 tests)
- [x] Pre-commit hook clean (fmt + clippy + no_std)
- [ ] `cargo bench --bench codecs -- jb2_encode` shows expected gain

🤖 Generated with [Claude Code](https://claude.com/claude-code)