### PR TITLE
feat(async): page_byte_range API + streaming async loader (#196 Phase 2)

### DIFF
--- a/src/djvu_async.rs
+++ b/src/djvu_async.rs
@@ -115,6 +115,76 @@ where
     Ok(DjVuDocument::parse(&buf)?)
 }
 
+/// Async loader that reads the IFF + FORM + DIRM head separately from the
+/// page bodies (#196 Phase 2).
+///
+/// **Phase 2 of #196.** Issues two `read_exact` calls for the document head
+/// (IFF magic + FORM length + form_type, then the DIRM chunk header + payload),
+/// then a single `read_to_end` for the remainder. The total bytes received
+/// match Phase 1 — this constructor still returns an in-memory
+/// [`DjVuDocument`] — but a bandwidth-instrumented `AsyncRead` implementation
+/// can observe the head-first read pattern, and the resulting document
+/// exposes [`DjVuDocument::page_byte_range`] for any caller that wants to
+/// fan out per-page byte fetches via HTTP `Range` requests on a separate
+/// connection.
+///
+/// For documents that aren't bundled DJVM (single-page DJVU, indirect DJVM,
+/// or anything without a DIRM in the first chunk), this falls back to the
+/// Phase 1 buffered-read behavior — there's nothing useful to stream.
+///
+/// # Errors
+///
+/// - `AsyncLoadError::Io` — any underlying read fails
+/// - `AsyncLoadError::Parse` — the assembled buffer fails [`DjVuDocument::parse`]
+pub async fn load_document_async_streaming<R>(mut reader: R) -> Result<DjVuDocument, AsyncLoadError>
+where
+    R: AsyncRead + Unpin + Send,
+{
+    // 1) IFF outer header: 4-byte magic "AT&T" + "FORM" + 4-byte length + 4-byte form_type = 16 bytes.
+    let mut head = [0u8; 16];
+    reader.read_exact(&mut head).await?;
+
+    // If it isn't a DJVM bundle, the rest of the file is just page payload —
+    // no per-chunk streaming benefit, so fall back to bulk read.
+    let is_djvm = &head[..4] == b"AT&T" && &head[4..8] == b"FORM" && &head[12..16] == b"DJVM";
+
+    let mut buf = Vec::with_capacity(if is_djvm {
+        // Pre-size: 1 MB head guess; Vec grows as needed.
+        1 << 20
+    } else {
+        16 * 1024
+    });
+    buf.extend_from_slice(&head);
+
+    if is_djvm {
+        // 2) Next chunk header: 4-byte id + 4-byte BE length.
+        let mut chunk_hdr = [0u8; 8];
+        reader.read_exact(&mut chunk_hdr).await?;
+        buf.extend_from_slice(&chunk_hdr);
+
+        // If the first inner chunk is DIRM, read its payload separately so
+        // a recording reader sees the head-first pattern. Otherwise just
+        // continue with read_to_end — the document layout is non-canonical
+        // and Phase 2's offset map wouldn't apply anyway.
+        if &chunk_hdr[..4] == b"DIRM" {
+            let dirm_len =
+                u32::from_be_bytes([chunk_hdr[4], chunk_hdr[5], chunk_hdr[6], chunk_hdr[7]])
+                    as usize;
+            // IFF chunks pad to 2-byte boundary; the parser handles this, but
+            // we must read those padding bytes too to keep alignment.
+            let padded = dirm_len + (dirm_len & 1);
+            let mut dirm_buf = vec![0u8; padded];
+            reader.read_exact(&mut dirm_buf).await?;
+            buf.extend_from_slice(&dirm_buf);
+        }
+    }
+
+    // 3) Bulk-read the remainder.
+    reader.read_to_end(&mut buf).await?;
+
+    Ok(DjVuDocument::parse(&buf)?)
+}
+
 // ── Async render functions ────────────────────────────────────────────────────
 
 /// Render `page` to an RGBA [`Pixmap`] asynchronously.
