### PR TITLE
feat(djvu-enc): minimal layered Quality (segment → Sjbz + BG44)

### DIFF
--- a/src/bin/djvu.rs
+++ b/src/bin/djvu.rs
@@ -1071,13 +1071,21 @@ fn cmd_encode(
     }
 
     let pixmap = decode_png_to_pixmap(input)?;
-    let seg = segment_page(&pixmap, &SegmentOptions::default());
 
-    let bytes = PageEncoder::from_bitmap(&seg.mask)
-        .with_dpi(dpi)
-        .with_quality(q)
-        .encode()
-        .map_err(|e| format!("encode: {e}"))?;
+    let bytes = match q {
+        EncodeQuality::Lossless => {
+            let seg = segment_page(&pixmap, &SegmentOptions::default());
+            PageEncoder::from_bitmap(&seg.mask)
+                .with_dpi(dpi)
+                .with_quality(EncodeQuality::Lossless)
+                .encode()
+        }
+        EncodeQuality::Quality | EncodeQuality::Archival => PageEncoder::from_pixmap(&pixmap)
+            .with_dpi(dpi)
+            .with_quality(q)
+            .encode(),
+    }
+    .map_err(|e| format!("encode: {e}"))?;
 
     std::fs::write(output, &bytes)?;
     eprintln!(

--- a/src/djvu_encode.rs
+++ b/src/djvu_encode.rs
@@ -25,17 +25,39 @@
 //! std::fs::write("scan.djvu", bytes).unwrap();
 //! ```
 //!
+//! Color scan → layered DjVu (mask via JB2 + sub-sampled BG via IW44):
+//!
+//! ```no_run
+//! use djvu_rs::Pixmap;
+//! use djvu_rs::djvu_encode::{PageEncoder, EncodeQuality};
+//!
+//! let pm = Pixmap::white(1024, 1280);
+//! let bytes = PageEncoder::from_pixmap(&pm)
+//!     .with_dpi(300)
+//!     .with_quality(EncodeQuality::Quality)
+//!     .encode()
+//!     .unwrap();
+//! ```
+//!
 //! # Status
 //!
-//! v1 ships the **`Lossless` profile for bilevel input only**: writes
-//! `INFO + Sjbz` into a `FORM:DJVU`. The other profiles
-//! (`Quality`, `Archival`) and color/gray input require the FG/BG
-//! segmentation pass tracked by issue #220 and the FG44 layered-mask
-//! integration; they currently return [`EncodeError::Unsupported`].
+//! - `Lossless` from a [`Bitmap`]: ships `INFO + Sjbz`. Pixel-exact.
+//! - `Quality` from a [`Pixmap`]: ships `INFO + Sjbz + BG44…` —
+//!   layered mask + sub-sampled IW44 background. Lossy by codec
+//!   definition; output is decodable end-to-end. FG layer and FGbz
+//!   palette are #220 follow-ups.
+//! - `Archival`: still [`EncodeError::Unsupported`] — wants the per-CC
+//!   profitability model from #194 Phase 2.5.
+//! - `Lossless` from a [`Pixmap`] / `Quality` from a [`Bitmap`] are
+//!   rejected: the combinations are mathematically meaningless
+//!   (IW44 is lossy; bilevel input has nothing to put in BG44).
 
 use crate::bitmap::Bitmap;
 use crate::iff::{Chunk, DjvuFile, emit};
+use crate::iw44_encode::{Iw44EncodeOptions, encode_iw44_color};
 use crate::jb2_encode;
+use crate::pixmap::Pixmap;
+use crate::segment::{SegmentOptions, segment_page};
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -54,34 +76,47 @@ pub enum EncodeError {
 /// Encoder quality profile.
 ///
 /// The profile drives codec selection (JB2 vs IW44, mask-only vs
-/// layered, optional FGbz palette) and quality knobs. Sizes are
-/// indicative — actual output depends heavily on input content.
+/// layered, optional FGbz palette) and quality knobs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum EncodeQuality {
-    /// Pixel-exact round-trip. For bilevel input this is `INFO + Sjbz`
-    /// (JB2). For color/gray input — *not yet supported* (would emit
-    /// IW44 at maximum quality, which is still mathematically lossy;
-    /// genuine lossless color requires a different codec path).
+    /// Pixel-exact round-trip. Requires bilevel input
+    /// ([`PageEncoder::from_bitmap`]); writes `INFO + Sjbz` (JB2).
     #[default]
     Lossless,
-    /// Layered foreground/background encoding tuned for readable text
-    /// at low bit rates. *Not yet supported* — needs FG/BG
-    /// segmentation (#220).
+    /// Layered foreground/background encoding. Requires color input
+    /// ([`PageEncoder::from_pixmap`]); writes `INFO + Sjbz + BG44…`
+    /// (mask + sub-sampled IW44 background). FG layer and FGbz palette
+    /// are #220 follow-ups.
     Quality,
     /// Archival profile with FGbz palette + aggressive lossy JB2
-    /// refinement matching. *Not yet supported* — needs #220 + the
-    /// per-CC profitability model (#194 Phase 2.5).
+    /// refinement matching. *Not yet supported* — needs the per-CC
+    /// profitability model (#194 Phase 2.5).
     Archival,
 }
 
 // ── Encoder ──────────────────────────────────────────────────────────────────
 
+enum Source<'a> {
+    Bitmap(&'a Bitmap),
+    Pixmap(&'a Pixmap),
+}
+
+impl Source<'_> {
+    fn dimensions(&self) -> (u32, u32) {
+        match self {
+            Source::Bitmap(b) => (b.width, b.height),
+            Source::Pixmap(p) => (p.width, p.height),
+        }
+    }
+}
+
 /// Builder-style page encoder.
 ///
-/// Constructed from a [`Bitmap`] (bilevel) and configured via the
-/// `with_*` methods, then finalised with [`encode`](Self::encode).
+/// Constructed from a [`Bitmap`] (bilevel) or [`Pixmap`] (RGBA) and
+/// configured via the `with_*` methods, then finalised with
+/// [`encode`](Self::encode).
 pub struct PageEncoder<'a> {
-    bitmap: &'a Bitmap,
+    source: Source<'a>,
     dpi: u16,
     quality: EncodeQuality,
 }
