### PR TITLE
chore: gitignore local dev cruft (.DS_Store, profile dumps, stray binaries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,22 @@ Cargo.lock
 scripts/djvulibre_bench
 scripts/djvulibre_bench_ci
 examples/wasm/pkg/
+
+# macOS Finder metadata
+.DS_Store
+
+# Local profiling output (samply, perf, custom JSON dumps)
+/profile.json.gz
+/profile_*.json
+/profile_*.json.gz
+
+# Stray dev artefacts (accidental render output, ad-hoc binaries)
+/0
+/rust_out
+
+# Local debug/profiling examples kept out-of-tree
+/examples/_debug_*.rs
+
+# Claude Code local state (user-specific, never shared)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Adds `.gitignore` patterns for files that accumulate in working trees but should never be committed. No tracked files matched the new patterns (verified via `git ls-files | grep ...`).

## Patterns added

- `.DS_Store` (recursive) — macOS Finder metadata
- `/profile.json.gz`, `/profile_*.json[.gz]` — samply / custom profiling output
- `/0`, `/rust_out` — accidental render output and ad-hoc binaries
- `/examples/_debug_*.rs` — convention for local repro/debug examples
- `.claude/settings.local.json`, `.claude/scheduled_tasks.lock` — Claude Code local state

## Test plan

- [x] `git status --short` no longer shows the cruft files
- [x] `git ls-files` confirms no previously-tracked file would be silently re-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)