### PR TITLE
feat(jb2-enc): multi-page shared Djbz dictionary, Phase 1 (#194)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,117 @@
+name: Encoder quality
+
+# Runs encode_quality_jb2 + encode_quality_iw44 on the in-tree corpus
+# (tests/corpus/*.djvu) and:
+#   - on a monthly schedule, uploads the JSONL results as artifacts and
+#     refreshes the historical CSV at target/quality/
+#   - on PRs that touch encoder code (`*_encode.rs`, encode_quality_*),
+#     posts a comparison comment showing the new vs base size + PSNR
+#     numbers
+#
+# This is the CI item from #191's DoD. The harnesses themselves live as
+# `examples/encode_quality_*.rs`; running them locally is a one-liner:
+#     cargo run --release --features cli --example encode_quality_jb2 \
+#         -- tests/corpus/*.djvu
+
+on:
+  pull_request:
+    paths:
+      - 'src/**_encode*.rs'
+      - 'src/jb2_encode/**'
+      - 'src/iw44_encode/**'
+      - 'examples/encode_quality_*.rs'
+      - '.github/workflows/quality.yml'
+  schedule:
+    - cron: '0 5 1 * *'   # 1st of each month, 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  quality:
+    name: Run quality harnesses
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: encode-quality
+
+      - name: Build harnesses
+        run: |
+          cargo build --release --features cli \
+            --example encode_quality_jb2 \
+            --example encode_quality_iw44
+
+      - name: JB2 quality (cjb2 baseline)
+        run: |
+          ./target/release/examples/encode_quality_jb2 \
+            tests/corpus/cable_1973_100133.djvu \
+            tests/corpus/conquete_paix.djvu \
+            tests/corpus/watchmaker.djvu \
+              > jb2_quality.jsonl 2> jb2_summary.txt || true
+          echo "── JB2 summary ──"
+          cat jb2_summary.txt
+
+      - name: IW44 quality (PSNR vs original BG44)
+        run: |
+          ./target/release/examples/encode_quality_iw44 \
+            tests/corpus/watchmaker.djvu \
+            tests/corpus/conquete_paix.djvu \
+              > iw44_quality.jsonl 2> iw44_summary.txt || true
+          echo "── IW44 summary ──"
+          cat iw44_summary.txt
+
+      - name: Build markdown report
+        id: report
+        run: |
+          {
+            echo "## Encoder quality — `${{ github.sha }}`"
+            echo
+            echo "### JB2 (size vs cjb2)"
+            echo '```'
+            cat jb2_summary.txt
+            echo '```'
+            echo
+            echo "### IW44 (size + PSNR vs original)"
+            echo '```'
+            cat iw44_summary.txt
+            echo '```'
+          } > report.md
+          # GH Actions output capture (multi-line via heredoc-style delimiter)
+          {
+            echo "report<<EOF"
+            cat report.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: encoder-quality
+          message: ${{ steps.report.outputs.report }}
+
+      - name: Upload JSONL artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: encoder-quality-${{ github.run_id }}
+          path: |
+            jb2_quality.jsonl
+            jb2_summary.txt
+            iw44_quality.jsonl
+            iw44_summary.txt
+          retention-days: 90

--- a/examples/encode_quality_jb2.rs
+++ b/examples/encode_quality_jb2.rs
@@ -1,0 +1,209 @@
+//! JB2 encoder quality benchmark — compares djvu-rs re-encoded Sjbz payload
+//! size against the original Sjbz chunk in a DjVu file (typically produced
+//! by `cjb2` from DjVuLibre).
+//!
+//! Also verifies lossless round-trip: the re-encoded stream must decode to
+//! the exact same `Bitmap` as the original.
+//!
+//! Usage:
+//!     cargo run --release --example encode_quality_jb2 -- <file.djvu> [<file2.djvu> ...]
+//!
+//! Output: one JSON line per page (jsonl), plus a final summary table on stderr.
+//!
+//! Fields per page:
+//!   file            — path of the source DjVu
+//!   page            — 0-based page index
+//!   width, height   — bitmap dimensions
+//!   orig_sjbz_bytes — original Sjbz payload size
+//!   rs_sjbz_bytes   — djvu-rs re-encoded Sjbz payload size
+//!   bpp_orig        — bits per pixel of the original
+//!   bpp_rs          — bits per pixel of the re-encoded
+//!   size_ratio      — rs_sjbz_bytes / orig_sjbz_bytes (>1.0 means djvu-rs worse)
+//!   roundtrip_ok    — re-encoded decodes to the same bitmap
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use djvu_rs::{DjVuDocument, jb2, jb2_encode::encode_jb2};
+
+#[derive(Copy, Clone, Debug)]
+enum RoundtripStatus {
+    Ok,
+    Mismatch,
+    /// Decoder rejected the re-encoded stream — see issue #198
+    /// (encoder emits whole image as one type-3 symbol > MAX_SYMBOL_PIXELS).
+    DecodeError,
+}
+
+impl RoundtripStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            RoundtripStatus::Ok => "ok",
+            RoundtripStatus::Mismatch => "mismatch",
+            RoundtripStatus::DecodeError => "decode_error",
+        }
+    }
+}
+
+struct PageResult {
+    file: String,
+    page: usize,
+    width: u32,
+    height: u32,
+    orig_sjbz_bytes: usize,
+    rs_sjbz_bytes: usize,
+    roundtrip: RoundtripStatus,
+}
+
+fn process_file(path: &Path) -> Vec<PageResult> {
+    let data = match std::fs::read(path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skip {}: {}", path.display(), e);
+            return vec![];
+        }
+    };
+    let doc = match DjVuDocument::parse(&data) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skip {}: parse failed: {}", path.display(), e);
+            return vec![];
+        }
+    };
+
+    let mut out = Vec::new();
+    for page_idx in 0..doc.page_count() {
+        let page = match doc.page(page_idx) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let orig_sjbz = match page.raw_chunk(b"Sjbz") {
+            Some(s) => s,
+            None => continue,
+        };
+        let bitmap = match page.extract_mask() {
+            Ok(Some(b)) => b,
+            _ => continue,
+        };
+
+        let rs_encoded = encode_jb2(&bitmap);
+
+        let roundtrip = match jb2::decode(&rs_encoded, None) {
+            Ok(b) => {
+                if b.width == bitmap.width && b.height == bitmap.height && b.data == bitmap.data {
+                    RoundtripStatus::Ok
+                } else {
+                    RoundtripStatus::Mismatch
+                }
+            }
+            Err(_) => RoundtripStatus::DecodeError,
+        };
+
+        out.push(PageResult {
+            file: path.display().to_string(),
+            page: page_idx,
+            width: bitmap.width,
+            height: bitmap.height,
+            orig_sjbz_bytes: orig_sjbz.len(),
+            rs_sjbz_bytes: rs_encoded.len(),
+            roundtrip,
+        });
+    }
+    out
+}
+
+fn bpp(bytes: usize, width: u32, height: u32) -> f64 {
+    if width == 0 || height == 0 {
+        return f64::NAN;
+    }
+    (bytes as f64 * 8.0) / (width as f64 * height as f64)
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!(
+            "usage: encode_quality_jb2 <file.djvu> [<file2.djvu> ...]\n\
+             \n\
+             Re-encodes every Sjbz chunk via djvu-rs and compares size to the\n\
+             original. Also verifies lossless round-trip."
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut all: Vec<PageResult> = Vec::new();
+    for arg in &args {
+        let path = Path::new(arg);
+        all.extend(process_file(path));
+    }
+
+    for r in &all {
+        println!(
+            "{{\"file\":\"{}\",\"page\":{},\"width\":{},\"height\":{},\
+             \"orig_sjbz_bytes\":{},\"rs_sjbz_bytes\":{},\
+             \"bpp_orig\":{:.4},\"bpp_rs\":{:.4},\
+             \"size_ratio\":{:.3},\"roundtrip\":\"{}\"}}",
+            r.file,
+            r.page,
+            r.width,
+            r.height,
+            r.orig_sjbz_bytes,
+            r.rs_sjbz_bytes,
+            bpp(r.orig_sjbz_bytes, r.width, r.height),
+            bpp(r.rs_sjbz_bytes, r.width, r.height),
+            r.rs_sjbz_bytes as f64 / r.orig_sjbz_bytes.max(1) as f64,
+            r.roundtrip.as_str(),
+        );
+    }
+
+    if all.is_empty() {
+        eprintln!("no JB2 pages processed");
+        return ExitCode::from(1);
+    }
+
+    let total_orig: usize = all.iter().map(|r| r.orig_sjbz_bytes).sum();
+    let total_rs: usize = all.iter().map(|r| r.rs_sjbz_bytes).sum();
+    let total_pixels: u64 = all.iter().map(|r| r.width as u64 * r.height as u64).sum();
+    let roundtrip_ok = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip, RoundtripStatus::Ok))
+        .count();
+    let roundtrip_mismatch = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip, RoundtripStatus::Mismatch))
+        .count();
+    let roundtrip_decode_err = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip, RoundtripStatus::DecodeError))
+        .count();
+
+    eprintln!();
+    eprintln!("=== JB2 encoder quality summary ===");
+    eprintln!("pages:                {}", all.len());
+    eprintln!("roundtrip ok:         {}", roundtrip_ok);
+    eprintln!("roundtrip mismatch:   {}", roundtrip_mismatch);
+    eprintln!(
+        "roundtrip decode err: {}   (issue #198: encoder > 1 MP single-symbol)",
+        roundtrip_decode_err
+    );
+    eprintln!(
+        "total orig size:   {:>10} bytes  ({:.4} bpp)",
+        total_orig,
+        (total_orig as f64 * 8.0) / total_pixels.max(1) as f64
+    );
+    eprintln!(
+        "total rs size:     {:>10} bytes  ({:.4} bpp)",
+        total_rs,
+        (total_rs as f64 * 8.0) / total_pixels.max(1) as f64
+    );
+    eprintln!(
+        "ratio rs / orig:   {:.3}×  (>1 = djvu-rs encoder worse)",
+        total_rs as f64 / total_orig.max(1) as f64
+    );
+
+    if roundtrip_mismatch > 0 {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}

--- a/examples/encode_quality_jb2.rs
+++ b/examples/encode_quality_jb2.rs
@@ -24,7 +24,10 @@
 use std::path::Path;
 use std::process::ExitCode;
 
