### PR TITLE
ci(diff): re-add navm_fgbz.djvu to diff CI corpus (#199 follow-up)

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -60,8 +60,12 @@ jobs:
       # tests/diff_tolerance.md for the empirical baseline.
       #
       # Excluded for now (tracked separately):
-      #   colorbook.djvu      — IW44 divergence under investigation (#192)
-      #   navm_fgbz.djvu p3-4 — small FGbz divergence under investigation
+      #   colorbook.djvu — residual ≈3.45% on p0, likely glyph-edge
+      #                    bilinear-interpolation drift (#199 follow-up)
+      #
+      # navm_fgbz.djvu was re-added after #248 fixed the page→plane-space
+      # coord conversion (#199); worst page p4 measures 0.12% mismatch /
+      # mean Δ 0.024, comfortably within the gate below.
       #
       # Width 99999 caps to native page width; small fixtures render at
       # their native dimensions. This is the only mode in which the diff
@@ -80,6 +84,7 @@ jobs:
             tests/fixtures/links.djvu \
             tests/fixtures/problem_page.djvu \
             tests/fixtures/big-scanned-page.djvu \
+            tests/fixtures/navm_fgbz.djvu \
               | tee diff_results.jsonl
 
       # CI gate: any page over the per-codec ceiling fails. See


### PR DESCRIPTION
## Summary

After #248 closed #199, `navm_fgbz.djvu` is comfortably within the existing diff CI gate (0.5% per-page mismatch / 0.2 mean Δ). Re-adding it as a regression guard for the FG44 / BG-plane page-space-coord fix.

## Verification

`cargo run --release --features=cli --example diff_djvulibre -- --width 99999 --tolerance 4 tests/fixtures/navm_fgbz.djvu`:

| page | mismatch% | max Δ | mean Δ |
|------|-----------|-------|--------|
| 0    | 0.000     | 0     | 0.000  |
| 1    | 0.001     | 0     | 0.000  |
| 2    | 0.000     | 0     | 0.000  |
| 3    | 0.015     | 78    | 0.007  |
| 4    | 0.116     | 78    | 0.024  ← worst |
| 5    | 0.000     | 0     | 0.000  |

Worst page is well under both gate thresholds (0.5% / 0.2).

`colorbook.djvu` stays excluded — its residual ≈3.45% on p0 is a separate bilinear-interpolation drift at glyph edges, not the clamp-to-rightmost-column bug that #248 fixed.

## Test plan

- [x] `diff_djvulibre` confirms all 6 navm_fgbz pages under the gate
- [ ] CI diff workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)