### PR TITLE
feat(jb2-enc): tunable shared-Djbz clustering + corpus harness (#194 Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,74 @@ gain.
 **Next step.** Re-attempt on ARM64 (M1) with raw NEON `vld2q_s16`, measure
 against the baseline `iw44_decode_first_chunk` (715 µs) on the reference
 hardware listed in `BENCHMARKS_RESULTS.md`.
+
+### #194 Phase 2 — multi-page shared Djbz with Hamming clustering — **Reverted default, kept tunable knob** (2026-04-28)
+
+**Approach.** Phase 1 (#194, shipped) builds the shared Djbz dictionary by
+byte-exact `(w, h, data)` dedup of CCs across pages: any CC signature
+appearing on `≥ threshold` distinct pages becomes a shared symbol, the rest
+stay per-page Sjbz. Phase 2 attempted to widen the cluster predicate to
+"same `(w, h)` AND `packed_hamming(rep, cc) ≤ pixels * fraction`", folding
+near-duplicate scanned-glyph variants into one shared rep so the per-page
+Sjbz can emit `rec-7` (matched copy) or `rec-6` (matched refinement)
+instead of `rec-1` (new direct).
+
+Implementation: `cluster_shared_symbols_tunable(pages, page_threshold,
+diff_fraction)` — bucketed by `(w, h)`, linear scan per bucket choosing the
+nearest existing rep within `max_diff = pixels * diff_fraction / 100` (with
+a `REFINEMENT_MIN_PIXELS = 32` floor that keeps tiny CCs byte-exact).
+`encode_djvm_bundle_jb2_with_shared(pages, &shared)` lets a benchmark
+harness drive cluster selection without re-running the IFF/DIRM pipeline.
+
+**Harness.** `examples/encode_quality_djbz.rs` — for each multi-page DjVu
+input, computes total bytes for {original Sjbz, independent
+`encode_jb2_dict` per page, bundled `encode_djvm_bundle_jb2_with_shared`}
+across configurable Hamming thresholds; verifies pixel-exact bundle
+round-trip.
+
+**Bench** (`encode_quality_djbz` on `pathogenic_bacteria_1896.djvu`,
+517 pages of cjb2 scans, Apple M1 Max):
+
+| `--diff-fraction` | shared syms | Djbz bytes | Σ Sjbz | bundle / independent | round-trip |
+|-------------------|-------------|------------|--------|----------------------|------------|
+| 0 (byte-exact, shipped) | 1 568 | 41 KB | 7.40 MB | **0.870×** (−13.0%) | ✓ |
+| 1% | 1 547 | 40 KB | 7.40 MB | 0.870× (−13.0%) | ✓ |
+| 2% | 1 503 | 39 KB | 7.41 MB | 0.871× (−12.9%) | ✓ |
+| 3% | 1 449 | 38 KB | — | — | **✗ mismatch** |
+| 4% | 1 387 | 36 KB | 7.50 MB | 0.877× (−12.3%) | ✓ |
+
+Small corpus (`tests/corpus/*.djvu`, 36 pages from 4 books):
+
+| `--diff-fraction` | bundle / independent |
+|-------------------|----------------------|
+| 0 (byte-exact)    | 1.021× (+2.1%) |
+| 4%                | 1.150× (+15.0%) |
+
+**Reason reverted as default.** The Phase 1 byte-exact win (−13.0% bundle
+vs independent on the 517-page corpus) is the entire shared-Djbz benefit.
+Hamming clustering at 1–2% is within 0.05% of byte-exact; at 4% it is
+strictly worse. Hypothesis: the per-page `symbol_index_ctx` encoding pays
+≈ `log2(K)` bits per reference, so growing `K` (more shared reps) inflates
+every `rec-7` reference; meanwhile `rec-6` refinement bitmaps cost more
+ZP-coded bits than a fresh `rec-1` direct emission whenever the shared rep
+isn't a near-perfect match. Net: cross-page Hamming clustering must match
+*better than* the per-page intra-CC refinement matcher already does within
+each page (#188 Phase 3) — and on this corpus it doesn't.
+
+**Reason kept tunable.** `cluster_shared_symbols_tunable` and
+`encode_djvm_bundle_jb2_with_shared` are exposed `pub` so the benchmark
+harness — and any future Phase 2.5 calibration work (per-CC profitability
+model instead of a flat fraction) — can sweep thresholds without forking
+the encoder. The default `cluster_shared_symbols` continues to delegate to
+`diff_fraction = 0`.
+
+**Open follow-ups.**
+1. The `diff_fraction = 3%` round-trip mismatch on the big corpus is a real
+   bug in the rec-6 refinement path against shared reps — should be filed
+   as a sub-issue. (Doesn't block ship: 0% remains lossless and is the
+   shipped default.)
+2. Per-CC profitability model: instead of a flat Hamming fraction, decide
+   per CC whether `cost(rec-6 against shared rep)` < `cost(rec-1 fresh) +
+   amortized log2(K) increase`. Unclear if the win exists — would need to
+   re-measure with a corpus where intra-page refinement is already
+   exhausted.

--- a/examples/encode_quality_djbz.rs
+++ b/examples/encode_quality_djbz.rs
@@ -1,0 +1,260 @@
+//! Multi-page shared-Djbz quality benchmark (#194 Phase 2).
+//!
+//! For each multi-page DjVu input, extracts every page's bilevel mask, then
+//! compares three encoder modes:
+//!   1. **Original** — sum of source Sjbz chunks (typically `cjb2`).
+//!   2. **Independent** — `encode_jb2_dict(page)` per page, summed.
+//!   3. **Bundled** — `encode_djvm_bundle_jb2(pages, threshold)` total bytes
+//!      (Djbz + per-page Sjbz, IFF/DIRM overhead included).
+//!
+//! Win = bundled / independent < 1.0.
+//!
+//! On 517-page `pathogenic_bacteria_1896.djvu` (real cjb2 scan corpus) the
+//! shipped byte-exact clustering (`--diff-fraction 0`) gives bundle = 87.0%
+//! of independent (−13.0%); 1%/2% Hamming clustering matches it within 0.05%;
+//! 3% introduces decode mismatches under rec-6 refinement. See CLAUDE.md
+//! "Multi-page shared Djbz dictionary, Phase 2" for the full investigation.
+//!
+//! Usage:
+//!     cargo run --release --example encode_quality_djbz -- <file.djvu> [<file2.djvu> ...]
+//!         [--threshold N]   # default 2 (default for encode_djvm_bundle_jb2)
+//!
+//! Output: per-file JSON line on stdout + summary table on stderr.
+//!
+//! Verifies bundle round-trip (every page decodes pixel-exact).
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use djvu_rs::{
+    Bitmap, DjVuDocument,
+    jb2_encode::{
+        cluster_shared_symbols_tunable, encode_djvm_bundle_jb2_with_shared, encode_jb2_dict,
+        encode_jb2_dict_with_shared, encode_jb2_djbz,
+    },
+};
+
+struct FileResult {
+    file: String,
+    pages: usize,
+    width_h_avg: (u32, u32),
+    orig_total: usize,
+    indep_total: usize,
+    bundle_total: usize,
+    roundtrip_ok: bool,
+    #[allow(dead_code)]
+    diff_fraction: u32,
+}
+
+fn collect_pages(path: &Path) -> Option<(Vec<Bitmap>, usize, (u32, u32))> {
+    let data = std::fs::read(path).ok()?;
+    let doc = DjVuDocument::parse(&data).ok()?;
+    let mut pages = Vec::new();
+    let mut orig_total = 0usize;
+    let (mut sw, mut sh, mut n) = (0u64, 0u64, 0u64);
+    for i in 0..doc.page_count() {
+        let p = match doc.page(i) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if let Some(s) = p.raw_chunk(b"Sjbz") {
+            orig_total += s.len();
+        }
+        let bm = match p.extract_mask() {
+            Ok(Some(b)) => b,
+            _ => continue,
+        };
+        sw += bm.width as u64;
+        sh += bm.height as u64;
+        n += 1;
+        pages.push(bm);
+    }
+    if pages.is_empty() {
+        return None;
+    }
+    let avg = ((sw / n) as u32, (sh / n) as u32);
+    Some((pages, orig_total, avg))
+}
+
+fn process_file(path: &Path, threshold: usize, diff_fraction: u32) -> Option<FileResult> {
+    let (pages, orig_total, avg) = match collect_pages(path) {
+        Some(t) => t,
+        None => {
+            eprintln!("skip {}: no JB2 pages", path.display());
+            return None;
+        }
+    };
+
+    let indep_total: usize = pages
+        .iter()
+        .map(|p: &Bitmap| encode_jb2_dict(p).len())
+        .sum();
+
+    // Build the bundle with a tunable cluster Hamming threshold so we can
+    // sweep different fractions independently of the shipped default.
+    let shared = cluster_shared_symbols_tunable(&pages, threshold, diff_fraction);
+    let bundle = encode_djvm_bundle_jb2_with_shared(&pages, &shared);
+    let bundle_total = bundle.len();
+
+    // Diagnostic breakdown: how big is the shared dict, vs per-page Sjbz?
+    let djbz_bytes = if shared.is_empty() {
+        0
+    } else {
+        encode_jb2_djbz(&shared).len()
+    };
+    let sjbz_total: usize = pages
+        .iter()
+        .map(|p| encode_jb2_dict_with_shared(p, &shared).len())
+        .sum();
+    eprintln!(
+        "  {}: diff={}% shared_syms={} djbz={}B sjbz_total={}B (jb2={}B, container_overhead={}B)",
+        path.display(),
+        diff_fraction,
+        shared.len(),
+        djbz_bytes,
+        sjbz_total,
+        djbz_bytes + sjbz_total,
+        bundle_total.saturating_sub(djbz_bytes + sjbz_total),
+    );
+
+    // Verify round-trip — every page must decode pixel-exact.
+    let roundtrip_ok = match DjVuDocument::parse(&bundle) {
+        Ok(doc) if doc.page_count() == pages.len() => {
+            (0..pages.len()).all(|i| match doc.page(i).and_then(|p| p.extract_mask()) {
+                Ok(Some(d)) => {
+                    d.width == pages[i].width
+                        && d.height == pages[i].height
+                        && d.data == pages[i].data
+                }
+                _ => false,
+            })
+        }
+        _ => false,
+    };
+
+    Some(FileResult {
+        file: path.display().to_string(),
+        pages: pages.len(),
+        width_h_avg: avg,
+        orig_total,
+        indep_total,
+        bundle_total,
+        roundtrip_ok,
+        diff_fraction,
+    })
+}
+
+fn main() -> ExitCode {
+    let mut threshold = 2usize;
+    // Default 0 = byte-exact, the shipped clustering. Higher values opt
+    // into Hamming clustering for experimentation.
+    let mut diff_fraction: u32 = 0;
+    let mut files: Vec<String> = Vec::new();
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        if a == "--threshold" {
+            threshold = args
+                .next()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(threshold);
+        } else if a == "--diff-fraction" {
+            diff_fraction = args
+                .next()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(diff_fraction);
+        } else {
+            files.push(a);
+        }
+    }
+
+    if files.is_empty() {
+        eprintln!(
+            "usage: encode_quality_djbz [--threshold N] [--diff-fraction P] <file.djvu> [...]\n\
+             \n\
+             Encodes every multi-page input via encode_djvm_bundle_jb2 and\n\
+             reports total bytes vs. independent per-page dict + original Sjbz.\n\
+             \n\
+             --threshold N      promote glyph clusters that span >= N pages (default 2)\n\
+             --diff-fraction P  Hamming distance allowance, percent of pixels (0..=10, default 0 = byte-exact)"
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut all = Vec::new();
+    for f in &files {
+        if let Some(r) = process_file(Path::new(f), threshold, diff_fraction) {
+            all.push(r);
+        }
+    }
+
+    if all.is_empty() {
+        eprintln!("no files processed");
+        return ExitCode::from(1);
+    }
+
+    for r in &all {
+        println!(
+            "{{\"file\":\"{}\",\"pages\":{},\"avg_w\":{},\"avg_h\":{},\
+             \"orig_bytes\":{},\"indep_bytes\":{},\"bundle_bytes\":{},\
+             \"bundle_vs_indep\":{:.4},\"bundle_vs_orig\":{:.4},\
+             \"threshold\":{},\"roundtrip_ok\":{}}}",
+            r.file,
+            r.pages,
+            r.width_h_avg.0,
+            r.width_h_avg.1,
+            r.orig_total,
+            r.indep_total,
+            r.bundle_total,
+            r.bundle_total as f64 / r.indep_total.max(1) as f64,
+            r.bundle_total as f64 / r.orig_total.max(1) as f64,
+            threshold,
+            r.roundtrip_ok,
+        );
+    }
+
+    let total_pages: usize = all.iter().map(|r| r.pages).sum();
+    let total_orig: usize = all.iter().map(|r| r.orig_total).sum();
+    let total_indep: usize = all.iter().map(|r| r.indep_total).sum();
+    let total_bundle: usize = all.iter().map(|r| r.bundle_total).sum();
+    let any_rt_fail = all.iter().any(|r| !r.roundtrip_ok);
+
+    eprintln!();
+    eprintln!(
+        "=== shared-Djbz quality summary (threshold={}) ===",
+        threshold
+    );
+    eprintln!("files: {}   pages: {}", all.len(), total_pages);
+    eprintln!();
+    eprintln!("{:<10} {:>14} {:>10}", "mode", "bytes", "vs orig");
+    eprintln!(
+        "{:<10} {:>14} {:>10}",
+        "original",
+        total_orig,
+        format!("{:.3}×", 1.0)
+    );
+    eprintln!(
+        "{:<10} {:>14} {:>10}",
+        "independent",
+        total_indep,
+        format!("{:.3}×", total_indep as f64 / total_orig.max(1) as f64),
+    );
+    eprintln!(
+        "{:<10} {:>14} {:>10}",
+        "bundled",
+        total_bundle,
+        format!("{:.3}×", total_bundle as f64 / total_orig.max(1) as f64),
+    );
+    eprintln!();
+    eprintln!(
+        "shared-Djbz win (bundle/independent): {:.3}×  ({:+.1}%)",
+        total_bundle as f64 / total_indep.max(1) as f64,
+        (total_bundle as f64 / total_indep.max(1) as f64 - 1.0) * 100.0,
+    );
+    eprintln!();
+    if any_rt_fail {
+        eprintln!("⚠ round-trip FAILED on at least one file");
+        return ExitCode::from(1);
+    }
+    eprintln!("✓ all bundle round-trips pixel-exact");
+    ExitCode::SUCCESS
+}

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -962,46 +962,97 @@ pub fn encode_jb2_djbz(symbols: &[Bitmap]) -> Vec<u8> {
 
 /// Cluster CCs from `pages` and return the bitmaps that should live in a
 /// shared Djbz: any (w, h, packed-data) signature that appears on `>=
-/// page_threshold` distinct pages.
+/// page_threshold` distinct pages, represented by the first-seen CC.
 ///
 /// Returns shared symbols in deterministic order (sorted by first-seen page,
 /// then first-seen position within that page). Pages without enough repetition
 /// produce an empty shared dict.
-pub(crate) fn cluster_shared_symbols(pages: &[Bitmap], page_threshold: usize) -> Vec<Bitmap> {
+///
+/// **Byte-exact dedup only.** Tried Hamming-distance clustering for #194
+/// Phase 2 (`cluster_shared_symbols_tunable` with `diff_fraction > 0`):
+/// no measurable byte saving on the 517-page `pathogenic_bacteria_1896`
+/// corpus (< 0.05% delta from byte-exact across 0%/1%/2% Hamming) and
+/// `diff_fraction = 3%` introduced per-page Sjbz decode mismatches under
+/// rec-6 refinement against shared reps. Byte-exact clustering already
+/// captures the multi-page win (−13.0% bundle vs independent on the same
+/// corpus). See CLAUDE.md "Multi-page shared Djbz dictionary, Phase 2"
+/// investigation for measurements.
+pub fn cluster_shared_symbols(pages: &[Bitmap], page_threshold: usize) -> Vec<Bitmap> {
+    cluster_shared_symbols_tunable(pages, page_threshold, 0)
+}
+
+/// Same as [`cluster_shared_symbols`] but exposes the per-CC Hamming
+/// allowance as a percentage of pixel count. `diff_fraction = 0` produces
+/// byte-exact clustering (the shipped default); higher values fold
+/// near-duplicate glyphs into a single shared rep at the cost of forcing
+/// the per-page Sjbz emitter through rec-6 (matched refinement) more often.
+///
+/// Provided for corpus benchmarking — most callers want
+/// [`cluster_shared_symbols`].
+pub fn cluster_shared_symbols_tunable(
+    pages: &[Bitmap],
+    page_threshold: usize,
+    diff_fraction: u32,
+) -> Vec<Bitmap> {
     if page_threshold < 2 || pages.len() < page_threshold {
         return Vec::new();
     }
 
-    // Track per-(w,h,data) signature: pages it appeared on (set), and the
-    // first-seen (page_idx, cc_idx) for stable ordering.
-    type Key = (u32, u32, Vec<u8>);
-    struct ClusterEntry {
+    struct Cluster {
+        rep: Bitmap,
         pages_seen: Vec<usize>,
         first_seen: (usize, usize),
-        bitmap: Bitmap,
     }
-    let mut seen: BTreeMap<Key, ClusterEntry> = BTreeMap::new();
+
+    let mut buckets: BTreeMap<(u32, u32), Vec<Cluster>> = BTreeMap::new();
+
     for (page_idx, page) in pages.iter().enumerate() {
         let ccs = extract_ccs(page);
         for (cc_idx, cc) in ccs.iter().enumerate() {
-            let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
-            let entry = seen.entry(key).or_insert_with(|| ClusterEntry {
-                pages_seen: Vec::new(),
-                first_seen: (page_idx, cc_idx),
-                bitmap: cc.bitmap.clone(),
-            });
-            if !entry.pages_seen.contains(&page_idx) {
-                entry.pages_seen.push(page_idx);
+            let bm = &cc.bitmap;
+            let pixel_count = (bm.width as u64) * (bm.height as u64);
+            // Tiny CCs always byte-exact: refinement is rejected per-page anyway.
+            let max_diff: u32 = if pixel_count < REFINEMENT_MIN_PIXELS {
+                0
+            } else {
+                ((pixel_count * diff_fraction as u64) / 100) as u32
+            };
+
+            let bucket = buckets.entry((bm.width, bm.height)).or_default();
+            let mut best: Option<(usize, u32)> = None;
+            for (i, c) in bucket.iter().enumerate() {
+                let d = packed_hamming(&bm.data, &c.rep.data);
+                if d > max_diff {
+                    continue;
+                }
+                match best {
+                    None => best = Some((i, d)),
+                    Some((_, bd)) if d < bd => best = Some((i, d)),
+                    _ => {}
+                }
+            }
+            match best {
+                Some((i, _)) => {
+                    if !bucket[i].pages_seen.contains(&page_idx) {
+                        bucket[i].pages_seen.push(page_idx);
+                    }
+                }
+                None => bucket.push(Cluster {
+                    rep: bm.clone(),
+                    pages_seen: vec![page_idx],
+                    first_seen: (page_idx, cc_idx),
+                }),
             }
         }
     }
 
-    let mut promoted: Vec<ClusterEntry> = seen
+    let mut promoted: Vec<Cluster> = buckets
         .into_values()
-        .filter(|e| e.pages_seen.len() >= page_threshold)
+        .flatten()
+        .filter(|c| c.pages_seen.len() >= page_threshold)
         .collect();
-    promoted.sort_by_key(|e| e.first_seen);
-    promoted.into_iter().map(|e| e.bitmap).collect()
+    promoted.sort_by_key(|c| c.first_seen);
+    promoted.into_iter().map(|c| c.rep).collect()
 }
 
 /// Encode a multi-page bilevel document as a bundled DJVM with a shared Djbz.
@@ -1019,10 +1070,18 @@ pub(crate) fn cluster_shared_symbols(pages: &[Bitmap], page_threshold: usize) ->
 ///
 /// [`Jb2Dict`]: crate::jb2::Jb2Dict
 pub fn encode_djvm_bundle_jb2(pages: &[Bitmap], shared_dict_page_threshold: usize) -> Vec<u8> {
+    let shared = cluster_shared_symbols(pages, shared_dict_page_threshold);
+    encode_djvm_bundle_jb2_with_shared(pages, &shared)
+}
+
+/// Same as [`encode_djvm_bundle_jb2`] but uses a caller-supplied shared
+/// dictionary instead of running [`cluster_shared_symbols`]. Lets callers
+/// drive cluster selection (e.g. corpus benchmarks measuring different
+/// Hamming thresholds) while reusing the IFF/DIRM emission logic.
+pub fn encode_djvm_bundle_jb2_with_shared(pages: &[Bitmap], shared: &[Bitmap]) -> Vec<u8> {
     use crate::iff;
 
-    let shared = cluster_shared_symbols(pages, shared_dict_page_threshold);
-    let djbz_bytes = encode_jb2_djbz(&shared);
+    let djbz_bytes = encode_jb2_djbz(shared);
 
     // ── Build component buffers (each = full FORM body, ready for IFF emit) ──
     //
@@ -1033,7 +1092,8 @@ pub fn encode_djvm_bundle_jb2(pages: &[Bitmap], shared_dict_page_threshold: usiz
     let mut comp_form_bodies: Vec<(Vec<u8>, /*is_page*/ bool, String)> = Vec::new();
 
     let dict_id = "dict0001.djvi".to_string();
-    if !shared.is_empty() {
+    let has_shared = !shared.is_empty();
+    if has_shared {
         let mut djvi_body = Vec::new();
         djvi_body.extend_from_slice(b"DJVI");
         djvi_body.extend_from_slice(b"Djbz");
@@ -1045,7 +1105,7 @@ pub fn encode_djvm_bundle_jb2(pages: &[Bitmap], shared_dict_page_threshold: usiz
         comp_form_bodies.push((djvi_body, false, dict_id.clone()));
     }
 
-    let shared_ref: &[Bitmap] = &shared;
+    let shared_ref: &[Bitmap] = shared;
     for (page_idx, page) in pages.iter().enumerate() {
         let sjbz = encode_jb2_dict_with_shared(page, shared_ref);
         let mut info = Vec::with_capacity(10);
@@ -1061,7 +1121,7 @@ pub fn encode_djvm_bundle_jb2(pages: &[Bitmap], shared_dict_page_threshold: usiz
         if !info.len().is_multiple_of(2) {
             djvu_body.push(0);
         }
-        if !shared.is_empty() {
+        if has_shared {
             let incl_payload = dict_id.as_bytes();
             djvu_body.extend_from_slice(b"INCL");
             djvu_body.extend_from_slice(&(incl_payload.len() as u32).to_be_bytes());
@@ -1432,7 +1492,7 @@ mod tests {
     fn dict_letter_like_shapes() {
         // Two disconnected 3×5 rectangles — should dedup to 1 symbol.
         let src = make_bitmap(32, 32, |x, y| {
-            (x < 3 && y < 5) || (x >= 20 && x < 23 && y >= 10 && y < 15)
+            (x < 3 && y < 5) || ((20..23).contains(&x) && (10..15).contains(&y))
         });
         let decoded = roundtrip_dict(&src);
         assert_bitmaps_eq(&src, &decoded);
@@ -1490,8 +1550,8 @@ mod tests {
         // 3 non-touching black squares.
         let src = make_bitmap(30, 30, |x, y| {
             (x < 3 && y < 3)
-                || (x >= 10 && x < 13 && y >= 10 && y < 13)
-                || (x >= 25 && x < 28 && y >= 25 && y < 28)
+                || ((10..13).contains(&x) && (10..13).contains(&y))
+                || ((25..28).contains(&x) && (25..28).contains(&y))
         });
         let ccs = extract_ccs(&src);
         assert_eq!(ccs.len(), 3);
@@ -1739,6 +1799,47 @@ mod tests {
         // A glyph is 4×5.
         assert_eq!(shared[0].width, 4);
         assert_eq!(shared[0].height, 5);
+    }
+
+    fn glyph_box8() -> Vec<&'static [u8]> {
+        vec![
+            b"########" as &[u8],
+            b"#      #" as &[u8],
+            b"#      #" as &[u8],
+            b"#      #" as &[u8],
+            b"#      #" as &[u8],
+            b"#      #" as &[u8],
+            b"#      #" as &[u8],
+            b"########" as &[u8],
+        ]
+    }
+
+    #[test]
+    fn cluster_tunable_groups_near_duplicate_large_glyphs() {
+        // 8×8 = 64 pixels (>= REFINEMENT_MIN_PIXELS=32). With diff_fraction=4%,
+        // max_diff = 64*4/100 = 2 bits. A glyph and its 1-bit-perturbed twin
+        // must cluster into one rep when Hamming clustering is opted into.
+        // Default (byte-exact) ships off — see Phase 2 calibration in CLAUDE.md.
+        //
+        // Use box outlines with one outline-pixel removed (so the noise alters
+        // the same CC instead of producing a stray 1-pixel CC).
+        let mut p1 = Bitmap::new(20, 20);
+        render_glyph(&mut p1, 4, 4, &glyph_box8());
+        p1.set(5, 4, false); // notch the top edge at x=5
+        let mut p2 = Bitmap::new(20, 20);
+        render_glyph(&mut p2, 4, 4, &glyph_box8());
+        p2.set(6, 4, false); // notch at x=6 instead — different bit
+
+        let shared = cluster_shared_symbols_tunable(&[p1.clone(), p2.clone()], 2, 4);
+        assert_eq!(shared.len(), 1, "near-duplicate twins should cluster at 4%");
+
+        // Default (byte-exact) keeps them separate — neither passes
+        // page_threshold=2 since each variant only appears on one page.
+        let shared_exact = cluster_shared_symbols(&[p1, p2], 2);
+        assert!(
+            shared_exact.is_empty(),
+            "byte-exact default must not promote noisy near-dupes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 2 of #194 explored cross-page Hamming-distance clustering for the shared Djbz dictionary (vs Phase 1's byte-exact dedup). **Result: Hamming clustering does not improve on byte-exact** on real cjb2 scan corpora — the per-page intra-CC refinement matcher from #188 Phase 3 already captures the near-duplicate win within each page.

This PR ships the measurement infrastructure and a tunable knob for future calibration work, but keeps the shipped default at `diff_fraction = 0` (byte-exact, which is the entire −13.0% win).

### Numbers (M1 Max, `pathogenic_bacteria_1896.djvu`, 517 pages)

| `--diff-fraction` | bundle / independent | round-trip |
|-------------------|----------------------|------------|
| 0 (byte-exact, shipped) | **0.870× (−13.0%)** | ✓ |
| 1% | 0.870× (−13.0%) | ✓ |
| 2% | 0.871× (−12.9%) | ✓ |
| 3% | — | ✗ rec-6 mismatch |
| 4% | 0.877× (−12.3%) | ✓ |

Full investigation in `CLAUDE.md` — section "#194 Phase 2 — multi-page shared Djbz with Hamming clustering".

## Changes

- **`src/jb2_encode.rs`**:
  - `cluster_shared_symbols_tunable(pages, page_threshold, diff_fraction)` — new pub fn, bucketed `(w,h)` Hamming clustering.
  - `cluster_shared_symbols` — promoted from `pub(crate)` to `pub`, now delegates to `cluster_shared_symbols_tunable(.., 0)`.
  - `encode_djvm_bundle_jb2_with_shared(pages, &shared)` — new pub fn, factored out of `encode_djvm_bundle_jb2` so callers can drive cluster selection.
- **`examples/encode_quality_djbz.rs`** — new multi-page corpus harness with `--threshold N` / `--diff-fraction P` flags; per-file JSON + summary table + bundle round-trip verification.
- **`CLAUDE.md`** — Phase 2 investigation log: calibration table, root-cause hypothesis, open follow-ups.

## Open follow-ups

- `diff_fraction = 3%` rec-6 round-trip mismatch on the 517-page corpus is a real refinement-matcher bug against shared reps — should file as a sub-issue. Doesn't block this PR (default = 0% remains lossless).
- Per-CC profitability model instead of flat Hamming fraction (would need a corpus where intra-page refinement is exhausted).

## Test plan

- [x] `cargo test --release --workspace` (489 passed, 6 ignored)
- [x] `cargo clippy --release --workspace --lib --tests --bins -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cluster_tunable_groups_near_duplicate_large_glyphs` exercises both default (byte-exact) and tunable (4%) paths
- [x] Bundle round-trip verified pixel-exact on `pathogenic_bacteria_1896.djvu` (517 pages) at 0%/1%/2%/4% Hamming

🤖 Generated with [Claude Code](https://claude.com/claude-code)