-use djvu_rs::{DjVuDocument, jb2, jb2_encode::encode_jb2};
+use djvu_rs::{
+    DjVuDocument, jb2,
+    jb2_encode::{encode_jb2, encode_jb2_dict},
+};
 
 #[derive(Copy, Clone, Debug)]
 enum RoundtripStatus {
@@ -52,7 +55,9 @@ struct PageResult {
     height: u32,
     orig_sjbz_bytes: usize,
     rs_sjbz_bytes: usize,
+    rs_dict_sjbz_bytes: usize,
     roundtrip: RoundtripStatus,
+    roundtrip_dict: RoundtripStatus,
 }
 
 fn process_file(path: &Path) -> Vec<PageResult> {
@@ -87,8 +92,19 @@ fn process_file(path: &Path) -> Vec<PageResult> {
         };
 
         let rs_encoded = encode_jb2(&bitmap);
+        let rs_dict_encoded = encode_jb2_dict(&bitmap);
 
         let roundtrip = match jb2::decode(&rs_encoded, None) {
+            Ok(b) => {
+                if b.width == bitmap.width && b.height == bitmap.height && b.data == bitmap.data {
+                    RoundtripStatus::Ok
+                } else {
+                    RoundtripStatus::Mismatch
+                }
+            }
+            Err(_) => RoundtripStatus::DecodeError,
+        };
+        let roundtrip_dict = match jb2::decode(&rs_dict_encoded, None) {
             Ok(b) => {
                 if b.width == bitmap.width && b.height == bitmap.height && b.data == bitmap.data {
                     RoundtripStatus::Ok
@@ -106,7 +122,9 @@ fn process_file(path: &Path) -> Vec<PageResult> {
             height: bitmap.height,
             orig_sjbz_bytes: orig_sjbz.len(),
             rs_sjbz_bytes: rs_encoded.len(),
+            rs_dict_sjbz_bytes: rs_dict_encoded.len(),
             roundtrip,
+            roundtrip_dict,
         });
     }
     out
@@ -140,19 +158,24 @@ fn main() -> ExitCode {
     for r in &all {
         println!(
             "{{\"file\":\"{}\",\"page\":{},\"width\":{},\"height\":{},\
-             \"orig_sjbz_bytes\":{},\"rs_sjbz_bytes\":{},\
-             \"bpp_orig\":{:.4},\"bpp_rs\":{:.4},\
-             \"size_ratio\":{:.3},\"roundtrip\":\"{}\"}}",
+             \"orig_sjbz_bytes\":{},\"rs_sjbz_bytes\":{},\"rs_dict_sjbz_bytes\":{},\
+             \"bpp_orig\":{:.4},\"bpp_rs\":{:.4},\"bpp_rs_dict\":{:.4},\
+             \"size_ratio\":{:.3},\"size_ratio_dict\":{:.3},\
+             \"roundtrip\":\"{}\",\"roundtrip_dict\":\"{}\"}}",
             r.file,
             r.page,
             r.width,
             r.height,
             r.orig_sjbz_bytes,
             r.rs_sjbz_bytes,
+            r.rs_dict_sjbz_bytes,
             bpp(r.orig_sjbz_bytes, r.width, r.height),
             bpp(r.rs_sjbz_bytes, r.width, r.height),
+            bpp(r.rs_dict_sjbz_bytes, r.width, r.height),
             r.rs_sjbz_bytes as f64 / r.orig_sjbz_bytes.max(1) as f64,
+            r.rs_dict_sjbz_bytes as f64 / r.orig_sjbz_bytes.max(1) as f64,
             r.roundtrip.as_str(),
+            r.roundtrip_dict.as_str(),
         );
     }
 
@@ -163,7 +186,9 @@ fn main() -> ExitCode {
 
     let total_orig: usize = all.iter().map(|r| r.orig_sjbz_bytes).sum();
     let total_rs: usize = all.iter().map(|r| r.rs_sjbz_bytes).sum();
+    let total_rs_dict: usize = all.iter().map(|r| r.rs_dict_sjbz_bytes).sum();
     let total_pixels: u64 = all.iter().map(|r| r.width as u64 * r.height as u64).sum();
+
     let roundtrip_ok = all
         .iter()
         .filter(|r| matches!(r.roundtrip, RoundtripStatus::Ok))
@@ -177,31 +202,61 @@ fn main() -> ExitCode {
         .filter(|r| matches!(r.roundtrip, RoundtripStatus::DecodeError))
         .count();
 
+    let roundtrip_dict_ok = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip_dict, RoundtripStatus::Ok))
+        .count();
+    let roundtrip_dict_mismatch = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip_dict, RoundtripStatus::Mismatch))
+        .count();
+    let roundtrip_dict_decode_err = all
+        .iter()
+        .filter(|r| matches!(r.roundtrip_dict, RoundtripStatus::DecodeError))
+        .count();
+
     eprintln!();
     eprintln!("=== JB2 encoder quality summary ===");
-    eprintln!("pages:                {}", all.len());
-    eprintln!("roundtrip ok:         {}", roundtrip_ok);
-    eprintln!("roundtrip mismatch:   {}", roundtrip_mismatch);
+    eprintln!("pages:                  {}", all.len());
+    eprintln!();
+    eprintln!("-- direct (record type 3, whole image) --");
+    eprintln!("roundtrip ok:           {}", roundtrip_ok);
+    eprintln!("roundtrip mismatch:     {}", roundtrip_mismatch);
     eprintln!(
-        "roundtrip decode err: {}   (issue #198: encoder > 1 MP single-symbol)",
+        "roundtrip decode err:   {}   (issue #198: >1 MP single-symbol)",
         roundtrip_decode_err
     );
     eprintln!(
-        "total orig size:   {:>10} bytes  ({:.4} bpp)",
-        total_orig,
-        (total_orig as f64 * 8.0) / total_pixels.max(1) as f64
-    );
-    eprintln!(
-        "total rs size:     {:>10} bytes  ({:.4} bpp)",
+        "total rs size:       {:>10} bytes  ({:.4} bpp)",
         total_rs,
         (total_rs as f64 * 8.0) / total_pixels.max(1) as f64
     );
     eprintln!(
-        "ratio rs / orig:   {:.3}×  (>1 = djvu-rs encoder worse)",
+        "ratio rs / orig:     {:.3}×",
         total_rs as f64 / total_orig.max(1) as f64
     );
+    eprintln!();
+    eprintln!("-- dict (CC + rec types 1+7) --");
+    eprintln!("roundtrip ok:           {}", roundtrip_dict_ok);
+    eprintln!("roundtrip mismatch:     {}", roundtrip_dict_mismatch);
+    eprintln!("roundtrip decode err:   {}", roundtrip_dict_decode_err);
+    eprintln!(
+        "total rs-dict size:  {:>10} bytes  ({:.4} bpp)",
+        total_rs_dict,
+        (total_rs_dict as f64 * 8.0) / total_pixels.max(1) as f64
+    );
+    eprintln!(
+        "ratio rs-dict / orig: {:.3}×  (>1 = djvu-rs encoder worse)",
+        total_rs_dict as f64 / total_orig.max(1) as f64
+    );
+    eprintln!();
+    eprintln!(
+        "total orig size:     {:>10} bytes  ({:.4} bpp)",
+        total_orig,
+        (total_orig as f64 * 8.0) / total_pixels.max(1) as f64
+    );
 
-    if roundtrip_mismatch > 0 {
+    if roundtrip_mismatch > 0 || roundtrip_dict_mismatch > 0 {
         ExitCode::from(1)
     } else {
         ExitCode::SUCCESS

--- a/src/jb2.rs
+++ b/src/jb2.rs
@@ -360,7 +360,11 @@ impl Jbm {
 /// Decodes top-to-bottom using an incremental rolling window that avoids
 /// recomputing all 10 context bits from scratch each pixel.
 const MAX_SYMBOL_PIXELS: usize = 1024 * 1024; // 1 MP per symbol — prevents DoS via huge bitmaps
-const MAX_TOTAL_SYMBOL_PIXELS: usize = 16 * 1024 * 1024; // 16 MP total across all symbols in one stream
+// 64 MP — matches the per-image MAX_PIXELS cap so any valid JB2 stream for a
+// representable image (incl. tiled direct-blit, see jb2_encode::encode_jb2)
+// fits the budget. Was 16 MP, raised in #198 to support naive tiled encoding
+// of full-page bitonal images that have one decoded symbol per tile.
+const MAX_TOTAL_SYMBOL_PIXELS: usize = 64 * 1024 * 1024;
 const MAX_TOTAL_BLIT_PIXELS: usize = 256 * 1024 * 1024; // 256 MP total blit work — prevents type-7 DoS
 const MAX_RECORDS: usize = 65_536; // 64 K records per stream — prevents DoS via record-loop spin on exhausted ZP input
 const MAX_COMMENT_BYTES: usize = 4096; // 4 KiB per comment record — prevents DoS via huge comment length

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -1005,6 +1005,53 @@ mod tests {
         assert_eq!(mismatches, 0);
     }
 
+    /// 1×1 single-pixel image — smallest round-trip case (#198 DoD).
+    #[test]
+    fn tiled_1x1_roundtrip() {
+        for &px in &[false, true] {
+            let src = make_bitmap(1, 1, |_, _| px);
+            let encoded = encode_jb2(&src);
+            let decoded = jb2::decode(&encoded, None).expect("decode failed");
+            assert_eq!(decoded.width, 1);
+            assert_eq!(decoded.height, 1);
+            assert_eq!(decoded.get(0, 0), px, "1x1 pixel mismatch px={px}");
+        }
+    }
+
+    /// 100×100 sub-tile image — single tile, exercise non-trivial geometry (#198 DoD).
+    #[test]
+    fn tiled_100x100_roundtrip() {
+        let src = make_bitmap(100, 100, |x, y| (x ^ y) & 1 == 0);
+        let encoded = encode_jb2(&src);
+        let decoded = jb2::decode(&encoded, None).expect("decode failed");
+        assert_eq!(decoded.width, 100);
+        assert_eq!(decoded.height, 100);
+        for y in 0..100u32 {
+            for x in 0..100u32 {
+                assert_eq!(decoded.get(x, y), src.get(x, y), "mismatch at ({x},{y})");
+            }
+        }
+    }
+
+    /// 4096×4096 = 16 MP forces a 4×4 tile grid (#198 DoD).
+    /// Sparse pattern keeps this test light enough to run in CI.
+    #[test]
+    #[ignore = "16 MP pixel-by-pixel verify is slow; enable with --ignored"]
+    fn tiled_4096x4096_roundtrip() {
+        let src = make_bitmap(4096, 4096, |x, y| {
+            ((x.wrapping_mul(2654435761)) ^ y.wrapping_mul(40503)) & 31 == 0
+        });
+        let encoded = encode_jb2(&src);
+        let decoded = jb2::decode(&encoded, None).expect("decode failed");
+        assert_eq!(decoded.width, 4096);
+        assert_eq!(decoded.height, 4096);
+        for y in 0..4096u32 {
+            for x in 0..4096u32 {
+                assert_eq!(decoded.get(x, y), src.get(x, y), "mismatch at ({x},{y})");
+            }
+        }
+    }
+
     // ── Dict-based encoder (Phase 1: record types 1 + 7) ──────────────────────
 
     fn roundtrip_dict(bm: &Bitmap) -> Bitmap {

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -308,8 +308,15 @@ fn encode_bitmap_ref(zp: &mut ZpEncoder, ctx: &mut [u8], cbm: &Bitmap, mbm: &Bit
 ///
 /// ## Encoding
 ///
-/// The entire image is encoded as a single direct-bitmap record (type 3).
+/// Images with `width * height ≤ 1 MP` are emitted as a single direct-bitmap
+/// record (type 3). Larger images are split into ≤ 1024×1024 tiles, each
+/// emitted as its own record-3 — this keeps every symbol within the decoder's
+/// `MAX_SYMBOL_PIXELS = 1 MP` DoS guard so the output round-trips through
+/// [`crate::jb2::decode`] for any size up to `MAX_PIXELS = 64 MP`.
+///
 /// No connected-component analysis or symbol dictionary is used.
+/// For substantially better compression on text-heavy bitmaps see
+/// [`encode_jb2_dict`].
 pub fn encode_jb2(bitmap: &Bitmap) -> Vec<u8> {
     let w = bitmap.width as i32;
     let h = bitmap.height as i32;
@@ -341,32 +348,80 @@ pub fn encode_jb2(bitmap: &Bitmap) -> Vec<u8> {
     // Reserved flag bit — must be 0.
     zp.encode_bit(&mut flag_ctx, false);
 
-    // ── Single direct-bitmap record ────────────────────────────────────────
-    // Record type 3: new symbol, direct, blit to page, NOT stored in dict.
-    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 3);
-
-    // Symbol dimensions.
-    encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, w);
-    encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, h);
-
-    // Bitmap data.
-    encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, bitmap);
-
-    // Coordinates: new_line=true, hoff=1, voff=0.
+    // ── Direct-bitmap records, tiled to stay under MAX_SYMBOL_PIXELS ───────
     //
-    // Decoder initial state: first_left=-1, first_bottom=image_height-1.
-    // new_line=true:
-    //   x = first_left + hoff = -1 + 1 = 0
-    //   y = first_bottom + voff - h + 1 = (image_height-1) + 0 - h + 1 = 0
-    // So the symbol lands at (0, 0) — bottom-left of the JB2 page. ✓
-    zp.encode_bit(&mut offset_type_ctx, true); // new_line = true
-    encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, 1);
-    encode_num(&mut zp, &mut voff_ctx, -262143, 262142, 0);
+    // Tile size: 1024 — equal to the decoder's MAX_SYMBOL_PIXELS = 1024*1024,
+    // and the per-symbol check is `pixels > MAX`, so tile_w*tile_h ≤ 1 MP is
+    // accepted. Layout state mirrors the decoder (jb2.rs:LayoutState):
+    //   first_left = -1, first_bottom = image_height - 1.
+    //
+    // JB2 stream coords are y-flipped relative to image coords: blit_to_bitmap
+    // uses bm_y = (image_height - 1 - jb2_y) - sym_row. For a tile of height
+    // th to land with its top row at image_y = ty (top-down convention), the
+    // required JB2 stream coord is jb2_y = h - th - ty. With new_line=true:
+    //   nx = first_left + hoff          → hoff = tx - first_left
+    //   ny = first_bottom + voff - th+1 → voff = (h - th - ty) + th - 1 - first_bottom
+    //                                          = h - 1 - ty - first_bottom
+    // After emit: first_left = nx, first_bottom = ny.
+    const TILE: u32 = 1024;
+    let mut first_left: i32 = -1;
+    let mut first_bottom: i32 = h - 1;
+
+    let mut ty: u32 = 0;
+    while ty < bitmap.height {
+        let th = TILE.min(bitmap.height - ty);
+        let mut tx: u32 = 0;
+        while tx < bitmap.width {
+            let tw = TILE.min(bitmap.width - tx);
+
+            // Record type 3: new symbol, direct, blit to page, NOT stored in dict.
+            encode_num(&mut zp, &mut record_type_ctx, 0, 11, 3);
+
+            // Symbol dimensions.
+            encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, tw as i32);
+            encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, th as i32);
+
+            // Bitmap data — crop tile from source.
+            let tile_bm = if tw == bitmap.width && th == bitmap.height {
+                // Single-tile fast path: avoid the crop allocation.
+                bitmap.clone()
+            } else {
+                crop_bitmap(bitmap, tx, ty, tw, th)
+            };
+            encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, &tile_bm);
+
+            // Coordinates: new_line=true, hoff/voff target (tx, ty).
+            let hoff = tx as i32 - first_left;
+            let voff = h - 1 - ty as i32 - first_bottom;
+            zp.encode_bit(&mut offset_type_ctx, true);
+            encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
+            encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
+
+            first_left = tx as i32;
+            first_bottom = h - th as i32 - ty as i32;
+
+            tx += tw;
+        }
+        ty += th;
+    }
 
     // ── End-of-data ────────────────────────────────────────────────────────
     encode_num(&mut zp, &mut record_type_ctx, 0, 11, 11);
 
     zp.finish()
+}
+
+/// Crop a tight sub-rectangle out of a bilevel bitmap.
+fn crop_bitmap(src: &Bitmap, x0: u32, y0: u32, w: u32, h: u32) -> Bitmap {
+    let mut out = Bitmap::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            if src.get(x0 + x, y0 + y) {
+                out.set_black(x, y);
+            }
+        }
+    }
+    out
 }
 
 // ── Connected-component extraction (symbol-dict encoding) ─────────────────────