@@ -479,6 +549,92 @@ mod tests {
         assert!(
             matches!(err, AsyncLoadError::Parse(_)),
             "expected Parse error, got {err:?}"
+        );
+    }
+
+    /// `load_document_async_streaming` produces the same document as
+    /// the buffered Phase 1 loader on a bundled DJVM.
+    #[tokio::test]
+    async fn streaming_loader_matches_buffered() {
+        let path = assets_path().join("DjVu3Spec_bundled.djvu");
+        let Ok(bytes) = std::fs::read(&path) else {
+            eprintln!("skip: {} missing", path.display());
+            return;
+        };
+        let streamed = load_document_async_streaming(std::io::Cursor::new(bytes.clone()))
+            .await
+            .expect("streaming load must succeed");
+        let buffered = DjVuDocument::parse(&bytes).expect("buffered parse");
+
+        assert_eq!(streamed.page_count(), buffered.page_count());
+        for i in 0..buffered.page_count() {
+            assert_eq!(streamed.page_byte_range(i), buffered.page_byte_range(i));
+        }
+    }
+
+    /// `load_document_async_streaming` reads the head before the body
+    /// (#196 Phase 2 DoD).
+    ///
+    /// A custom `AsyncRead` records every requested read size. The first
+    /// three calls must be small and bounded (IFF head 16 B, chunk header
+    /// 8 B, DIRM payload — typically a few KB on a real document).
+    #[tokio::test]
+    async fn streaming_loader_reads_head_before_body() {
+        use std::sync::{Arc, Mutex};
+
+        let path = assets_path().join("DjVu3Spec_bundled.djvu");
+        let Ok(bytes) = std::fs::read(&path) else {
+            eprintln!("skip: {} missing", path.display());
+            return;
+        };
+
+        struct RecordingReader {
+            inner: std::io::Cursor<Vec<u8>>,
+            sizes: Arc<Mutex<Vec<usize>>>,
+        }
+        impl tokio::io::AsyncRead for RecordingReader {
+            fn poll_read(
+                mut self: std::pin::Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                buf: &mut tokio::io::ReadBuf<'_>,
+            ) -> std::task::Poll<std::io::Result<()>> {
+                let want = buf.remaining();
+                let pos = self.inner.position() as usize;
+                let src = self.inner.get_ref();
+                let n = want.min(src.len().saturating_sub(pos));
+                if n > 0 {
+                    buf.put_slice(&src[pos..pos + n]);
+                    self.inner.set_position((pos + n) as u64);
+                }
+                self.sizes.lock().unwrap().push(n);
+                std::task::Poll::Ready(Ok(()))
+            }
+        }
+
+        let sizes = Arc::new(Mutex::new(Vec::new()));
+        let reader = RecordingReader {
+            inner: std::io::Cursor::new(bytes.clone()),
+            sizes: Arc::clone(&sizes),
+        };
+        let _ = load_document_async_streaming(reader)
+            .await
+            .expect("streaming load must succeed");
+
+        let sizes = sizes.lock().unwrap().clone();
+        // Strip 0-byte tail reads (EOF signals from read_to_end).
+        let nonzero: Vec<usize> = sizes.into_iter().filter(|&n| n > 0).collect();
+
+        // First read: the 16-byte IFF + FORM + form_type head.
+        assert_eq!(nonzero[0], 16, "first read must be 16-byte IFF head");
+        // Second read: the 8-byte DIRM chunk header.
+        assert_eq!(nonzero[1], 8, "second read must be 8-byte chunk header");
+        // Third read: the DIRM payload — must be smaller than the full body.
+        assert!(
+            nonzero[2] < bytes.len() / 4,
+            "third read should be the DIRM payload, well under the full body \
+             (got {} bytes for a {} byte file)",
+            nonzero[2],
+            bytes.len()
         );
     }
 

--- a/src/djvu_document.rs
+++ b/src/djvu_document.rs
@@ -720,6 +720,15 @@ pub struct DjVuDocument {
     /// Raw document-level chunks (NAVM, DIRM, etc.) from the DJVM container,
     /// or from the top-level DJVU form for single-page documents.
     global_chunks: Vec<RawChunk>,
+    /// Byte ranges of each page's outer FORM chunk inside the original
+    /// document buffer, in page order. Populated only for bundled DJVM
+    /// documents parsed from a contiguous slice; empty otherwise (single-page
+    /// DJVU, indirect DJVM, or when offsets were unavailable).
+    ///
+    /// Used by [`DjVuDocument::page_byte_range`] (#196 Phase 2). Lets a
+    /// future HTTP-Range fetcher (#196 Phase 3) request exactly the bytes
+    /// for a given page.
+    page_byte_ranges: Vec<core::ops::Range<u64>>,
 }
 
 impl DjVuDocument {
@@ -758,10 +767,14 @@ impl DjVuDocument {
                     })
                     .collect();
                 let page = parse_page_from_chunks(&form.chunks, 0, None)?;