@@ -90,9 +125,20 @@ impl<'a> PageEncoder<'a> {
     /// Start encoding a bilevel page. Defaults: 300 dpi, `Lossless`.
     pub fn from_bitmap(bitmap: &'a Bitmap) -> Self {
         Self {
-            bitmap,
+            source: Source::Bitmap(bitmap),
             dpi: 300,
             quality: EncodeQuality::Lossless,
+        }
+    }
+
+    /// Start encoding a colour page. Defaults: 300 dpi, `Quality` (the
+    /// only sensible profile for colour input — `Lossless` requires a
+    /// `Bitmap`).
+    pub fn from_pixmap(pixmap: &'a Pixmap) -> Self {
+        Self {
+            source: Source::Pixmap(pixmap),
+            dpi: 300,
+            quality: EncodeQuality::Quality,
         }
     }
 
@@ -115,49 +161,72 @@ impl<'a> PageEncoder<'a> {
     /// Produce the bytes of a single-page DjVu file (`FORM:DJVU`
     /// wrapped in the `AT&T` IFF container).
     pub fn encode(&self) -> Result<Vec<u8>, EncodeError> {
-        match self.quality {
-            EncodeQuality::Lossless => self.encode_lossless_bilevel(),
-            EncodeQuality::Quality => Err(EncodeError::Unsupported(
-                "Quality profile requires FG/BG segmentation (#220) and layered mask integration",
-            )),
-            EncodeQuality::Archival => Err(EncodeError::Unsupported(
-                "Archival profile requires FG/BG segmentation (#220) plus the per-CC profitability model (#194 Phase 2.5)",
-            )),
-        }
-    }
-
-    fn encode_lossless_bilevel(&self) -> Result<Vec<u8>, EncodeError> {
-        let w = u16::try_from(self.bitmap.width).map_err(|_| {
+        let (w, h) = self.source.dimensions();
+        let w = u16::try_from(w).map_err(|_| {
             EncodeError::Unsupported("page width exceeds INFO chunk limit (65 535 px)")
         })?;
-        let h = u16::try_from(self.bitmap.height).map_err(|_| {
+        let h = u16::try_from(h).map_err(|_| {
             EncodeError::Unsupported("page height exceeds INFO chunk limit (65 535 px)")
         })?;
-
         let info = encode_info(w, h, self.dpi);
-        let sjbz = jb2_encode::encode_jb2(self.bitmap);
 
-        let file = DjvuFile {
-            root: Chunk::Form {
-                secondary_id: *b"DJVU",
-                length: 0, // recomputed by emit
-                children: vec![
-                    Chunk::Leaf {
-                        id: *b"INFO",
-                        data: info,
-                    },
-                    Chunk::Leaf {
-                        id: *b"Sjbz",
-                        data: sjbz,
-                    },
-                ],
-            },
-        };
-        Ok(emit(&file))
+        match (&self.source, self.quality) {
+            (Source::Bitmap(bm), EncodeQuality::Lossless) => Ok(encode_form_djvu(vec![
+                Chunk::Leaf {
+                    id: *b"INFO",
+                    data: info,
+                },
+                Chunk::Leaf {
+                    id: *b"Sjbz",
+                    data: jb2_encode::encode_jb2(bm),
+                },
+            ])),
+            (Source::Pixmap(pm), EncodeQuality::Quality) => {
+                let seg = segment_page(pm, &SegmentOptions::default());
+                let sjbz = jb2_encode::encode_jb2(&seg.mask);
+                let bg44_chunks = encode_iw44_color(&seg.bg, &Iw44EncodeOptions::default());
+                let mut chunks = Vec::with_capacity(2 + bg44_chunks.len());
+                chunks.push(Chunk::Leaf {
+                    id: *b"INFO",
+                    data: info,
+                });
+                chunks.push(Chunk::Leaf {
+                    id: *b"Sjbz",
+                    data: sjbz,
+                });
+                for body in bg44_chunks {
+                    chunks.push(Chunk::Leaf {
+                        id: *b"BG44",
+                        data: body,
+                    });
+                }
+                Ok(encode_form_djvu(chunks))
+            }
+            (Source::Pixmap(_), EncodeQuality::Lossless) => Err(EncodeError::Unsupported(
+                "Lossless requires bilevel input — use from_bitmap or switch to Quality",
+            )),
+            (Source::Bitmap(_), EncodeQuality::Quality) => Err(EncodeError::Unsupported(
+                "Quality requires colour input — use from_pixmap or switch to Lossless",
+            )),
+            (_, EncodeQuality::Archival) => Err(EncodeError::Unsupported(
+                "Archival profile requires the per-CC profitability model (#194 Phase 2.5)",
+            )),
+        }
     }
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn encode_form_djvu(children: Vec<Chunk>) -> Vec<u8> {
+    let file = DjvuFile {
+        root: Chunk::Form {
+            secondary_id: *b"DJVU",
+            length: 0, // recomputed by emit
+            children,
+        },
+    };
+    emit(&file)
+}
 
 /// Build the 10-byte `INFO` chunk body.
 ///
@@ -203,11 +272,9 @@ mod tests {
             .encode()
             .expect("encode");
 
-        // Parse back
         let form = parse_form(&bytes).expect("parse_form");
         assert_eq!(&form.form_type, b"DJVU");
 
-        // Find INFO + Sjbz
         let mut info_data: Option<&[u8]> = None;
         let mut sjbz_data: Option<&[u8]> = None;
         for chunk in &form.chunks {
@@ -220,12 +287,10 @@ mod tests {
         let info = info_data.expect("INFO chunk present");
         let sjbz = sjbz_data.expect("Sjbz chunk present");
 
-        // INFO dimensions
         assert_eq!(u16::from_be_bytes([info[0], info[1]]), 64);
         assert_eq!(u16::from_be_bytes([info[2], info[3]]), 48);
         assert_eq!(u16::from_le_bytes([info[6], info[7]]), 150);
 
-        // Sjbz round-trip → bit-exact bitmap
         let decoded = jb2::decode(sjbz, None).expect("jb2 decode");
         assert_eq!(decoded.width, bm.width);
         assert_eq!(decoded.height, bm.height);
@@ -237,11 +302,19 @@ mod tests {
     }
 
     #[test]
-    fn defaults_are_300_dpi_lossless() {
+    fn defaults_are_300_dpi_lossless_for_bitmap() {
         let bm = Bitmap::new(8, 8);
         let enc = PageEncoder::from_bitmap(&bm);
         assert_eq!(enc.dpi, 300);
         assert_eq!(enc.quality, EncodeQuality::Lossless);
+    }
+
+    #[test]
+    fn defaults_are_300_dpi_quality_for_pixmap() {
+        let pm = Pixmap::white(8, 8);
+        let enc = PageEncoder::from_pixmap(&pm);
+        assert_eq!(enc.dpi, 300);
+        assert_eq!(enc.quality, EncodeQuality::Quality);
     }
 
     #[test]
@@ -252,18 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn quality_profile_unsupported_until_segmentation() {
-        let bm = Bitmap::new(16, 16);
-        let err = PageEncoder::from_bitmap(&bm)
-            .with_quality(EncodeQuality::Quality)
-            .encode()
-            .unwrap_err();
-        let msg = format!("{err}");
-        assert!(msg.contains("Quality"));
-    }
-
-    #[test]
-    fn archival_profile_unsupported_until_segmentation() {
+    fn archival_profile_still_unsupported() {
         let bm = Bitmap::new(16, 16);
         let err = PageEncoder::from_bitmap(&bm)
             .with_quality(EncodeQuality::Archival)
@@ -279,5 +341,84 @@ mod tests {
         let bytes = PageEncoder::from_bitmap(&bm).encode().expect("encode");
         let form = parse_form(&bytes).expect("parse");
         assert_eq!(&form.form_type, b"DJVU");
+    }
+
+    #[test]
+    fn quality_color_emits_info_sjbz_bg44() {
+        // 64×64 page: white background with a black 16×16 ink square.
+        let mut pm = Pixmap::white(64, 64);
+        for y in 16..32 {
+            for x in 16..32 {
+                pm.set_rgb(x, y, 0, 0, 0);
+            }
+        }
+
+        let bytes = PageEncoder::from_pixmap(&pm)
+            .with_dpi(200)
+            .with_quality(EncodeQuality::Quality)
+            .encode()
+            .expect("encode");
+
+        let form = parse_form(&bytes).expect("parse_form");
+        assert_eq!(&form.form_type, b"DJVU");
+
+        let mut has_info = false;
+        let mut has_sjbz = false;
+        let mut bg44_count = 0;
+        for chunk in &form.chunks {
+            match &chunk.id {
+                b"INFO" => has_info = true,
+                b"Sjbz" => has_sjbz = true,
+                b"BG44" => bg44_count += 1,
+                _ => {}
+            }
+        }
+        assert!(has_info, "INFO chunk missing");
+        assert!(has_sjbz, "Sjbz chunk missing");
+        assert!(
+            bg44_count > 0,
+            "expected at least one BG44 chunk, got {bg44_count}"
+        );
+    }
+
+    #[test]
+    fn lossless_pixmap_rejected() {
+        let pm = Pixmap::white(8, 8);
+        let err = PageEncoder::from_pixmap(&pm)
+            .with_quality(EncodeQuality::Lossless)
+            .encode()
+            .unwrap_err();
+        assert!(format!("{err}").contains("Lossless"));
+    }
+
+    #[test]
+    fn quality_bitmap_rejected() {
+        let bm = Bitmap::new(8, 8);
+        let err = PageEncoder::from_bitmap(&bm)
+            .with_quality(EncodeQuality::Quality)
+            .encode()
+            .unwrap_err();
+        assert!(format!("{err}").contains("Quality"));
+    }
+
+    #[test]
+    fn quality_color_round_trips_through_document() {
+        // End-to-end: encode a colour page at Quality, parse it back
+        // through the high-level Document API, and confirm dimensions
+        // + that the page has both an Sjbz and at least one BG44 chunk.
+        let pm = Pixmap::white(32, 24);
+        let bytes = PageEncoder::from_pixmap(&pm)
+            .with_dpi(150)
+            .with_quality(EncodeQuality::Quality)
+            .encode()
+            .expect("encode");
+
+        let doc = crate::djvu_document::DjVuDocument::parse(&bytes).expect("parse");
+        let page = doc.page(0).expect("page 0");
+        assert_eq!(page.width(), 32);
+        assert_eq!(page.height(), 24);
+        assert_eq!(page.dpi(), 150);
+        assert!(page.raw_chunk(b"Sjbz").is_some());
+        assert!(!page.all_chunks(b"BG44").is_empty());
     }
 }

--- a/tests/cli_encode.rs
+++ b/tests/cli_encode.rs
@@ -73,7 +73,7 @@ fn encode_default_dpi_is_300() {
 }
 
 #[test]
-fn encode_quality_profile_unsupported_until_segmentation() {
+fn encode_quality_profile_emits_layered_djvu() {
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("in.png");
     let output = dir.path().join("out.djvu");
@@ -90,8 +90,36 @@ fn encode_quality_profile_unsupported_until_segmentation() {
             "quality",
         ])
         .assert()
+        .success();
+
+    // Layered output must contain at least one BG44 chunk in addition to Sjbz.
+    let bytes = std::fs::read(&output).unwrap();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&bytes).unwrap();
+    let page = doc.page(0).unwrap();
+    assert!(page.raw_chunk(b"Sjbz").is_some());
+    assert!(!page.all_chunks(b"BG44").is_empty());
+}
+
+#[test]
+fn encode_archival_profile_still_unsupported() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.png");
+    let output = dir.path().join("out.djvu");
+    write_test_png(&input, 16, 16);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "--quality",
+            "archival",
+        ])
+        .assert()
         .failure()
-        .stderr(predicates::str::contains("Quality profile"));
+        .stderr(predicates::str::contains("Archival"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Wires the `Quality` profile end-to-end on `PageEncoder` so colour input now produces a layered DjVu page (mask + sub-sampled IW44 background), not just bilevel `INFO + Sjbz`.

- `PageEncoder::from_pixmap(&Pixmap)` constructor (300 dpi, `Quality` default)
- `(Pixmap, Quality)` path: `segment_page` → `INFO + Sjbz + BG44…` via `encode_iw44_color`
- Mismatched combos now error explicitly:
  - `(Pixmap, Lossless)` → \"use from_bitmap or switch to Quality\"
  - `(Bitmap, Quality)` → \"use from_pixmap or switch to Lossless\"
- `Archival` still `Unsupported` (gated on #194 Phase 2.5 per-CC profitability model)
- Internal `Source<'a>` enum unifies dimension + dispatch

The CLI plumbing landed in #244/#245; this PR is the missing library piece behind `--quality quality`.

## Test plan
- [x] `cargo test --lib djvu_encode` — 10/10 pass (5 new tests, including round-trip via `DjVuDocument::parse` confirming page dims + Sjbz + non-empty BG44)
- [x] `cargo test --lib` — 384/384 pass
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo fmt`

## Follow-ups
- FG layer (`FG44`) + FGbz palette extraction (#220 v2)
- Adaptive binarisation (Sauvola/Wolf) for the segmentation step
- Quality knobs on `EncodeQuality::Quality` (currently hardcoded to `Iw44EncodeOptions::default()` + `SegmentOptions::default()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)