@@ -909,6 +964,45 @@ mod tests {
         assert!(encode_jb2(&Bitmap::new(0, 0)).is_empty());
         assert!(encode_jb2(&Bitmap::new(8, 0)).is_empty());
         assert!(encode_jb2(&Bitmap::new(0, 8)).is_empty());
+    }
+
+    /// Round-trip across the 1 MP tile boundary (#198).
+    /// 2048×2048 = 4 MP forces a 2×2 tile grid (each tile 1024×1024 = 1 MP).
+    #[test]
+    fn tiled_2048x2048_roundtrip() {
+        let src = make_bitmap(2048, 2048, |x, y| {
+            // Pseudo-random pattern that stresses each tile differently.
+            ((x.wrapping_mul(2654435761)) ^ y.wrapping_mul(40503)) & 7 == 0
+        });
+        let encoded = encode_jb2(&src);
+        let decoded = jb2::decode(&encoded, None).expect("decode failed");
+        assert_eq!(decoded.width, 2048);
+        assert_eq!(decoded.height, 2048);
+        for y in 0..2048u32 {
+            for x in 0..2048u32 {
+                assert_eq!(decoded.get(x, y), src.get(x, y), "mismatch at ({x},{y})");
+            }
+        }
+    }
+
+    /// Tile boundary not on a power-of-two stride — checks edge tiles smaller
+    /// than 1024 in either axis (#198).
+    #[test]
+    fn tiled_irregular_size_roundtrip() {
+        let src = make_bitmap(1500, 1100, |x, y| (x * 13 + y * 7) % 11 == 0);
+        let encoded = encode_jb2(&src);
+        let decoded = jb2::decode(&encoded, None).expect("decode failed");
+        assert_eq!(decoded.width, 1500);
+        assert_eq!(decoded.height, 1100);
+        let mut mismatches = 0u32;
+        for y in 0..1100u32 {
+            for x in 0..1500u32 {
+                if decoded.get(x, y) != src.get(x, y) {
+                    mismatches += 1;
+                }
+            }
+        }
+        assert_eq!(mismatches, 0);
     }
 
     // ── Dict-based encoder (Phase 1: record types 1 + 7) ──────────────────────

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -221,6 +221,84 @@ fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
     }
 }
 
+// ── Refinement bitmap encoding (11-bit context) ──────────────────────────────
+
+/// Encode `cbm` relative to a reference (matched) bitmap `mbm` using the
+/// refinement 11-pixel context.
+///
+/// Mirrors `decode_bitmap_ref` in `jb2.rs`. Center alignment is used per
+/// the DjVu spec: the reference bitmap is anchored at the centre of the
+/// child.
+///
+/// Both bitmaps are in [`Bitmap`] top-down storage (y=0 = top of image).
+/// The decoder's bottom-up Jbm traversal corresponds to top-down image
+/// processing, so we iterate `y in 0..ch`. Context rows are then:
+///   * c_r1 = the row just above current in image  (Y - 1 in Bitmap storage)
+///   * m_r1 = mbm row at the same image height as the current cbm row
+///   * m_r0 = mbm row one below current in image    (m_r1's Bitmap Y + 1)
+///   * m_r2 = mbm row one above current in image    (m_r1's Bitmap Y - 1)
+///
+/// `row_offset = mrow - crow` is the centre-alignment shift expressed in
+/// Bitmap (top-down) row indices.
+fn encode_bitmap_ref(zp: &mut ZpEncoder, ctx: &mut [u8], cbm: &Bitmap, mbm: &Bitmap) {
+    debug_assert_eq!(ctx.len(), 2048);
+    let cw = cbm.width as i32;
+    let ch = cbm.height as i32;
+    if cw <= 0 || ch <= 0 {
+        return;
+    }
+    let mw = mbm.width as i32;
+    let mh = mbm.height as i32;
+
+    let crow = (ch - 1) >> 1;
+    let ccol = (cw - 1) >> 1;
+    let mrow = (mh - 1) >> 1;
+    let mcol = (mw - 1) >> 1;
+    let row_offset = mrow - crow;
+    let col_shift = mcol - ccol;
+
+    let mbm_pixel = |y: i32, x: i32| -> u32 {
+        if y < 0 || y >= mh || x < 0 || x >= mw {
+            0
+        } else {
+            mbm.get(x as u32, y as u32) as u32
+        }
+    };
+    let cbm_pixel = |y: i32, x: i32| -> u32 {
+        if y < 0 || y >= ch || x < 0 || x >= cw {
+            0
+        } else {
+            cbm.get(x as u32, y as u32) as u32
+        }
+    };
+
+    for y in 0..ch {
+        let my = y + row_offset; // mbm row at same image height as cbm row y
+
+        // Initialise rolling windows at col=0 (col-1 / col-2 OOB → 0).
+        let mut c_r1 = (cbm_pixel(y - 1, 0) << 1) | cbm_pixel(y - 1, 1);
+        let mut c_r0: u32 = 0;
+        let mut m_r1 = (mbm_pixel(my, col_shift - 1) << 2)
+            | (mbm_pixel(my, col_shift) << 1)
+            | mbm_pixel(my, col_shift + 1);
+        let mut m_r0 = (mbm_pixel(my + 1, col_shift - 1) << 2)
+            | (mbm_pixel(my + 1, col_shift) << 1)
+            | mbm_pixel(my + 1, col_shift + 1);
+
+        for col in 0..cw {
+            let m_r2 = mbm_pixel(my - 1, col + col_shift);
+            let idx = ((c_r1 << 8) | (c_r0 << 7) | (m_r2 << 6) | (m_r1 << 3) | m_r0) & 2047;
+            let bit = cbm_pixel(y, col) != 0;
+            zp.encode_bit(&mut ctx[idx as usize], bit);
+
+            c_r1 = ((c_r1 << 1) & 0b111) | cbm_pixel(y - 1, col + 2);
+            c_r0 = bit as u32;
+            m_r1 = ((m_r1 << 1) & 0b111) | mbm_pixel(my, col + col_shift + 2);
+            m_r0 = ((m_r0 << 1) & 0b111) | mbm_pixel(my + 1, col + col_shift + 2);
+        }
+    }
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────────
 
 /// Encode a bilevel [`Bitmap`] into a JB2 stream (Sjbz chunk payload).
@@ -394,20 +472,87 @@ fn extract_ccs(bitmap: &Bitmap) -> Vec<Cc> {
     out
 }
 
-// ── Dict-based encoding: record types 1 (new) + 7 (matched copy) ──────────────
+// ── Dict-based encoding: record types 1 (new) + 6 (refinement) + 7 (copy) ────
+
+/// Hamming distance between two equal-sized packed bitmap byte buffers.
+fn packed_hamming(a: &[u8], b: &[u8]) -> u32 {
+    debug_assert_eq!(a.len(), b.len());
+    let mut total: u32 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        total += (x ^ y).count_ones();
+    }
+    total
+}
+
+/// Phase 3 refinement-match threshold (percent of pixels).
+///
+/// A candidate dict entry of the same (w, h) qualifies as a refinement
+/// reference when its Hamming distance to the new CC is at most this
+/// fraction of total pixels. Calibrated against `tests/corpus/*.djvu`:
+/// values above ~4% start producing record-6 emissions whose refinement
+/// bitmap costs more bits than a fresh record-1 on noisy / halftone CCs,
+/// regressing total size on dense scanned pages.
+const REFINEMENT_DIFF_FRACTION: u32 = 4;
+
+/// Minimum pixel area for a CC to be considered for refinement matching.
+///
+/// Sub-32-pixel CCs (typical: dust, single anti-aliasing fragments) encode
+/// in only a handful of bytes via record-1; the per-record overhead of a
+/// record-6 (matched-refinement coordinate header + 11-bit refinement
+/// context state) outweighs any saving even at low Hamming distance.
+const REFINEMENT_MIN_PIXELS: u64 = 32;
+
+/// Find the best refinement-reference dict index for `cand` among
+/// dict entries of identical (w, h). Returns `None` if no candidate is
+/// close enough to be worth a record-6 emission.
+fn find_refinement_ref(
+    cand: &Bitmap,
+    dict_entries: &[Bitmap],
+    same_size_indices: &[usize],
+) -> Option<usize> {
+    if same_size_indices.is_empty() {
+        return None;
+    }
+    let pixel_count = (cand.width as u64) * (cand.height as u64);
+    if pixel_count < REFINEMENT_MIN_PIXELS {
+        return None;
+    }
+    let max_diff = ((pixel_count * REFINEMENT_DIFF_FRACTION as u64) / 100) as u32;
+
+    let mut best: Option<(usize, u32)> = None;
+    for &i in same_size_indices {
+        let ref_bm = &dict_entries[i];
+        debug_assert_eq!(ref_bm.width, cand.width);
+        debug_assert_eq!(ref_bm.height, cand.height);
+        let d = packed_hamming(&cand.data, &ref_bm.data);
+        if d > max_diff {
+            continue;
+        }
+        match best {
+            None => best = Some((i, d)),
+            Some((_, bd)) if d < bd => best = Some((i, d)),
+            _ => {}
+        }
+    }
+    best.map(|(i, _)| i)
+}
 
 /// Encode a bilevel [`Bitmap`] into a JB2 stream using a **symbol dictionary**.
 ///
 /// Performs connected-component (CC) extraction, exact-match deduplication,
