### PR TITLE
test(no_std): consumer-side smoke crate for codec entry points (#227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,14 @@ jobs:
       - name: cargo build --no-default-features --target wasm32-unknown-unknown
         run: cargo build --no-default-features --target wasm32-unknown-unknown
 
+      # Consumer-side no_std smoke (#227). The wasm32 build above proves the
+      # lib *itself* is no_std-clean; this sub-crate proves the four codec
+      # entry points (iff::parse_form, bzz_new::bzz_decode, jb2::decode_dict,
+      # iw44_new::Iw44Image::decode_chunk) are *callable* from a `#![no_std]`
+      # consumer. A leaked std type in any of those signatures fails here.
+      - name: cargo build (no_std smoke crate, wasm32)
+        run: cargo build --manifest-path tests/no_std_smoke/Cargo.toml --target wasm32-unknown-unknown
+
   # ── Tesseract OCR integration ────────────────────────────────────────────────
   ocr-tesseract:
     name: OCR (tesseract)

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /fuzz/target
+/tests/no_std_smoke/target
 Cargo.lock
 *.orig
 scripts/djvulibre_bench

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [".", "djvu-py"]
-exclude = ["fuzz"]
+exclude = ["fuzz", "tests/no_std_smoke"]
 
 [package]
 name = "djvu-rs"

--- a/tests/no_std_smoke/Cargo.toml
+++ b/tests/no_std_smoke/Cargo.toml
@@ -1,0 +1,19 @@
+[workspace]
+
+[package]
+name = "djvu-rs-no-std-smoke"
+version = "0.0.0"
+edition = "2024"
+publish = false
+license = "MIT"
+description = "No-op crate that proves djvu-rs codec entry points are reachable from a `#![no_std]` consumer."
+
+# Excluded from the root workspace (see root Cargo.toml `workspace.exclude`)
+# so it can pin its own `default-features = false` build of djvu-rs without
+# fighting the workspace feature unification.
+
+[dependencies]
+djvu-rs = { path = "../..", default-features = false }
+
+[lib]
+crate-type = ["rlib"]

--- a/tests/no_std_smoke/src/lib.rs
+++ b/tests/no_std_smoke/src/lib.rs
@@ -1,0 +1,59 @@
+//! `#![no_std]` smoke test for the codec entry points called out in #227.
+//!
+//! Goal: prove that `iff::parse_form`, `bzz_new::bzz_decode`, `jb2::decode_dict`,
+//! and `iw44_new::Iw44Image::decode_chunk` are callable from a consumer crate
+//! that has `default-features = false` (no `std`). If any of these public
+//! signatures grow a `std::*` type, this crate fails to compile.
+//!
+//! The bytes are embedded via `include_bytes!` so this crate has no I/O —
+//! only `core` + `alloc` + `djvu-rs` (no_std build).
+//!
+//! Built in CI by the `wasm` job. Not run as a test (the lib never links a
+//! binary). Compile-only verification is sufficient: a leaked `std::*` would
+//! refuse to type-check here.
+
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use djvu_rs::{bzz_new, iff, iw44_new, jb2};
+
+/// Minimal IFF FORM:DJVU containing one INFO chunk. Hand-crafted to
+/// exercise `iff::parse_form` without pulling a fixture file.
+const TINY_FORM: &[u8] = &[
+    b'A', b'T', b'&', b'T', // "AT&T" magic
+    b'F', b'O', b'R', b'M', // FORM
+    0x00, 0x00, 0x00, 0x10, // FORM length = 16 (4 type + 12 INFO chunk)
+    b'D', b'J', b'V', b'U', // form type
+    b'I', b'N', b'F', b'O', // INFO chunk id
+    0x00, 0x00, 0x00, 0x04, // INFO length
+    0x00, 0x10, 0x00, 0x10, // 4 bytes of INFO body (truncated header — fine for the parser)
+];
+
+/// Embedded BZZ stream from `tests/golden/bzz/test_short.bzz` (36 bytes).
+const TINY_BZZ: &[u8] = include_bytes!("../../golden/bzz/test_short.bzz");
+
+/// Calls each of the four codec entry points named in #227.
+///
+/// Returns `()` on success. Errors are folded into `Result<(), ()>` so the
+/// signature stays free of any third-party error type — this keeps the
+/// no_std contract focused on the codec APIs themselves.
+#[allow(clippy::result_unit_err)]
+pub fn smoke() -> Result<(), ()> {
+    iff::parse_form(TINY_FORM).map_err(|_| ())?;
+
+    let _decoded: Vec<u8> = bzz_new::bzz_decode(TINY_BZZ).map_err(|_| ())?;
+
+    // jb2::decode_dict on an empty buffer returns Err — that still proves
+    // the symbol is reachable from a no_std consumer. We don't care about
+    // the value, only that the signature compiles.
+    let _ = jb2::decode_dict(&[], None);
+
+    // Iw44Image::new() + decode_chunk on a 2-byte header returns Err —
+    // same rationale: signature reachability, not value correctness.
+    let mut img = iw44_new::Iw44Image::new();
+    let _ = img.decode_chunk(&[0u8, 0u8]);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes the last DoD item on #227 — a `#![no_std]` consumer crate that
calls the four codec entry points explicitly named in the issue.

- `tests/no_std_smoke/` — separate (non-workspace) crate that depends on
  `djvu-rs` with `default-features = false` and calls
  `iff::parse_form`, `bzz_new::bzz_decode`, `jb2::decode_dict`, and
  `iw44_new::Iw44Image::decode_chunk` from a `#![no_std]` lib.
- New CI step (under the existing `wasm` job): builds the smoke crate
  for `wasm32-unknown-unknown`. Adds ~5s to the wasm job — uses the same
  Swatinem cache key.
- Workspace exclude in root `Cargo.toml` so the sub-crate can hold its
  own feature unification.
- `.gitignore` for the sub-crate `target/`.

## Why this and not just the wasm32 lib build

The wasm32 `--no-default-features` build added in #236 proves the lib
*itself* compiles without std — but that only catches std leaks
*reachable from the lib's pub surface in cdylib link mode*. This new
crate adds a tighter check: the four codec entry points must be
*callable* from a no_std consumer. A leaked std type in any of those
signatures (e.g., `pub fn x() -> Result<…, std::io::Error>`) fails to
compile in this crate even if it never breaks the lib build.

## Test plan

- [x] `cargo build --manifest-path tests/no_std_smoke/Cargo.toml --target wasm32-unknown-unknown` — succeeds locally
- [x] `cargo build --no-default-features` (root) — still succeeds
- [x] `cargo clippy --lib --tests` and clippy on the sub-crate — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)