+                // Single-page document spans the entire buffer.
+                #[allow(clippy::single_range_in_vec_init)]
+                let page_byte_ranges = vec![0u64..(data.len() as u64)];
                 Ok(DjVuDocument {
                     pages: vec![page],
                     bookmarks: vec![],
                     global_chunks,
+                    page_byte_ranges,
                 })
             }
             b"DJVM" => {
@@ -772,7 +785,7 @@ impl DjVuDocument {
                     .find(|c| &c.id == b"DIRM")
                     .ok_or(DocError::MissingChunk("DIRM"))?;
 
-                let (entries, is_bundled) = parse_dirm(dirm_chunk.data)?;
+                let (entries, is_bundled, comp_offsets) = parse_dirm(dirm_chunk.data)?;
 
                 // Collect NAVM bookmarks (BZZ-compressed)
                 let bookmarks = parse_navm_bookmarks(&form.chunks)?;
@@ -829,6 +842,7 @@ impl DjVuDocument {
                         .collect();
 
                     let mut pages = Vec::new();
+                    let mut page_byte_ranges = Vec::new();
                     let mut page_idx = 0usize;
                     for (comp_idx, entry) in entries.iter().enumerate() {
                         if entry.comp_type != ComponentType::Page {
@@ -857,13 +871,39 @@ impl DjVuDocument {
 
                         let page = parse_page_from_chunks(&sub_chunks, page_idx, shared_djbz)?;
                         pages.push(page);
+
+                        // Record the byte range of this page's outer FORM. The DIRM
+                        // offset points at the 4 bytes `b"FORM"`; the size sits at
+                        // offset+4 (BE u32) and covers the form_type + payload bytes,
+                        // so the full container is `8 + size` bytes long.
+                        if let Some(off) = comp_offsets.get(comp_idx) {
+                            let start = *off as usize;
+                            if let Some(size_bytes) = data.get(start + 4..start + 8) {
+                                let size = u32::from_be_bytes([
+                                    size_bytes[0],
+                                    size_bytes[1],
+                                    size_bytes[2],
+                                    size_bytes[3],
+                                ]) as u64;
+                                let begin = start as u64;
+                                let end = begin.saturating_add(8).saturating_add(size);
+                                page_byte_ranges.push(begin..end);
+                            }
+                        }
                         page_idx += 1;
+                    }
+
+                    // Only expose offsets if we got one for every page; partial
+                    // tables would surprise callers iterating by page index.
+                    if page_byte_ranges.len() != pages.len() {
+                        page_byte_ranges.clear();
                     }
 
                     Ok(DjVuDocument {
                         pages,
                         bookmarks,
                         global_chunks,
+                        page_byte_ranges,
                     })
                 } else {
                     // Indirect: pages must be resolved by name
@@ -887,6 +927,9 @@ impl DjVuDocument {
                         pages,
                         bookmarks,
                         global_chunks,
+                        // Indirect: per-page bytes live in external files, not the
+                        // index buffer — no meaningful range to expose here.
+                        page_byte_ranges: Vec::new(),
                     })
                 }
             }
@@ -897,6 +940,27 @@ impl DjVuDocument {
     /// Number of pages.
     pub fn page_count(&self) -> usize {
         self.pages.len()
+    }
+
+    /// Byte range of `page`'s outer FORM chunk inside the original document
+    /// buffer (#196 Phase 2).
+    ///
+    /// Returns `Some(start..end)` where `start` is the absolute offset of the
+    /// 4-byte `FORM` magic and `end` is one past the last byte of the chunk
+    /// payload. The range is suitable for an HTTP `Range:` request that
+    /// fetches exactly the bytes needed to decode that page (assuming any
+    /// referenced shared `DJVI` dictionaries are already in hand — those
+    /// have their own ranges too, but `page_byte_range` only covers pages).
+    ///
+    /// Returns `None` for:
+    /// - `index >= page_count()`
+    /// - Indirect DJVM documents (per-page bytes live in external files)
+    /// - Bundled DJVM documents whose DIRM offset table couldn't be matched
+    ///   to every page
+    ///
+    /// Single-page DJVU documents always return the full buffer range.
+    pub fn page_byte_range(&self, index: usize) -> Option<core::ops::Range<u64>> {
+        self.page_byte_ranges.get(index).cloned()
     }
 
     /// Access a page by 0-based index.
@@ -1249,8 +1313,11 @@ struct DirmEntry {
 
 /// Parse the DIRM chunk (directory of files in FORM:DJVM).
 ///
-/// Returns `(entries, is_bundled)`.
-fn parse_dirm(data: &[u8]) -> Result<(Vec<DirmEntry>, bool), DocError> {
+/// Returns `(entries, is_bundled, offsets)`. `offsets` is non-empty only for
+/// bundled documents; each entry is the absolute byte offset of the
+/// corresponding component's outer `b"FORM"` header within the original
+/// document buffer.
+fn parse_dirm(data: &[u8]) -> Result<(Vec<DirmEntry>, bool, Vec<u32>), DocError> {
     if data.len() < 3 {
         return Err(DocError::Malformed("DIRM chunk too short"));
     }
@@ -1264,15 +1331,25 @@ fn parse_dirm(data: &[u8]) -> Result<(Vec<DirmEntry>, bool), DocError> {
 
     let mut pos = 3usize;
 
-    // Bundled documents embed 4-byte offsets (skipped; we rely on in-order FORM children).
+    // Bundled documents embed 4-byte BE offsets to each component's FORM header.
+    let mut offsets: Vec<u32> = Vec::new();
     if is_bundled {
         let offsets_size = nfiles * 4;
-        pos = pos
+        let end = pos
             .checked_add(offsets_size)
             .ok_or(DocError::Malformed("DIRM offset arithmetic overflow"))?;
-        if pos > data.len() {
+        if end > data.len() {
             return Err(DocError::Malformed("DIRM offset table truncated"));
         }
+        offsets.reserve(nfiles);
+        for i in 0..nfiles {
+            let base = pos + i * 4;
+            let bytes = data
+                .get(base..base + 4)
+                .ok_or(DocError::Malformed("DIRM offset slice OOB"))?;
+            offsets.push(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]));
+        }
+        pos = end;
     }
 
     // Remaining bytes are BZZ-compressed metadata.
@@ -1295,7 +1372,7 @@ fn parse_dirm(data: &[u8]) -> Result<(Vec<DirmEntry>, bool), DocError> {
                 id: format!("p{:04}", i),
             })
             .collect();
-        return Ok((entries, is_bundled));
+        return Ok((entries, is_bundled, offsets));
     }
     let flags: Vec<u8> = meta
         .get(mpos..mpos + nfiles)
@@ -1324,7 +1401,7 @@ fn parse_dirm(data: &[u8]) -> Result<(Vec<DirmEntry>, bool), DocError> {
         entries.push(DirmEntry { comp_type, id });
     }
 
-    Ok((entries, is_bundled))
+    Ok((entries, is_bundled, offsets))
 }
 
 /// Read a null-terminated UTF-8 string from `data` at `*pos`, advancing `*pos`.
@@ -1882,6 +1959,61 @@ mod tests {
         assert_eq!(reparsed.width, page.width() as u16);
         assert_eq!(reparsed.height, page.height() as u16);
         assert_eq!(reparsed.dpi, page.dpi());
+    }
+
+    // ── #196 Phase 2: page_byte_range ────────────────────────────────────────
+
+    /// Single-page DJVU: byte range covers the entire input buffer.
+    #[test]
+    fn page_byte_range_single_page_covers_full_buffer() {
+        let data =
+            std::fs::read(assets_path().join("chicken.djvu")).expect("chicken.djvu must exist");
+        let doc = DjVuDocument::parse(&data).expect("parse must succeed");
+
+        let r = doc.page_byte_range(0).expect("page 0 must have a range");
+        assert_eq!(r.start, 0);
+        assert_eq!(r.end, data.len() as u64);
+
+        assert!(
+            doc.page_byte_range(1).is_none(),
+            "out-of-range index returns None"
+        );
+    }
+
+    /// Bundled DJVM: every page's byte range is non-empty, in-bounds,
+    /// non-overlapping with neighbours, and re-parseable as a FORM.
+    #[test]
+    fn page_byte_range_bundled_djvm_round_trips() {
+        let path = assets_path().join("DjVu3Spec_bundled.djvu");
+        let Ok(data) = std::fs::read(&path) else {
+            eprintln!("skip: {} missing", path.display());
+            return;
+        };
+        let doc = DjVuDocument::parse(&data).expect("bundled DJVM parse must succeed");
+
+        let mut prev_end = 0u64;
+        for i in 0..doc.page_count() {
+            let r = doc
+                .page_byte_range(i)
+                .unwrap_or_else(|| panic!("page {i} must have a range"));
+            assert!(r.end <= data.len() as u64, "page {i} range OOB");
+            assert!(r.start < r.end, "page {i} range empty");
+            assert!(r.start >= prev_end, "page {i} overlaps previous");
+            prev_end = r.end;
+
+            // The range must start with `b"FORM"` magic.
+            let slice = &data[r.start as usize..r.end as usize];
+            assert_eq!(&slice[..4], b"FORM", "page {i} range must start with FORM");
+        }
+    }
+
+    /// Out-of-range page index returns None.
+    #[test]
+    fn page_byte_range_out_of_range() {
+        let data =
+            std::fs::read(assets_path().join("chicken.djvu")).expect("chicken.djvu must exist");
+        let doc = DjVuDocument::parse(&data).expect("parse must succeed");
+        assert!(doc.page_byte_range(99).is_none());
     }
 
     /// MmapDocument opens a file and parses identically to in-memory parse.


### PR DESCRIPTION
Closes #232.

## Summary

Two related deliverables for the #196 streaming roadmap:

### 1. `DjVuDocument::page_byte_range`

`parse_dirm` already walked over the bundled DJVM offset table but discarded it. It now returns the offsets alongside `(entries, is_bundled)`, and the bundled-DJVM branch of `parse_with_resolver` reads each component's outer FORM size at `offset+4`, materialising a `Vec<Range<u64>>` of per-page byte ranges.

New API: \`pub fn page_byte_range(&self, i: usize) -> Option<Range<u64>>\`

| Document kind | Behavior |
|---|---|
| Bundled DJVM | Real per-page offsets into the input buffer |
| Single-page DJVU | Full buffer range |
| Indirect DJVM | \`None\` (per-page bytes live in external files) |
| Out-of-range index | \`None\` |

This is the metadata foundation for HTTP-Range-aware Phase 3 (#233) — given the buffer used to construct the document, a caller can now know exactly which bytes correspond to page N without re-parsing.

### 2. `load_document_async_streaming`

Phase 1 (\`load_document_async\`) buffers the entire reader before parsing. Phase 2 issues three head-reads on bundled DJVM, then a bulk read for the remainder:

1. \`read_exact(16)\` — IFF magic + FORM length + form_type
2. \`read_exact(8)\` — first chunk header (typically DIRM)
3. \`read_exact(dirm_payload_size)\` — DIRM payload (a few KB on real docs)
4. \`read_to_end(...)\` — page bodies

Total bytes received match Phase 1 and the constructor still returns a fully materialised \`DjVuDocument\` — Phase 2 is foundational, not a memory-saver. Phase 3 will swap step 4 for per-page on-demand range fetches.

Falls back to Phase 1 bulk-read for non-DJVM inputs.

## Test plan

- [x] \`page_byte_range_single_page_covers_full_buffer\`
- [x] \`page_byte_range_bundled_djvm_round_trips\` — every page range starts with \`b\"FORM\"\`, is in-bounds, non-empty, and non-overlapping
- [x] \`page_byte_range_out_of_range\`
- [x] \`streaming_loader_matches_buffered\` — same pages + same byte ranges as Phase 1
- [x] \`streaming_loader_reads_head_before_body\` — custom \`AsyncRead\` records read sizes; first three are 16 / 8 / DIRM-payload, all small relative to the full file
- [x] \`cargo test --features async,cli --lib\` — 366 passed
- [x] \`cargo build --no-default-features\` — clean (\`Range<u64>\` is in \`core::ops\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)