-/// and emits record type 1 for each unique CC (new symbol, direct, stored in
-/// dict + blitted) and record type 7 for each repeat (matched copy, blit only).
+/// near-duplicate refinement matching, and emits one of:
+///  * record type 1 — new symbol (direct, stored in dict + blitted)
+///  * record type 6 — matched refinement (blit only, encodes diff vs an
+///    existing dict entry of identical size using the 11-bit context)
+///  * record type 7 — matched copy (no refinement, blit only)
 ///
 /// Lossless. Matches [`crate::jb2::decode`] for round-trip.
 ///
-/// ## Limitations (Phase 1)
-/// - Exact-match only — no near-duplicate matching or lossy refinement.
-/// - Coordinate coding uses `new_line = true` for every symbol (wastes space
-///   compared to baseline-relative same-line coding; optimized in a later phase).
+/// ## Limitations
+/// - Refinement matching only considers dict entries of identical (w, h).
+///   Cross-size matching (which the format permits via wdiff/hdiff) needs
+///   per-pixel resampling to compute the Hamming distance and is left to
+///   a future phase.
 /// - Components >= 1 MP are encoded as-is; the decoder will reject them via
 ///   `MAX_SYMBOL_PIXELS`. For scanned text pages this is not a practical issue.
 pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
@@ -444,12 +589,15 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     let mut image_size_ctx = NumContext::new();
     let mut symbol_width_ctx = NumContext::new();
     let mut symbol_height_ctx = NumContext::new();
+    let mut symbol_width_diff_ctx = NumContext::new();
+    let mut symbol_height_diff_ctx = NumContext::new();
     let mut symbol_index_ctx = NumContext::new();
     let mut hoff_ctx = NumContext::new();
     let mut voff_ctx = NumContext::new();
     let mut shoff_ctx = NumContext::new();
     let mut svoff_ctx = NumContext::new();
     let mut direct_bitmap_ctx = vec![0u8; 1024];
+    let mut refinement_bitmap_ctx = vec![0u8; 2048];
     let mut offset_type_ctx: u8 = 0;
     let mut flag_ctx: u8 = 0;
 
@@ -462,9 +610,14 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     // Layout state — mirrors `LayoutState::new` in jb2.rs:1187.
     let mut layout = EncoderLayout::new(h);
 
-    // Dedup: (w, h, packed-data) → dict index assigned on first emission.
+    // Exact-match dedup: (w, h, packed-data) → dict index.
     let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
-    let mut dict_size: usize = 0;
+    // Stored dict entries (parallel to the decoder's `dict` vector) — needed
+    // so refinement matching can score Hamming distance against historical
+    // glyphs.
+    let mut dict_entries: Vec<Bitmap> = Vec::new();
+    // Index of dict entries by (w, h) for O(1) lookup of refinement candidates.
+    let mut by_size: BTreeMap<(u32, u32), Vec<usize>> = BTreeMap::new();
 
     for &cc_idx in &order {
         let cc = &ccs[cc_idx];
@@ -475,24 +628,65 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
         let y_jb2 = h - cc.y as i32 - cc_h;
 
         let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
-        let dict_action = dedup.get(&key).copied();
+        let exact_match = dedup.get(&key).copied();
 
-        // Record header (shared between types 1 and 7).
-        match dict_action {
-            None => {
+        // Choose record type:
+        //   exact match → 7  (matched copy, blit only)
+        //   near match  → 6  (matched refinement, blit only)
+        //   otherwise   → 1  (new symbol, direct, add to dict + blit)
+        enum Action {
+            New,
+            Copy(usize),
+            Refine(usize),
+        }
+        let action = if let Some(idx) = exact_match {
+            Action::Copy(idx)
+        } else {
+            let candidates = by_size
+                .get(&(cc.bitmap.width, cc.bitmap.height))
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            match find_refinement_ref(&cc.bitmap, &dict_entries, candidates) {
+                Some(ref_idx) => Action::Refine(ref_idx),
+                None => Action::New,
+            }
+        };
+
+        let dict_size = dict_entries.len();
+        match &action {
+            Action::New => {
                 encode_num(&mut zp, &mut record_type_ctx, 0, 11, 1);
                 encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, cc_w);
                 encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, cc_h);
                 encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, &cc.bitmap);
             }
-            Some(dict_idx) => {
+            Action::Copy(dict_idx) => {
                 encode_num(&mut zp, &mut record_type_ctx, 0, 11, 7);
                 encode_num(
                     &mut zp,
                     &mut symbol_index_ctx,
                     0,
                     (dict_size - 1) as i32,
-                    dict_idx as i32,
+                    *dict_idx as i32,
+                );
+            }
+            Action::Refine(ref_idx) => {
+                encode_num(&mut zp, &mut record_type_ctx, 0, 11, 6);
+                encode_num(
+                    &mut zp,
+                    &mut symbol_index_ctx,
+                    0,
+                    (dict_size - 1) as i32,
+                    *ref_idx as i32,
+                );
+                // Same-size refinement: width/height diffs are zero.
+                encode_num(&mut zp, &mut symbol_width_diff_ctx, -262143, 262142, 0);
+                encode_num(&mut zp, &mut symbol_height_diff_ctx, -262143, 262142, 0);
+                encode_bitmap_ref(
+                    &mut zp,
+                    &mut refinement_bitmap_ctx,
+                    &cc.bitmap,
+                    &dict_entries[*ref_idx],
                 );
             }
         }
@@ -540,9 +734,16 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
             layout.same_line_seen = true;
         }
 
-        if dict_action.is_none() {
-            dedup.insert(key, dict_size);
-            dict_size += 1;
+        // Only record-type-1 (new symbol) extends the dict — types 6 and 7
+        // are blit-only and the decoder leaves the dict untouched.
+        if matches!(action, Action::New) {
+            let next_idx = dict_entries.len();
+            dedup.insert(key, next_idx);
+            by_size
+                .entry((cc.bitmap.width, cc.bitmap.height))
+                .or_default()
+                .push(next_idx);
+            dict_entries.push(cc.bitmap.clone());
         }
     }
 
@@ -720,15 +921,20 @@ mod tests {
     fn assert_bitmaps_eq(a: &Bitmap, b: &Bitmap) {
         assert_eq!(a.width, b.width, "width mismatch");
         assert_eq!(a.height, b.height, "height mismatch");
-        let mut mismatches = 0u32;
+        let mut mismatches = Vec::new();
         for y in 0..a.height {
             for x in 0..a.width {
                 if a.get(x, y) != b.get(x, y) {
-                    mismatches += 1;
+                    mismatches.push((x, y, a.get(x, y), b.get(x, y)));
                 }
             }
         }
-        assert_eq!(mismatches, 0, "{mismatches} pixel mismatches");
+        assert!(
+            mismatches.is_empty(),
+            "{} pixel mismatches: {:?}",
+            mismatches.len(),
+            mismatches
+        );
     }
 
     #[test]
@@ -839,5 +1045,80 @@ mod tests {
         assert_eq!(ccs.len(), 1);
         assert_eq!(ccs[0].bitmap.width, 2);
         assert_eq!(ccs[0].bitmap.height, 2);
+    }
+
+    // ── Refinement matching (Phase 3 of #188): record type 6 ─────────────────
+
+    #[test]
+    fn refine_near_duplicate_glyphs_roundtrip() {
+        // Two glyph-like shapes with the same bounding box and a 1-pixel diff
+        // — well within REFINEMENT_DIFF_FRACTION (10%). The encoder should
+        // emit record-1 for the first and record-6 for the second; the
+        // decoder must reconstruct each shape exactly at its own location.
+        //
+        // Shape A: solid 5×5 block.
+        // Shape B: same 5×5 block with one pixel flipped (4% diff).
+        let src = make_bitmap(40, 12, |x, y| {
+            // CC1 at (2, 2)..(7, 7): solid 5×5
+            let in_a = (2..7).contains(&x) && (2..7).contains(&y);
+            // CC2 at (20, 2)..(25, 7): solid 5×5 with (24, 6) flipped to white
+            let in_b = (20..25).contains(&x) && (2..7).contains(&y) && !(x == 24 && y == 6);
+            in_a || in_b
+        });
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn refine_text_like_repeats_roundtrip() {
+        // Six 7×9 "letters" — a plus sign and small variants — laid out in a
+        // single row. Same size, low Hamming distance, so the encoder should
+        // pick refinement encoding for the variants.
+        let src = make_bitmap(80, 12, |x, y| {
+            let local_x = x % 12;
+            let local_y = y;
+            let glyph_idx = x / 12;
+            // Base glyph: a plus sign in a 7×9 box.
+            let base = (local_x == 3 && (1..8).contains(&local_y))
+                || (local_y == 4 && (1..7).contains(&local_x));
+            // Each repeat flips one different pixel (introducing a tiny diff).
+            let perturbed = match glyph_idx {
+                1 => local_x == 0 && local_y == 0,
+                2 => local_x == 6 && local_y == 8,
+                3 => local_x == 6 && local_y == 0,
+                4 => local_x == 0 && local_y == 8,
+                _ => false,
+            };
+            base ^ perturbed
+        });
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn refine_far_glyph_falls_back_to_new() {
+        // A 5×5 block followed by an unrelated 5×5 X-pattern — Hamming
+        // distance ≫ 10%, so refinement matching should *not* fire and the
+        // encoder should emit two record-1 entries. Output must still
+        // round-trip exactly.
+        let src = make_bitmap(40, 12, |x, y| {
+            let in_block = (2..7).contains(&x) && (2..7).contains(&y);
+            let in_x = (20..25).contains(&x)
+                && (2..7).contains(&y)
+                && (x - 20 == y - 2 || x - 20 == 6 - (y - 2));
+            in_block || in_x
+        });
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn refine_packed_hamming_basic() {
+        let a = vec![0b1010_1010u8, 0b0000_1111u8];
+        let b = vec![0b1010_1011u8, 0b0000_1111u8];
+        assert_eq!(packed_hamming(&a, &b), 1);
+        let c = vec![0u8; 2];
+        let d = vec![0xff; 2];
+        assert_eq!(packed_hamming(&c, &d), 16);
     }
 }

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -419,9 +419,25 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
 
     let ccs = extract_ccs(bitmap);
 
-    // Reading-order sort: top-to-bottom, then left-to-right.
+    // Reading-order sort by baseline-bucket, then left-to-right.
+    //
+    // The JB2 coord stream's `same_line` mode is keyed off `y_jb2` (the bottom
+    // edge of each symbol in JB2 bottom-up coords). Glyphs sharing a text
+    // baseline have similar `y_jb2` values regardless of height (e.g. 't' vs
+    // 'o'), but they differ in top-left `cc.y`. Sorting by `cc.y` therefore
+    // interleaves glyphs from adjacent lines, defeating same-line coding.
+    //
+    // Bucketing by bottom-row in top-down coords (`cc.y + cc_h`), rounded to a
+    // line-height grid, then by `x` within a bucket, gives proper reading order
+    // for same-line detection. The bucket granularity is the same baseline
+    // tolerance used in the same/new-line decision below.
     let mut order: Vec<usize> = (0..ccs.len()).collect();
-    order.sort_by_key(|&i| (ccs[i].y, ccs[i].x));
+    let bucket = (SAME_LINE_BASELINE_TOL.max(1)) as u32;
+    order.sort_by_key(|&i| {
+        let cc = &ccs[i];
+        let bottom = cc.y + cc.bitmap.height;
+        (bottom / bucket, cc.x)
+    });
 
     let mut zp = ZpEncoder::new();
     let mut record_type_ctx = NumContext::new();
@@ -431,6 +447,8 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     let mut symbol_index_ctx = NumContext::new();
     let mut hoff_ctx = NumContext::new();
     let mut voff_ctx = NumContext::new();
+    let mut shoff_ctx = NumContext::new();
+    let mut svoff_ctx = NumContext::new();
     let mut direct_bitmap_ctx = vec![0u8; 1024];
     let mut offset_type_ctx: u8 = 0;
     let mut flag_ctx: u8 = 0;
@@ -441,9 +459,8 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     encode_num(&mut zp, &mut image_size_ctx, 0, 262142, h);
     zp.encode_bit(&mut flag_ctx, false);
 
-    // Layout state — mirrors `LayoutState::new`.
-    let mut first_left: i32 = -1;
-    let mut first_bottom: i32 = h - 1;
+    // Layout state — mirrors `LayoutState::new` in jb2.rs:1187.
+    let mut layout = EncoderLayout::new(h);
 
     // Dedup: (w, h, packed-data) → dict index assigned on first emission.
     let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
@@ -454,32 +471,21 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
         let cc_w = cc.bitmap.width as i32;
         let cc_h = cc.bitmap.height as i32;
         // JB2 uses bottom-up y: y_jb2 is the bottom y of the symbol.
-        // Top-down bottom = cc.y + cc_h - 1; JB2 y = (h - 1) - (cc.y + cc_h - 1).
         let x_jb2 = cc.x as i32;
         let y_jb2 = h - cc.y as i32 - cc_h;
 
         let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
-        match dedup.get(&key).copied() {
+        let dict_action = dedup.get(&key).copied();
+
+        // Record header (shared between types 1 and 7).
+        match dict_action {
             None => {
-                // Type 1 — new symbol, direct decode, add to dict AND blit.
                 encode_num(&mut zp, &mut record_type_ctx, 0, 11, 1);
                 encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, cc_w);
                 encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, cc_h);
                 encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, &cc.bitmap);
-
-                zp.encode_bit(&mut offset_type_ctx, true); // new_line
-                let hoff = x_jb2 - first_left;
-                let voff = y_jb2 + cc_h - 1 - first_bottom;
-                encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
-                encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
-                first_left = x_jb2;
-                first_bottom = y_jb2;
-
-                dedup.insert(key, dict_size);
-                dict_size += 1;
             }
             Some(dict_idx) => {
-                // Type 7 — matched copy, no refinement, blit only.
                 encode_num(&mut zp, &mut record_type_ctx, 0, 11, 7);
                 encode_num(
                     &mut zp,
@@ -488,20 +494,118 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
                     (dict_size - 1) as i32,
                     dict_idx as i32,
                 );
-
-                zp.encode_bit(&mut offset_type_ctx, true); // new_line
-                let hoff = x_jb2 - first_left;
-                let voff = y_jb2 + cc_h - 1 - first_bottom;
-                encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
-                encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
-                first_left = x_jb2;
-                first_bottom = y_jb2;
             }
+        }
+
+        // ── Coordinate coding (Phase 2: same-line vs new_line) ────────────
+        //
+        // Decide whether the symbol fits the running baseline / line:
+        //   * shoff = x_jb2 - last_right     (small, often 0..16 for a font)
+        //   * svoff = y_jb2 - baseline_value (small, near 0 if same line)
+        //
+        // If both are within typical text-line tolerances we encode with
+        // offset_type=false (same-line); else fall back to offset_type=true
+        // (new_line), exactly mirroring what the decoder does in
+        // jb2.rs::decode_symbol_coords.
+        let shoff = x_jb2 - layout.last_right;
+        let svoff = y_jb2 - layout.baseline_get();
+        let same_line = layout.same_line_seen
+            && svoff.abs() <= SAME_LINE_BASELINE_TOL
+            && (-SAME_LINE_OVERLAP_TOL..=SAME_LINE_GAP_MAX).contains(&shoff);
+
+        if same_line {
+            zp.encode_bit(&mut offset_type_ctx, false);
+            encode_num(&mut zp, &mut shoff_ctx, -262143, 262142, shoff);
+            encode_num(&mut zp, &mut svoff_ctx, -262143, 262142, svoff);
+            // Decoder: x = last_right + shoff, y = baseline + svoff.
+            let nx = layout.last_right + shoff;
+            let ny = layout.baseline_get() + svoff;
+            layout.baseline_add(ny);
+            layout.last_right = nx + cc_w - 1;
+        } else {
+            zp.encode_bit(&mut offset_type_ctx, true);
+            let hoff = x_jb2 - layout.first_left;
+            let voff = y_jb2 + cc_h - 1 - layout.first_bottom;
+            encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
+            encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
+            // Decoder: nx = first_left+hoff, ny = first_bottom+voff-h+1, then
+            // first_left = nx, first_bottom = ny, baseline.fill(ny).
+            let nx = layout.first_left + hoff;
+            let ny = layout.first_bottom + voff - cc_h + 1;
+            layout.first_left = nx;
+            layout.first_bottom = ny;
+            layout.baseline_fill(ny);
+            layout.baseline_add(ny);
+            layout.last_right = nx + cc_w - 1;
+            layout.same_line_seen = true;
+        }
+
+        if dict_action.is_none() {
+            dedup.insert(key, dict_size);
+            dict_size += 1;
         }
     }
 
     encode_num(&mut zp, &mut record_type_ctx, 0, 11, 11);
     zp.finish()
