### PR TITLE
feat(async): load_document_async — buffered AsyncRead constructor (#196 Phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ miniz_oxide = { version = "0.8", optional = true }
 zune-jpeg = { version = "0.5", optional = true }
 tiff = { version = "0.9", optional = true }
 jpeg-encoder = { version = "0.6", optional = true }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"], optional = true }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "io-util", "fs"], optional = true }
 async-stream = { version = "0.3", optional = true }
 futures-core = { version = "0.3", optional = true }
 rayon = { version = "1", optional = true }

--- a/src/djvu_async.rs
+++ b/src/djvu_async.rs
@@ -45,13 +45,15 @@
 
 use std::sync::Arc;
 
+use tokio::io::{AsyncRead, AsyncReadExt};
+
 use crate::{
-    djvu_document::DjVuPage,
+    djvu_document::{DjVuDocument, DjVuPage, DocError},
     djvu_render::{self, RenderError, RenderOptions},
     pixmap::{GrayPixmap, Pixmap},
 };
 
-// ── Error type ────────────────────────────────────────────────────────────────
+// ── Error types ───────────────────────────────────────────────────────────────
 
 /// Errors from async rendering.
 #[derive(Debug, thiserror::Error)]
@@ -63,6 +65,54 @@ pub enum AsyncRenderError {
     /// The blocking task was cancelled or panicked.
     #[error("spawn_blocking join error: {0}")]
     Join(String),
+}
+
+/// Errors from async document loading.
+#[derive(Debug, thiserror::Error)]
+pub enum AsyncLoadError {
+    /// I/O error from the underlying async reader.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The buffered bytes failed to parse as a DjVu document.
+    #[error("parse error: {0}")]
+    Parse(#[from] DocError),
+}
+
+// ── Async document loader ─────────────────────────────────────────────────────
+
+/// Asynchronously load and parse a DjVu document from any [`AsyncRead`].
+///
+/// **Phase 1 of #196.** Convenience constructor that buffers the full reader
+/// into memory before handing the bytes to [`DjVuDocument::parse`]. Memory
+/// still peaks at full file size, but removes the synchronous `std::fs::read`
+/// boundary at the call site — works directly with [`tokio::fs::File`], HTTP
+/// body streams, S3 GetObject, etc.
+///
+/// Phases 2/3 will add genuine streaming: Phase 2 reads only the IFF
+/// header and DIRM up front and exposes per-page byte offsets; Phase 3
+/// makes [`DjVuDocument::page`] async and fetches each page's bytes on
+/// demand (HTTP Range requests, etc.).
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use djvu_rs::djvu_async::load_document_async;
+/// use tokio::fs::File;
+///
+/// let file = File::open("document.djvu").await?;
+/// let doc = load_document_async(file).await?;
+/// println!("loaded {} pages", doc.page_count());
+/// # Ok(()) }
+/// ```
+pub async fn load_document_async<R>(mut reader: R) -> Result<DjVuDocument, AsyncLoadError>
+where
+    R: AsyncRead + Unpin + Send,
+{
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).await?;
+    Ok(DjVuDocument::parse(&buf)?)
 }
 
 // ── Async render functions ────────────────────────────────────────────────────
@@ -376,6 +426,81 @@ mod tests {
         assert_eq!(
             count, expected_count,
             "frame count must equal BG44 chunk count"
+        );
+    }
+
+    // ── load_document_async tests ────────────────────────────────────────────
+
+    /// `load_document_async` over `tokio::fs::File` matches `DjVuDocument::parse`.
+    #[tokio::test]
+    async fn load_document_async_matches_sync_parse() {
+        let path = assets_path().join("chicken.djvu");
+        let file = tokio::fs::File::open(&path)
+            .await
+            .expect("open must succeed");
+        let async_doc = load_document_async(file)
+            .await
+            .expect("async load must succeed");
+
+        let sync_data = std::fs::read(&path).expect("sync read must succeed");
+        let sync_doc = DjVuDocument::parse(&sync_data).expect("sync parse must succeed");
+
+        assert_eq!(async_doc.page_count(), sync_doc.page_count());
+        for i in 0..sync_doc.page_count() {
+            let a = async_doc.page(i).expect("async page");
+            let s = sync_doc.page(i).expect("sync page");
+            assert_eq!(a.width(), s.width());
+            assert_eq!(a.height(), s.height());
+        }
+    }
+
+    /// `load_document_async` works with an in-memory `&[u8]` reader (e.g. HTTP body).
+    #[tokio::test]
+    async fn load_document_async_from_in_memory_reader() {
+        let path = assets_path().join("chicken.djvu");
+        let bytes = std::fs::read(&path).expect("read");
+
+        // `&[u8]` implements AsyncRead via tokio's blanket impl on slices.
+        let reader = std::io::Cursor::new(bytes.clone());
+        let doc = load_document_async(reader)
+            .await
+            .expect("async load from cursor must succeed");
+        assert!(doc.page_count() > 0);
+    }
+
+    /// Truncated / non-DjVu bytes surface as `AsyncLoadError::Parse`, not panic.
+    #[tokio::test]
+    async fn load_document_async_propagates_parse_error() {
+        let bogus = b"not a djvu file at all".to_vec();
+        let reader = std::io::Cursor::new(bogus);
+        let err = load_document_async(reader)
+            .await
+            .expect_err("must fail to parse garbage");
+        assert!(
+            matches!(err, AsyncLoadError::Parse(_)),
+            "expected Parse error, got {err:?}"
+        );
+    }
+
+    /// I/O failure surfaces as `AsyncLoadError::Io`, not panic.
+    #[tokio::test]
+    async fn load_document_async_propagates_io_error() {
+        struct FailingReader;
+        impl tokio::io::AsyncRead for FailingReader {
+            fn poll_read(
+                self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                _buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                std::task::Poll::Ready(Err(std::io::Error::other("simulated I/O failure")))
+            }
+        }
+        let err = load_document_async(FailingReader)
+            .await
+            .expect_err("must fail on I/O error");
+        assert!(
+            matches!(err, AsyncLoadError::Io(_)),
+            "expected Io error, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of #196 (async streaming decode). Adds a convenience constructor that loads + parses a DjVu document from any `AsyncRead` source without forcing the caller through a sync `std::fs::read` boundary. Memory still peaks at file size — Phase 2 will add real DIRM-head streaming, Phase 3 per-page lazy load via `AsyncSeek`.

See [the design comment on #196](https://github.com/matyushkin/djvu-rs/issues/196#issuecomment-4331893448) for why this is the right phasing (audit shows `DjVuDocument` already owns its bytes and carries no lifetime parameters, so Phase 1 needs zero type refactoring; Phase 3 needs significant ownership-model changes deferred to a separate issue).

## API

```rust
pub async fn load_document_async<R>(reader: R) -> Result<DjVuDocument, AsyncLoadError>
where R: AsyncRead + Unpin + Send;

pub enum AsyncLoadError {
    Io(std::io::Error),       // from the underlying reader
    Parse(DocError),          // from DjVuDocument::parse on the buffered bytes
}
```

Use case:
```rust
use djvu_rs::djvu_async::load_document_async;
use tokio::fs::File;

let file = File::open("document.djvu").await?;
let doc = load_document_async(file).await?;
```

## Changes

- `src/djvu_async.rs`: new `load_document_async` + `AsyncLoadError` + 4 test cases.
- `Cargo.toml`: tokio gets `io-util` + `fs` features (only pulled when `--features async`).
- `src/jb2_encode.rs`: drive-by — replaces 6 `manual_range_contains` patterns in pre-existing tests with `(a..b).contains(&x)`. **Identical to the same fix in #219**; rebase will be a clean overlap regardless of merge order.

## Test plan

- [x] `cargo test --release --features async --lib djvu_async` → 12 passed (8 existing render tests + 4 new loader tests):
  - `load_document_async_matches_sync_parse` — `tokio::fs::File` matches sync `DjVuDocument::parse`
  - `load_document_async_from_in_memory_reader` — works over `std::io::Cursor` (HTTP body case)
  - `load_document_async_propagates_parse_error` — bogus bytes surface as `AsyncLoadError::Parse`
  - `load_document_async_propagates_io_error` — custom failing `AsyncRead` impl surfaces as `AsyncLoadError::Io`
- [x] `cargo nextest run --workspace --exclude djvu-py --features cli --filter-expr 'not (binary(pdf_conversion) or test(iw44_new_decode_big))'` → 471 passed, 6 skipped (mirrors CI fast suite)
- [x] `cargo clippy --workspace --lib --tests --bins -- -D warnings` clean
- [x] `cargo fmt --check` clean

## Phase 2/3 follow-ups (separate issues to file later)

- **Phase 2**: stream IFF header + DIRM via `read_exact`, expose per-page byte offsets as document metadata. Foundation for HTTP Range requests.
- **Phase 3**: `DjVuDocument::page` becomes async, holds `Arc<Mutex<R>>`, DJVI cache becomes `Arc<RwLock<…>>`. Touches 4–6 files; breaks `Clone` semantics; needs careful WASM gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)