### PR TITLE
ci(bench): add x86-64-v3 AVX2 validation job

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,12 +2,14 @@ name: Benchmarks
 
 on:
   # Track regressions on every PR that touches code or benchmarks.
+  # Workflow file itself is included so changes to bench.yml re-run on PR.
   pull_request:
     paths:
       - 'src/**'
       - 'benches/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.github/workflows/bench.yml'
 
   # Update the baseline when code or benchmarks actually change on main / release tags.
   # Tags always bump Cargo.toml so the paths filter still fires for releases.
@@ -20,6 +22,7 @@ on:
       - 'benches/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - '.github/workflows/bench.yml'
 
   # Allow manual runs (e.g. to seed the initial baseline).
   workflow_dispatch:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -165,6 +165,163 @@ jobs:
             target/criterion/
           retention-days: 30
 
+  # ── x86-64-v3 (AVX2) validation: measures whether the AVX2 hot paths in
+  # iw44_new actually beat the scalar/wide::i32x8 fallback when AVX2 is
+  # enabled at the codegen level. The default Bench job above runs with
+  # whatever target-cpu cargo picks (typically `x86-64` baseline = SSE2),
+  # which means our `cfg(target_feature = "avx2")` branches are dead code
+  # on CI — every PR claiming "AVX2 path" was effectively unmeasured.
+  #
+  # This job reruns the AVX2-relevant benches twice (default RUSTFLAGS vs
+  # `-C target-cpu=x86-64-v3`) on the same runner and posts the delta.
+  # Tracks the validation gate added after #251/#252/#253 shipped without
+  # baseline numbers — see CLAUDE.md follow-up for context.
+  bench-x86-64-v3:
+    name: Benchmark (x86-64-v3 AVX2 validation)
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: bench-ubuntu-x86-64-v3
+
+      # Bound scope to AVX2-relevant benches to keep CI time tractable.
+      # Filters target iw44 SIMD hot paths (load8s/store8s, ycbcr_row_from_i16)
+      # plus the renderer benches that exercise the whole IW44 pipeline.
+      - name: Bench codecs (default RUSTFLAGS — baseline)
+        run: |
+          cargo bench --bench codecs -- 'iw44_to_rgb|iw44_decode' --output-format bencher 2>&1 \
+            | tee codec_bench_default.txt
+        continue-on-error: true
+
+      - name: Bench render (default RUSTFLAGS — baseline)
+        run: |
+          cargo bench --bench render -- 'render_corpus_color|render_colorbook' --output-format bencher 2>&1 \
+            | tee render_bench_default.txt
+        continue-on-error: true
+
+      # Discard criterion state so the +x86-64-v3 run starts clean and
+      # criterion treats it as an independent baseline.
+      - name: Reset criterion state
+        run: rm -rf target/criterion
+
+      - name: Bench codecs (RUSTFLAGS=-C target-cpu=x86-64-v3)
+        env:
+          RUSTFLAGS: -C target-cpu=x86-64-v3
+        run: |
+          cargo bench --bench codecs -- 'iw44_to_rgb|iw44_decode' --output-format bencher 2>&1 \
+            | tee codec_bench_v3.txt
+        continue-on-error: true
+
+      - name: Bench render (RUSTFLAGS=-C target-cpu=x86-64-v3)
+        env:
+          RUSTFLAGS: -C target-cpu=x86-64-v3
+        run: |
+          cargo bench --bench render -- 'render_corpus_color|render_colorbook' --output-format bencher 2>&1 \
+            | tee render_bench_v3.txt
+        continue-on-error: true
+
+      - name: Compare default vs +x86-64-v3
+        run: |
+          python3 - <<'PYEOF' | tee bench_v3_comment.md
+          import re, os
+          BENCHER_RE = re.compile(
+              r"^test\s+(?P<name>\S+)\s+\.\.\.\s+bench:\s+"
+              r"(?P<ns>[\d,]+)\s+ns/iter"
+          )
+
+          def parse(path):
+              out = {}
+              if not os.path.exists(path):
+                  return out
+              for line in open(path):
+                  m = BENCHER_RE.match(line.strip())
+                  if not m:
+                      continue
+                  out[m.group("name")] = int(m.group("ns").replace(",", ""))
+              return out
+
+          sections = [
+              ("Codecs", "codec_bench_default.txt", "codec_bench_v3.txt"),
+              ("Render", "render_bench_default.txt", "render_bench_v3.txt"),
+          ]
+
+          print("## AVX2 validation: default RUSTFLAGS vs `-C target-cpu=x86-64-v3`")
+          print()
+          print("Same runner, same benches, run back-to-back. Negative Δ% = AVX2 path is faster.")
+          print()
+          any_speedup = False
+          any_regression = False
+          for title, default_path, v3_path in sections:
+              d = parse(default_path)
+              v = parse(v3_path)
+              names = sorted(set(d) | set(v))
+              if not names:
+                  continue
+              print(f"### {title}")
+              print()
+              print("| Bench | default ns | +x86-64-v3 ns | Δ% |")
+              print("|---|---:|---:|---:|")
+              for n in names:
+                  a = d.get(n)
+                  b = v.get(n)
+                  if a is None or b is None:
+                      print(f"| `{n}` | {a if a is not None else '—'} | {b if b is not None else '—'} | — |")
+                      continue
+                  delta = (b - a) / a * 100.0
+                  if delta <= -3.0:
+                      any_speedup = True
+                  elif delta >= 3.0:
+                      any_regression = True
+                  print(f"| `{n}` | {a:,} | {b:,} | {delta:+.2f}% |")
+              print()
+
+          print("---")
+          if any_speedup and not any_regression:
+              print("**Verdict.** AVX2 path measurably faster (≥3% on ≥1 bench, no regressions).")
+          elif any_regression and not any_speedup:
+              print("**Verdict.** No AVX2 speedup — and at least one regression (≥3%). "
+                    "The shipped SIMD path is hurting on x86-64-v3; "
+                    "consider reverting #251/#252.")
+          elif not any_speedup and not any_regression:
+              print("**Verdict.** No measurable difference (all benches within ±3%). "
+                    "The AVX2 hot paths are not earning their keep — "
+                    "consider reverting #251/#252 with a "
+                    "_Reverted: no measurable speedup_ entry in CLAUDE.md.")
+          else:
+              print("**Verdict.** Mixed: some speedup, some regression. Investigate per-bench.")
+          PYEOF
+
+      - name: Post AVX2 validation comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: bench-x86-64-v3
+          path: bench_v3_comment.md
+        continue-on-error: true
+
+      - name: Upload AVX2 validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-x86-64-v3-${{ github.sha }}
+          path: |
+            codec_bench_default.txt
+            codec_bench_v3.txt
+            render_bench_default.txt
+            render_bench_v3.txt
+            bench_v3_comment.md
+          retention-days: 30
+
   # ── macOS run: tags and manual only (for BENCHMARKS.md) ─────────────────────
   bench-macos:
     name: Benchmark (macOS)