+}
+
+/// Same-line tolerances (Phase 2 of #188) used to decide between new_line
+/// and same-line coordinate coding. Values are in image pixels and chosen
+/// to cover normal text glyph variation while still treating a real line
+/// break as a new_line. Looser thresholds reduce shoff/svoff magnitudes
+/// at the cost of forcing same-line coding when the receiver would have
+/// preferred a fresh baseline; tighter thresholds do the opposite.
+const SAME_LINE_BASELINE_TOL: i32 = 16;
+const SAME_LINE_OVERLAP_TOL: i32 = 16;
+const SAME_LINE_GAP_MAX: i32 = 1000;
+
+/// Mirror of jb2::LayoutState held encoder-side.
+struct EncoderLayout {
+    first_left: i32,
+    first_bottom: i32,
+    last_right: i32,
+    baseline: [i32; 3],
+    baseline_idx: i32,
+    /// `false` until the first symbol has been emitted — same-line coding
+    /// is invalid before then because there is no "previous" baseline.
+    same_line_seen: bool,
+}
+
+impl EncoderLayout {
+    fn new(image_height: i32) -> Self {
+        Self {
+            first_left: -1,
+            first_bottom: image_height - 1,
+            last_right: 0,
+            baseline: [0, 0, 0],
+            baseline_idx: -1,
+            same_line_seen: false,
+        }
+    }
+
+    fn baseline_fill(&mut self, val: i32) {
+        self.baseline = [val, val, val];
+    }
+
+    fn baseline_add(&mut self, val: i32) {
+        self.baseline_idx += 1;
+        if self.baseline_idx == 3 {
+            self.baseline_idx = 0;
+        }
+        self.baseline[self.baseline_idx as usize] = val;
+    }
+
+    fn baseline_get(&self) -> i32 {
+        let (a, b, c) = (self.baseline[0], self.baseline[1], self.baseline[2]);
+        if (a >= b && a <= c) || (a <= b && a >= c) {
+            a
+        } else if (b >= a && b <= c) || (b <= a && b >= c) {
+            b
+        } else {
+            c
+        }
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -611,6 +611,25 @@ fn find_refinement_ref(
 /// - Components >= 1 MP are encoded as-is; the decoder will reject them via
 ///   `MAX_SYMBOL_PIXELS`. For scanned text pages this is not a practical issue.
 pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
+    encode_jb2_dict_with_shared(bitmap, &[])
+}
+
+/// Encode a bilevel [`Bitmap`] into a JB2 stream that inherits its initial
+/// symbol library from a previously-encoded shared dictionary (Djbz).
+///
+/// Same as [`encode_jb2_dict`] but emits a "required-dict-or-reset"
+/// (record type 9) preamble announcing `shared_symbols.len()` inherited
+/// entries. Per-symbol matches that hit any of the shared symbols are
+/// emitted as record-7 (matched copy) referencing the shared index, so
+/// the per-page Sjbz never re-transmits glyphs already present in the
+/// shared Djbz.
+///
+/// `shared_symbols` must be the **identical bitmap sequence** the matching
+/// Djbz was built from (see [`encode_jb2_djbz`]).
+///
+/// Round-trip: pass the resulting Sjbz bytes plus
+/// `decode_dict(djbz_bytes, None)` to [`crate::jb2::decode`].
+pub fn encode_jb2_dict_with_shared(bitmap: &Bitmap, shared_symbols: &[Bitmap]) -> Vec<u8> {
     let w = bitmap.width as i32;
     let h = bitmap.height as i32;
     if w == 0 || h == 0 {
@@ -647,6 +666,7 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     let mut symbol_width_diff_ctx = NumContext::new();
     let mut symbol_height_diff_ctx = NumContext::new();
     let mut symbol_index_ctx = NumContext::new();
+    let mut inherit_dict_size_ctx = NumContext::new();
     let mut hoff_ctx = NumContext::new();
     let mut voff_ctx = NumContext::new();
     let mut shoff_ctx = NumContext::new();
@@ -657,6 +677,18 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     let mut flag_ctx: u8 = 0;
 
     // Preamble.
+    if !shared_symbols.is_empty() {
+        // Required-dict-or-reset: announce the inherited library size before
+        // start-of-image so the decoder pre-populates `dict` from `shared_dict`.
+        encode_num(&mut zp, &mut record_type_ctx, 0, 11, 9);
+        encode_num(
+            &mut zp,
+            &mut inherit_dict_size_ctx,
+            0,
+            262142,
+            shared_symbols.len() as i32,
+        );
+    }
     encode_num(&mut zp, &mut record_type_ctx, 0, 11, 0);
     encode_num(&mut zp, &mut image_size_ctx, 0, 262142, w);
     encode_num(&mut zp, &mut image_size_ctx, 0, 262142, h);
@@ -665,7 +697,9 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     // Layout state — mirrors `LayoutState::new` in jb2.rs:1187.
     let mut layout = EncoderLayout::new(h);
 
-    // Exact-match dedup: (w, h, packed-data) → dict index.
+    // Exact-match dedup: (w, h, packed-data) → dict index. Pre-populated from
+    // shared_symbols so cross-page identical glyphs encode as rec-7 (copy)
+    // referencing the shared library.
     let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
     // Stored dict entries (parallel to the decoder's `dict` vector) — needed
     // so refinement matching can score Hamming distance against historical
@@ -673,6 +707,15 @@ pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
     let mut dict_entries: Vec<Bitmap> = Vec::new();
     // Index of dict entries by (w, h) for O(1) lookup of refinement candidates.
     let mut by_size: BTreeMap<(u32, u32), Vec<usize>> = BTreeMap::new();
+    for sym in shared_symbols {
+        let idx = dict_entries.len();
+        dedup.insert((sym.width, sym.height, sym.data.clone()), idx);
+        by_size
+            .entry((sym.width, sym.height))
+            .or_default()
+            .push(idx);
+        dict_entries.push(sym.clone());
+    }
 
     for &cc_idx in &order {
         let cc = &ccs[cc_idx];
@@ -862,6 +905,281 @@ impl EncoderLayout {
             c
         }
     }
+}
+
+// ── Djbz dictionary stream + multi-page sharing (#194) ─────────────────────────
+
+/// Encode a sequence of bilevel symbols as a JB2 **Djbz** chunk payload.
+///
+/// Each symbol is emitted as record-type-2 (new symbol, direct, dict-only) in
+/// the order given. The decoder side ([`crate::jb2::decode_dict`]) reconstructs
+/// a [`crate::jb2::Jb2Dict`] whose symbol indices match this input order, so
+/// downstream Sjbz streams encoded with [`encode_jb2_dict_with_shared`] using
+/// the same `&[Bitmap]` reference will round-trip cleanly.
+///
+/// The Djbz contains no positioning information — symbols are abstract
+/// glyph bitmaps, not blits. The page Sjbz alone places them.
+pub fn encode_jb2_djbz(symbols: &[Bitmap]) -> Vec<u8> {
+    let mut zp = ZpEncoder::new();
+    let mut record_type_ctx = NumContext::new();
+    let mut image_size_ctx = NumContext::new();
+    let mut symbol_width_ctx = NumContext::new();
+    let mut symbol_height_ctx = NumContext::new();
+    let mut direct_bitmap_ctx = vec![0u8; 1024];
+    let mut flag_ctx: u8 = 0;
+
+    // Preamble: start-of-image (rec 0) — no rec-9 since a Djbz never inherits
+    // from another dict in this encoder. Dimensions are written but unused on
+    // the decode side (see `decode_dictionary` in jb2.rs:1990).
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 0);
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, 0);
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, 0);
+    zp.encode_bit(&mut flag_ctx, false);
+
+    // Symbol body: rec-2 per entry.
+    for sym in symbols {
+        encode_num(&mut zp, &mut record_type_ctx, 0, 11, 2);
+        encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, sym.width as i32);
+        encode_num(
+            &mut zp,
+            &mut symbol_height_ctx,
+            0,
+            262142,
+            sym.height as i32,
+        );
+        encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, sym);
+    }
+
+    // End-of-data.
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 11);
+    zp.finish()
+}
+
+/// Cluster CCs from `pages` and return the bitmaps that should live in a
+/// shared Djbz: any (w, h, packed-data) signature that appears on `>=
+/// page_threshold` distinct pages.
+///
+/// Returns shared symbols in deterministic order (sorted by first-seen page,
+/// then first-seen position within that page). Pages without enough repetition
+/// produce an empty shared dict.
+pub(crate) fn cluster_shared_symbols(pages: &[Bitmap], page_threshold: usize) -> Vec<Bitmap> {
+    if page_threshold < 2 || pages.len() < page_threshold {
+        return Vec::new();
+    }
+
+    // Track per-(w,h,data) signature: pages it appeared on (set), and the
+    // first-seen (page_idx, cc_idx) for stable ordering.
+    type Key = (u32, u32, Vec<u8>);
+    struct ClusterEntry {
+        pages_seen: Vec<usize>,
+        first_seen: (usize, usize),
+        bitmap: Bitmap,
+    }
+    let mut seen: BTreeMap<Key, ClusterEntry> = BTreeMap::new();
+    for (page_idx, page) in pages.iter().enumerate() {
+        let ccs = extract_ccs(page);
+        for (cc_idx, cc) in ccs.iter().enumerate() {
+            let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
+            let entry = seen.entry(key).or_insert_with(|| ClusterEntry {
+                pages_seen: Vec::new(),
+                first_seen: (page_idx, cc_idx),
+                bitmap: cc.bitmap.clone(),
+            });
+            if !entry.pages_seen.contains(&page_idx) {
+                entry.pages_seen.push(page_idx);
+            }
+        }
+    }
+
+    let mut promoted: Vec<ClusterEntry> = seen
+        .into_values()
+        .filter(|e| e.pages_seen.len() >= page_threshold)
+        .collect();
+    promoted.sort_by_key(|e| e.first_seen);
+    promoted.into_iter().map(|e| e.bitmap).collect()
+}
+
+/// Encode a multi-page bilevel document as a bundled DJVM with a shared Djbz.
+///
+/// CCs that appear on at least `shared_dict_page_threshold` distinct input
+/// pages are promoted into a single shared [`Jb2Dict`] (Djbz) emitted as a
+/// `FORM:DJVI` component. Each page's `FORM:DJVU` then carries a small
+/// `INCL` chunk pointing at that DJVI plus a Sjbz that references the shared
+/// dictionary by index.
+///
+/// Returns the full DjVu container bytes (with `AT&T` magic, ready to write
+/// to a file). With `pages.len() < 2` or `shared_dict_page_threshold > pages.len()`,
+/// no symbols qualify for sharing and the encoder degrades to per-page
+/// independent encoding (still wrapped in DJVM).
+///
+/// [`Jb2Dict`]: crate::jb2::Jb2Dict
+pub fn encode_djvm_bundle_jb2(pages: &[Bitmap], shared_dict_page_threshold: usize) -> Vec<u8> {
+    use crate::iff;
+
+    let shared = cluster_shared_symbols(pages, shared_dict_page_threshold);
+    let djbz_bytes = encode_jb2_djbz(&shared);
+
+    // ── Build component buffers (each = full FORM body, ready for IFF emit) ──
+    //
+    // DJVI component (only when there is something to share): contains a single
+    // INFO chunk (none required by spec) + the Djbz.
+    //
+    // DJVU page components: INFO + INCL("dict0001.djvi") + Sjbz.
+    let mut comp_form_bodies: Vec<(Vec<u8>, /*is_page*/ bool, String)> = Vec::new();
+
+    let dict_id = "dict0001.djvi".to_string();
+    if !shared.is_empty() {
+        let mut djvi_body = Vec::new();
+        djvi_body.extend_from_slice(b"DJVI");
+        djvi_body.extend_from_slice(b"Djbz");
+        djvi_body.extend_from_slice(&(djbz_bytes.len() as u32).to_be_bytes());
+        djvi_body.extend_from_slice(&djbz_bytes);
+        if !djbz_bytes.len().is_multiple_of(2) {
+            djvi_body.push(0);
+        }
+        comp_form_bodies.push((djvi_body, false, dict_id.clone()));
+    }
+
+    let shared_ref: &[Bitmap] = &shared;
+    for (page_idx, page) in pages.iter().enumerate() {
+        let sjbz = encode_jb2_dict_with_shared(page, shared_ref);
+        let mut info = Vec::with_capacity(10);
+        info.extend_from_slice(&(page.width as u16).to_be_bytes());
+        info.extend_from_slice(&(page.height as u16).to_be_bytes());
+        info.extend_from_slice(&[24, 0, 100, 0, 1, 0]); // version major, minor, dpi(le16), gamma, rotation
+
+        let mut djvu_body = Vec::new();
+        djvu_body.extend_from_slice(b"DJVU");
+        djvu_body.extend_from_slice(b"INFO");
+        djvu_body.extend_from_slice(&(info.len() as u32).to_be_bytes());
+        djvu_body.extend_from_slice(&info);
+        if !info.len().is_multiple_of(2) {
+            djvu_body.push(0);
+        }
+        if !shared.is_empty() {
+            let incl_payload = dict_id.as_bytes();
+            djvu_body.extend_from_slice(b"INCL");
+            djvu_body.extend_from_slice(&(incl_payload.len() as u32).to_be_bytes());
+            djvu_body.extend_from_slice(incl_payload);
+            if !incl_payload.len().is_multiple_of(2) {
+                djvu_body.push(0);
+            }
+        }
+        djvu_body.extend_from_slice(b"Sjbz");
+        djvu_body.extend_from_slice(&(sjbz.len() as u32).to_be_bytes());
+        djvu_body.extend_from_slice(&sjbz);
+        if !sjbz.len().is_multiple_of(2) {
+            djvu_body.push(0);
+        }
+
+        let pid = format!("p{:04}.djvu", page_idx + 1);
+        comp_form_bodies.push((djvu_body, true, pid));
+    }
+
+    // ── Build DIRM directly (bundled, with offsets) ──
+    //
+    // Reuses the shape of `crate::djvm::build_djvm` but inlined here because
+    // we have FORM bodies (not full FORM chunks with header) to embed. The
+    // simpler path: build full FORM chunks here, then call `iff::emit_form`.
+    // Each component is a FORM chunk: { id: "FORM", body: <DJVU/DJVI ...> }.
+    let comp_form_data: Vec<&[u8]> = comp_form_bodies
+        .iter()
+        .map(|(b, _, _)| b.as_slice())
+        .collect();
+
+    // DIRM payload: build matching the bundled-format layout in
+    // `djvu_document.rs::parse` (flags=0x81 → bundled+1.0; count u16-be;
+    // per-component offsets u32-be; bzz-compressed metadata table).
+    let n = comp_form_bodies.len();
+    let mut dirm = Vec::new();
+    dirm.push(0x81); // bundled (high bit) + version 1
+    dirm.extend_from_slice(&(n as u16).to_be_bytes());
+
+    // Compute offsets after the DIRM chunk has been laid down.
+    // Layout: AT&T (4) + FORM (4) + form_size (4) + "DJVM" (4) + "DIRM" (4) +
+    //         dirm_size (4) + dirm_payload_with_offsets+bzz_meta + pad +
+    //         each FORM chunk header (8) + body + pad.
+    //
+    // Offsets in the DIRM are *file-byte* offsets to the AT&T-stripped FORM
+    // chunk header for each component. So offset[i] = position of "FORM" id
+    // bytes for that component within the file.
+    //
+    // We don't know the DIRM size until we know the offsets; resolve via
+    // two-pass: build metadata table first, then layout.
+    let mut meta = Vec::new();
+    for (body, _, _) in &comp_form_bodies {
+        let total = body.len() + 8; // FORM + size + body
+        meta.extend_from_slice(&(total as u32).to_be_bytes()[1..4]); // 24-bit size
+    }
+    for (_, is_page, _) in &comp_form_bodies {
+        let flag = if *is_page { 1u8 } else { 0u8 };
+        meta.push(flag);
+    }
+    for (_, _, id) in &comp_form_bodies {
+        meta.extend_from_slice(id.as_bytes());
+        meta.push(0);
+    }
+    for (_, _, id) in &comp_form_bodies {
+        meta.extend_from_slice(id.as_bytes());
+        meta.push(0);
+    }
+    meta.extend(core::iter::repeat_n(0u8, n)); // empty titles
+    let bzz_meta = crate::bzz_encode::bzz_encode(&meta);
+
+    // dirm payload final size = 1 (flags) + 2 (count) + 4*n (offsets) + bzz_meta.len()
+    let dirm_size = 1 + 2 + 4 * n + bzz_meta.len();
+
+    // Compute DJVM body size and component offsets.
+    let dirm_chunk_total = 8 + dirm_size + (dirm_size & 1); // header + payload + pad
+    let mut form_body_size: usize = 4; // "DJVM"
+    form_body_size += dirm_chunk_total;
+    let mut comp_offsets: Vec<u32> = Vec::with_capacity(n);
+    for body in &comp_form_data {
+        // File offset = AT&T(4) + FORM(4) + size(4) + DJVM(4) + dirm_chunk_total
+        //             + sum-of-prior-comp-totals
+        // The decoder treats DIRM offsets as byte offsets from start of file
+        // pointing at the "FORM" id bytes of the component. Offset 0 of the
+        // file = 'A' of "AT&T", so offset = 12 + 4 + dirm_chunk_total + prior.
+        let off = 4 + 4 + 4 + 4 + dirm_chunk_total + (form_body_size - 4 - dirm_chunk_total);
+        comp_offsets.push(off as u32);
+        let tot = body.len() + 8;
+        form_body_size += tot + (tot & 1); // pad component to even
+    }
+
+    // Now write final dirm payload with offsets.
+    let _ = dirm; // computed above for reference; final form built fresh below.
+    let mut dirm_full = Vec::with_capacity(dirm_size);
+    dirm_full.push(0x81);
+    dirm_full.extend_from_slice(&(n as u16).to_be_bytes());
+    for off in &comp_offsets {
+        dirm_full.extend_from_slice(&off.to_be_bytes());
+    }
+    dirm_full.extend_from_slice(&bzz_meta);
+    debug_assert_eq!(dirm_full.len(), dirm_size);
+
+    // Emit final file.
+    let mut out = Vec::with_capacity(12 + form_body_size);
+    out.extend_from_slice(b"AT&T");
+    out.extend_from_slice(b"FORM");
+    out.extend_from_slice(&(form_body_size as u32).to_be_bytes());
+    out.extend_from_slice(b"DJVM");
+    out.extend_from_slice(b"DIRM");
+    out.extend_from_slice(&(dirm_size as u32).to_be_bytes());
+    out.extend_from_slice(&dirm_full);
+    if dirm_size & 1 == 1 {
+        out.push(0);
+    }
+    for body in &comp_form_data {
+        out.extend_from_slice(b"FORM");
+        out.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        out.extend_from_slice(body);
+        if body.len() & 1 == 1 {
+            out.push(0);
+        }
+    }
+
+    let _ = iff::parse_form; // silence unused-import warning
+    out
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -1261,5 +1579,188 @@ mod tests {
         let c = vec![0u8; 2];
         let d = vec![0xff; 2];
         assert_eq!(packed_hamming(&c, &d), 16);
+    }
+
+    // ── #194 multi-page shared Djbz ────────────────────────────────────────────
+
+    fn render_glyph(bm: &mut Bitmap, x: u32, y: u32, glyph: &[&[u8]]) {
+        for (gy, row) in glyph.iter().enumerate() {
+            for (gx, &c) in row.iter().enumerate() {
+                if c == b'#' {
+                    bm.set(x + gx as u32, y + gy as u32, true);
+                }
+            }
+        }
+    }
+
+    fn glyph_a() -> Vec<&'static [u8]> {
+        vec![
+            b" ## " as &[u8],
+            b"#  #" as &[u8],
+            b"####" as &[u8],
+            b"#  #" as &[u8],
+            b"#  #" as &[u8],
+        ]
+    }
+    fn glyph_b() -> Vec<&'static [u8]> {
+        vec![
+            b"### " as &[u8],
+            b"#  #" as &[u8],
+            b"### " as &[u8],
+            b"#  #" as &[u8],
+            b"### " as &[u8],
+        ]
+    }
+
+    fn make_text_page(words: &[&[u8]]) -> Bitmap {
+        let mut bm = Bitmap::new(80, 30);
+        let mut x = 4;
+        for word in words {
+            for &letter in *word {
+                let g = match letter {
+                    b'A' => glyph_a(),
+                    b'B' => glyph_b(),
+                    _ => continue,
+                };
+                render_glyph(&mut bm, x, 8, &g);
+                x += 6;
+            }
+            x += 4;
+        }
+        bm
+    }
+
+    fn assert_decoded_eq(src: &Bitmap, decoded: &Bitmap) {
+        assert_eq!(src.width, decoded.width, "width mismatch");
+        assert_eq!(src.height, decoded.height, "height mismatch");
+        let mut mismatches = 0u32;
+        for y in 0..src.height {
+            for x in 0..src.width {
+                if src.get(x, y) != decoded.get(x, y) {
+                    mismatches += 1;
+                }
+            }
+        }
+        assert_eq!(mismatches, 0, "{mismatches} pixel mismatches");
+    }
+
+    #[test]
+    fn djbz_roundtrip_two_glyphs() {
+        // Encode two distinct glyph bitmaps as a Djbz, decode it, and verify
+        // the resulting Jb2Dict has exactly those two symbols in order.
+        let mut a = Bitmap::new(4, 5);
+        render_glyph(&mut a, 0, 0, &glyph_a());
+        let mut b = Bitmap::new(4, 5);
+        render_glyph(&mut b, 0, 0, &glyph_b());
+        let djbz = encode_jb2_djbz(&[a.clone(), b.clone()]);
+        assert!(!djbz.is_empty());
+
+        // Sanity-decode by constructing a Sjbz that uses the shared dict
+        // and checking the two glyphs round-trip.
+        let dict = jb2::decode_dict(&djbz, None).expect("decode_dict");
+        // Use the shared dict in a 1-page Sjbz that places both glyphs.
+        let mut page = Bitmap::new(20, 8);
+        render_glyph(&mut page, 2, 2, &glyph_a());
+        render_glyph(&mut page, 10, 2, &glyph_b());
+        let sjbz = encode_jb2_dict_with_shared(&page, &[a, b]);
+        let decoded = jb2::decode(&sjbz, Some(&dict)).expect("decode");
+        assert_decoded_eq(&page, &decoded);
+    }
+
+    #[test]
+    fn shared_dict_smaller_than_independent_for_repeated_pages() {
+        // Build two identical text pages. Encoding them with a shared Djbz
+        // should produce strictly smaller total bytes than two independent
+        // dict encodings.
+        let p1 = make_text_page(&[b"AABB", b"BABA"]);
+        let p2 = make_text_page(&[b"AABB", b"BABA"]);
+
+        let independent_total = encode_jb2_dict(&p1).len() + encode_jb2_dict(&p2).len();
+
+        let bundle = encode_djvm_bundle_jb2(&[p1.clone(), p2.clone()], 2);
+        assert!(!bundle.is_empty());
+
+        // Round-trip via the document parser.
+        let doc = crate::djvu_document::DjVuDocument::parse(&bundle).expect("parse DJVM");
+        assert_eq!(doc.page_count(), 2);
+        let d1 = doc
+            .page(0)
+            .expect("page 0")
+            .extract_mask()
+            .expect("extract_mask 0")
+            .expect("mask 0 present");
+        let d2 = doc
+            .page(1)
+            .expect("page 1")
+            .extract_mask()
+            .expect("extract_mask 1")
+            .expect("mask 1 present");
+        assert_decoded_eq(&p1, &d1);
+        assert_decoded_eq(&p2, &d2);
+
+        // Size win sanity check (bundle includes DIRM + IFF wrappers, so we
+        // only assert the pure JB2 payload across (Djbz + 2× Sjbz) is smaller
+        // than the pure 2× independent Sjbz).
+        let shared = cluster_shared_symbols(&[p1.clone(), p2.clone()], 2);
+        assert!(
+            !shared.is_empty(),
+            "two identical pages should produce shared symbols"
+        );
+        let djbz = encode_jb2_djbz(&shared);
+        let sjbz1 = encode_jb2_dict_with_shared(&p1, &shared);
+        let sjbz2 = encode_jb2_dict_with_shared(&p2, &shared);
+        let shared_jb2_total = djbz.len() + sjbz1.len() + sjbz2.len();
+        assert!(
+            shared_jb2_total < independent_total,
+            "expected shared jb2 < independent: shared={}  independent={}",
+            shared_jb2_total,
+            independent_total
+        );
+    }
+
+    #[test]
+    fn cluster_promotes_only_repeated_glyphs() {
+        // A appears on both pages, B appears on only one. With threshold=2,
+        // only A should be promoted.
+        let mut p1 = Bitmap::new(20, 10);
+        render_glyph(&mut p1, 2, 2, &glyph_a());
+        render_glyph(&mut p1, 10, 2, &glyph_b());
+        let mut p2 = Bitmap::new(20, 10);
+        render_glyph(&mut p2, 2, 2, &glyph_a());
+        // No B on page 2.
+
+        let shared = cluster_shared_symbols(&[p1, p2], 2);
+        assert_eq!(shared.len(), 1, "only A should cross the threshold");
+        // A glyph is 4×5.
+        assert_eq!(shared[0].width, 4);
+        assert_eq!(shared[0].height, 5);
+    }
+
+    #[test]
+    fn djvm_bundle_with_no_repeats_still_round_trips() {
+        // Two pages with no shared CCs — bundle should still parse and decode
+        // each page correctly (degraded path: empty Djbz / no shared dict).
+        let mut p1 = Bitmap::new(20, 10);
+        render_glyph(&mut p1, 2, 2, &glyph_a());
+        let mut p2 = Bitmap::new(20, 10);
+        render_glyph(&mut p2, 2, 2, &glyph_b());
+
+        let bundle = encode_djvm_bundle_jb2(&[p1.clone(), p2.clone()], 2);
+        let doc = crate::djvu_document::DjVuDocument::parse(&bundle).expect("parse DJVM");
+        assert_eq!(doc.page_count(), 2);
+        let d1 = doc
+            .page(0)
+            .expect("page 0")
+            .extract_mask()
+            .expect("extract_mask 0")
+            .expect("mask 0 present");
+        let d2 = doc
+            .page(1)
+            .expect("page 1")
+            .extract_mask()
+            .expect("extract_mask 1")
+            .expect("mask 1 present");
+        assert_decoded_eq(&p1, &d1);
+        assert_decoded_eq(&p2, &d2);
     }
 }

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -28,6 +28,11 @@
 use crate::bitmap::Bitmap;
 use crate::zp_impl::encoder::ZpEncoder;
 
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+
 // ── NumContext: binary-tree arena for variable-length integer encoding ─────────
 
 /// Binary-tree context store used to encode variable-length integers with ZP.