### PR DESCRIPTION
## Summary

Adds a parallel `Benchmark (x86-64-v3 AVX2 validation)` job to `bench.yml` that reruns the AVX2-relevant codec/render benches twice on the same runner — once with default `RUSTFLAGS` (effectively SSE2 baseline = the scalar / `wide::i32x8` fallback) and once with `-C target-cpu=x86-64-v3` (AVX2/AVX/SSE4.2 = the SIMD hot paths shipped in #251/#252) — and posts a sticky PR comment with per-bench Δ%.

## Why

The default `Bench` job has zero `target-cpu` / `target-feature` override. That means every `cfg(target_feature = "avx2")` branch shipped in #251/#252 was **dead code in CI**. Those PRs merged with bench comments showing _"no baseline for comparison"_ and numbers indistinguishable from pre-AVX2 runs — the AVX2 paths were never actually measured.

This job closes that gap, scoped to the four benchmarks that exercise `load8s` / `store8s` / `ycbcr_row_from_i16` on the hot path:

- `iw44_to_rgb_*`, `iw44_decode_*` (codecs)
- `render_corpus_color`, `render_colorbook` (render)

The comment ends with an explicit verdict — including a direct _"consider reverting #251/#252"_ recommendation if no speedup is measured.

## What this PR's own bench output will tell us

The diff itself touches no Rust code, so the `Benchmark` job (the existing one) should be a no-op. But this PR is the **first run of the new validation job** — its output is the actual experiment:

- If AVX2 path is measurably faster (≥3% on ≥1 bench): #251/#252 are validated, autonomous SIMD shipping resumes.
- If no measurable difference / regression: open follow-up to revert #251/#252 with a _Reverted: no measurable speedup_ entry in `CLAUDE.md`.

Until this comment lands, the autonomous SIMD-port loop is paused (per user direction).

## Test plan

- [ ] `Benchmark (x86-64-v3 AVX2 validation)` job runs to completion
- [ ] Sticky PR comment with header `bench-x86-64-v3` posts default vs +x86-64-v3 numbers
- [ ] Verdict line at bottom of comment is unambiguous (speedup / regression / no-diff / mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)