@@ -286,6 +291,219 @@ pub fn encode_jb2(bitmap: &Bitmap) -> Vec<u8> {
     zp.finish()
 }
 
+// ── Connected-component extraction (symbol-dict encoding) ─────────────────────
+
+/// A single connected component: its cropped bitmap and top-left bbox origin.
+struct Cc {
+    /// Top-left x of the component in the source bitmap (0 = left edge).
+    x: u32,
+    /// Top-left y of the component in the source bitmap (0 = top edge).
+    y: u32,
+    /// Cropped bitmap: tight bbox, pixels of this component only.
+    bitmap: Bitmap,
+}
+
+/// Extract all 8-connected components of black pixels from `bitmap`.
+///
+/// Uses iterative DFS on an unpacked byte grid; each component's cropped
+/// bitmap is the minimal bounding box that contains its black pixels.
+/// Ordering is raster-scan of the seed pixel (roughly top-to-bottom,
+/// left-to-right).
+fn extract_ccs(bitmap: &Bitmap) -> Vec<Cc> {
+    let w = bitmap.width as usize;
+    let h = bitmap.height as usize;
+    if w == 0 || h == 0 {
+        return Vec::new();
+    }
+
+    // Unpack into a mutable byte grid — 1 = black-unvisited, 0 = white-or-visited.
+    let mut pix = vec![0u8; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            if bitmap.get(x as u32, y as u32) {
+                pix[y * w + x] = 1;
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    let mut stack: Vec<(u32, u32)> = Vec::new();
+    let mut cc_pixels: Vec<(u32, u32)> = Vec::new();
+
+    for y0 in 0..h {
+        for x0 in 0..w {
+            if pix[y0 * w + x0] == 0 {
+                continue;
+            }
+            stack.clear();
+            cc_pixels.clear();
+            stack.push((x0 as u32, y0 as u32));
+            pix[y0 * w + x0] = 0;
+
+            let mut min_x = x0;
+            let mut max_x = x0;
+            let mut min_y = y0;
+            let mut max_y = y0;
+
+            while let Some((cx, cy)) = stack.pop() {
+                cc_pixels.push((cx, cy));
+                let cxi = cx as usize;
+                let cyi = cy as usize;
+                if cxi < min_x {
+                    min_x = cxi;
+                }
+                if cxi > max_x {
+                    max_x = cxi;
+                }
+                if cyi < min_y {
+                    min_y = cyi;
+                }
+                if cyi > max_y {
+                    max_y = cyi;
+                }
+
+                let lo_x = cxi.saturating_sub(1);
+                let hi_x = (cxi + 1).min(w - 1);
+                let lo_y = cyi.saturating_sub(1);
+                let hi_y = (cyi + 1).min(h - 1);
+                for ny in lo_y..=hi_y {
+                    let row_base = ny * w;
+                    for nx in lo_x..=hi_x {
+                        if pix[row_base + nx] != 0 {
+                            pix[row_base + nx] = 0;
+                            stack.push((nx as u32, ny as u32));
+                        }
+                    }
+                }
+            }
+
+            let cc_w = (max_x - min_x + 1) as u32;
+            let cc_h = (max_y - min_y + 1) as u32;
+            let mut cc_bm = Bitmap::new(cc_w, cc_h);
+            for &(px, py) in &cc_pixels {
+                cc_bm.set(px - min_x as u32, py - min_y as u32, true);
+            }
+            out.push(Cc {
+                x: min_x as u32,
+                y: min_y as u32,
+                bitmap: cc_bm,
+            });
+        }
+    }
+
+    out
+}
+
+// ── Dict-based encoding: record types 1 (new) + 7 (matched copy) ──────────────
+
+/// Encode a bilevel [`Bitmap`] into a JB2 stream using a **symbol dictionary**.
+///
+/// Performs connected-component (CC) extraction, exact-match deduplication,
+/// and emits record type 1 for each unique CC (new symbol, direct, stored in
+/// dict + blitted) and record type 7 for each repeat (matched copy, blit only).
+///
+/// Lossless. Matches [`crate::jb2::decode`] for round-trip.
+///
+/// ## Limitations (Phase 1)
+/// - Exact-match only — no near-duplicate matching or lossy refinement.
+/// - Coordinate coding uses `new_line = true` for every symbol (wastes space
+///   compared to baseline-relative same-line coding; optimized in a later phase).
+/// - Components >= 1 MP are encoded as-is; the decoder will reject them via
+///   `MAX_SYMBOL_PIXELS`. For scanned text pages this is not a practical issue.
+pub fn encode_jb2_dict(bitmap: &Bitmap) -> Vec<u8> {
+    let w = bitmap.width as i32;
+    let h = bitmap.height as i32;
+    if w == 0 || h == 0 {
+        return Vec::new();
+    }
+
+    let ccs = extract_ccs(bitmap);
+
+    // Reading-order sort: top-to-bottom, then left-to-right.
+    let mut order: Vec<usize> = (0..ccs.len()).collect();
+    order.sort_by_key(|&i| (ccs[i].y, ccs[i].x));
+
+    let mut zp = ZpEncoder::new();
+    let mut record_type_ctx = NumContext::new();
+    let mut image_size_ctx = NumContext::new();
+    let mut symbol_width_ctx = NumContext::new();
+    let mut symbol_height_ctx = NumContext::new();
+    let mut symbol_index_ctx = NumContext::new();
+    let mut hoff_ctx = NumContext::new();
+    let mut voff_ctx = NumContext::new();
+    let mut direct_bitmap_ctx = vec![0u8; 1024];
+    let mut offset_type_ctx: u8 = 0;
+    let mut flag_ctx: u8 = 0;
+
+    // Preamble.
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 0);
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, w);
+    encode_num(&mut zp, &mut image_size_ctx, 0, 262142, h);
+    zp.encode_bit(&mut flag_ctx, false);
+
+    // Layout state — mirrors `LayoutState::new`.
+    let mut first_left: i32 = -1;
+    let mut first_bottom: i32 = h - 1;
+
+    // Dedup: (w, h, packed-data) → dict index assigned on first emission.
+    let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
+    let mut dict_size: usize = 0;
+
+    for &cc_idx in &order {
+        let cc = &ccs[cc_idx];
+        let cc_w = cc.bitmap.width as i32;
+        let cc_h = cc.bitmap.height as i32;
+        // JB2 uses bottom-up y: y_jb2 is the bottom y of the symbol.
+        // Top-down bottom = cc.y + cc_h - 1; JB2 y = (h - 1) - (cc.y + cc_h - 1).
+        let x_jb2 = cc.x as i32;
+        let y_jb2 = h - cc.y as i32 - cc_h;
+
+        let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
+        match dedup.get(&key).copied() {
+            None => {
+                // Type 1 — new symbol, direct decode, add to dict AND blit.
+                encode_num(&mut zp, &mut record_type_ctx, 0, 11, 1);
+                encode_num(&mut zp, &mut symbol_width_ctx, 0, 262142, cc_w);
+                encode_num(&mut zp, &mut symbol_height_ctx, 0, 262142, cc_h);
+                encode_bitmap_direct(&mut zp, &mut direct_bitmap_ctx, &cc.bitmap);
+
+                zp.encode_bit(&mut offset_type_ctx, true); // new_line
+                let hoff = x_jb2 - first_left;
+                let voff = y_jb2 + cc_h - 1 - first_bottom;
+                encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
+                encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
+                first_left = x_jb2;
+                first_bottom = y_jb2;
+
+                dedup.insert(key, dict_size);
+                dict_size += 1;
+            }
+            Some(dict_idx) => {
+                // Type 7 — matched copy, no refinement, blit only.
+                encode_num(&mut zp, &mut record_type_ctx, 0, 11, 7);
+                encode_num(
+                    &mut zp,
+                    &mut symbol_index_ctx,
+                    0,
+                    (dict_size - 1) as i32,
+                    dict_idx as i32,
+                );
+
+                zp.encode_bit(&mut offset_type_ctx, true); // new_line
+                let hoff = x_jb2 - first_left;
+                let voff = y_jb2 + cc_h - 1 - first_bottom;
+                encode_num(&mut zp, &mut hoff_ctx, -262143, 262142, hoff);
+                encode_num(&mut zp, &mut voff_ctx, -262143, 262142, voff);
+                first_left = x_jb2;
+                first_bottom = y_jb2;
+            }
+        }
+    }
+
+    encode_num(&mut zp, &mut record_type_ctx, 0, 11, 11);
+    zp.finish()
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -386,5 +604,136 @@ mod tests {
         assert!(encode_jb2(&Bitmap::new(0, 0)).is_empty());
         assert!(encode_jb2(&Bitmap::new(8, 0)).is_empty());
         assert!(encode_jb2(&Bitmap::new(0, 8)).is_empty());
+    }
+
+    // ── Dict-based encoder (Phase 1: record types 1 + 7) ──────────────────────
+
+    fn roundtrip_dict(bm: &Bitmap) -> Bitmap {
+        let encoded = encode_jb2_dict(bm);
+        jb2::decode(&encoded, None).expect("dict decode failed")
+    }
+
+    fn assert_bitmaps_eq(a: &Bitmap, b: &Bitmap) {
+        assert_eq!(a.width, b.width, "width mismatch");
+        assert_eq!(a.height, b.height, "height mismatch");
+        let mut mismatches = 0u32;
+        for y in 0..a.height {
+            for x in 0..a.width {
+                if a.get(x, y) != b.get(x, y) {
+                    mismatches += 1;
+                }
+            }
+        }
+        assert_eq!(mismatches, 0, "{mismatches} pixel mismatches");
+    }
+
+    #[test]
+    fn dict_all_white_roundtrip() {
+        let src = Bitmap::new(32, 32);
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn dict_single_pixel_roundtrip() {
+        let src = make_bitmap(16, 16, |x, y| x == 4 && y == 7);
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn dict_two_dots_dedup() {
+        // Two identical 1-pixel CCs — dict size should be 1.
+        let src = make_bitmap(32, 32, |x, y| (x == 3 && y == 5) || (x == 20 && y == 25));
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+        // Assert deduplication happened by checking that the encoded stream
+        // is *smaller* than encoding each CC as a fresh record-type-1 would be.
+        // Indirect check: re-encode and make sure two CCs exist in the source.
+        let ccs = extract_ccs(&src);
+        assert_eq!(ccs.len(), 2);
+    }
+
+    #[test]
+    fn dict_letter_like_shapes() {
+        // Two disconnected 3×5 rectangles — should dedup to 1 symbol.
+        let src = make_bitmap(32, 32, |x, y| {
+            (x < 3 && y < 5) || (x >= 20 && x < 23 && y >= 10 && y < 15)
+        });
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn dict_checkerboard_many_ccs() {
+        // 8×8 checkerboard: 32 single-pixel CCs, all identical → 1 dict entry.
+        let src = make_bitmap(8, 8, |x, y| (x + y) % 2 == 0);
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn dict_two_different_shapes_multiple_occurrences() {
+        // Shape A: 2x2 block.  Shape B: 1x3 vertical line.
+        // Four copies of each, interleaved spatially.
+        let src = make_bitmap(64, 64, |x, y| {
+            // A: (0-1, 0-1), (30-31, 0-1), (0-1, 30-31), (30-31, 30-31)
+            let in_a = |ax: u32, ay: u32| x >= ax && x < ax + 2 && y >= ay && y < ay + 2;
+            // B: (10, 5-7), (40, 5-7), (10, 45-47), (40, 45-47)
+            let in_b = |bx: u32, by: u32| x == bx && y >= by && y < by + 3;
+            in_a(0, 0)
+                || in_a(30, 0)
+                || in_a(0, 30)
+                || in_a(30, 30)
+                || in_b(10, 5)
+                || in_b(40, 5)
+                || in_b(10, 45)
+                || in_b(40, 45)
+        });
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+        let ccs = extract_ccs(&src);
+        assert_eq!(ccs.len(), 8, "expected 4+4 CCs");
+    }
+
+    #[test]
+    fn dict_dimension_encoded_correctly() {
+        // Non-multiple-of-8 dimensions stress row-stride handling.
+        let src = make_bitmap(13, 7, |x, y| (x * 3 + y) % 5 == 0);
+        let decoded = roundtrip_dict(&src);
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn dict_zero_dimension_returns_empty() {
+        assert!(encode_jb2_dict(&Bitmap::new(0, 0)).is_empty());
+        assert!(encode_jb2_dict(&Bitmap::new(8, 0)).is_empty());
+        assert!(encode_jb2_dict(&Bitmap::new(0, 8)).is_empty());
+    }
+
+    #[test]
+    fn dict_extract_ccs_counts() {
+        // 3 non-touching black squares.
+        let src = make_bitmap(30, 30, |x, y| {
+            (x < 3 && y < 3)
+                || (x >= 10 && x < 13 && y >= 10 && y < 13)
+                || (x >= 25 && x < 28 && y >= 25 && y < 28)
+        });
+        let ccs = extract_ccs(&src);
+        assert_eq!(ccs.len(), 3);
+        for cc in &ccs {
+            assert_eq!(cc.bitmap.width, 3);
+            assert_eq!(cc.bitmap.height, 3);
+        }
+    }
+
+    #[test]
+    fn dict_extract_ccs_8connected() {
+        // Diagonal pair — 8-connected should merge into 1 CC.
+        let src = make_bitmap(4, 4, |x, y| (x == 0 && y == 0) || (x == 1 && y == 1));
+        let ccs = extract_ccs(&src);
+        assert_eq!(ccs.len(), 1);
+        assert_eq!(ccs[0].bitmap.width, 2);
+        assert_eq!(ccs[0].bitmap.height, 2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,8 @@ pub mod iw44_encode;
 
 /// JB2 bilevel image encoder — produces Sjbz chunk payloads.
 ///
-/// Provides [`jb2_encode::encode_jb2`].
+/// Provides [`jb2_encode::encode_jb2`] (single record-type-3 direct encoding) and
+/// [`jb2_encode::encode_jb2_dict`] (connected-component symbol-dictionary encoding).
 #[cfg(feature = "std")]
 pub mod jb2_encode;
 


### PR DESCRIPTION
## Summary
Cross-page CC dedup as follow-on to #209. Three new public APIs in `src/jb2_encode.rs`:

| API | Output |
|-----|--------|
| `encode_jb2_djbz(symbols)` | Djbz chunk payload (rec-2 per symbol, no inheritance) |
| `encode_jb2_dict_with_shared(bitmap, shared)` | Sjbz chunk emitting rec-9 (required-dict-or-reset) preamble + rec-7 references to shared dict |
| `encode_djvm_bundle_jb2(pages, threshold)` | full DJVM container with one DJVI(Djbz) + N DJVU(INCL+Sjbz) |

**Phase 1 algorithm**: exact-match `(w, h, packed-data)` clustering across pages; CCs appearing on `>= threshold` distinct pages get promoted to the shared Djbz, the rest stay per-page. Same-line/refinement matching from #209 carries over inside each page's Sjbz.

**Validation** — 4 new unit tests on toy 2-page text bitmaps:
- `djbz_roundtrip_two_glyphs`
- `shared_dict_smaller_than_independent_for_repeated_pages` (the milestone)
- `cluster_promotes_only_repeated_glyphs`
- `djvm_bundle_with_no_repeats_still_round_trips`

Stacked on **#210** (which is stacked on #209/#208).

## Phase 2 (not in this PR)
- Cross-page Hamming/refinement clustering (rec-6 against shared dict)
- Corpus-level size benchmark
- CLI extension `djvu encode --input-dir`

## Test plan
- [x] All 4 new unit tests pass + 488 existing tests
- [x] Pre-commit clean
- [x] Full DJVM container parses cleanly through `DjVuDocument::parse`; both pages' bitmaps round-trip pixel-exact through `extract_mask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)