### PR TITLE
perf(jb2-enc): per-CC accounting harness for shared-Djbz (#194 Phase 2.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,62 @@ Referenced from issue templates ("Record result in CLAUDE.md (Kept or Reverted +
 
 Each entry: issue, approach, numbers, decision, reason.
 
+### #194 Phase 2.5 — per-CC accounting harness for shared-Djbz refinement — **Kept (instrumentation only)** (2026-04-28)
+
+**Approach.** Added `pub fn analyze_jb2_cc_stats(page, &shared)` that mirrors
+the rec-1/rec-6/rec-7 action-selection branch in
+`encode_jb2_dict_with_shared` but emits no bytes — just counts and a
+Hamming-distance histogram for rec-6 emissions, separating refs that
+land in the shared dict (cross-page) from refs that land in the
+page-local running dict. Wired through to `encode_quality_djbz` via a
+new `--cc-stats` flag.
+
+This is the measurement layer Phase 2.5 needs before deciding whether
+the per-CC profitability model in CLAUDE.md's #194 follow-up is worth
+implementing. The Phase 2 result already showed flat Hamming clustering
+doesn't beat byte-exact; the open question was whether selective
+near-duplicate promotion (with a profitability gate per CC) could.
+Without the actual rec-6 distribution we were guessing.
+
+**Observations** (`--cc-stats` on `tests/corpus/*.djvu`, 36 pages, 4 books):
+
+| File | Pages | rec-1 fresh | rec-6 shared | rec-6 local | rec-7 exact |
+|---|---:|---:|---:|---:|---:|
+| `cable_1973_100133.djvu` | 2  | 12.4% | 0.0%  | 4.7% | 82.8% |
+| `conquete_paix.djvu`     | 22 | 40.7% | 0.2%  | 2.1% | 56.9% |
+| `watchmaker.djvu`        | 12 | 6.1%  | 24.7% | 1.8% | 67.5% |
+
+rec-6 Hamming-distance distribution on `watchmaker.djvu` (6256 rec-6
+matches, dominant case): 49.7% in [1, 4], 47.7% in [5, 16], 2.5% in
+[17, 64], 0% above. Very tight — the existing 4%-of-pixels threshold in
+`find_refinement_ref` is approximately right; there is little headroom
+for "tighter" to improve the picture.
+
+**Reason kept.** Pure instrumentation, no encoder behavior change. Gives
+future Phase 2.5 work (and any Phase 4 lossy-refinement experiment from
+#224) a concrete CC-action breakdown without round-tripping bytes.
+Round-trip + clippy + nextest all clean; new test
+`analyze_jb2_cc_stats_classifies_records` covers all three buckets +
+shared/local distinction.
+
+**What this tells us about Phase 2.5 viability.** On the dominant
+shared-dict beneficiary (`watchmaker`), rec-6 already covers 24.7% of
+CCs against the shared dict, and the Hamming distribution is bimodal
+on [1, 16]. The remaining 6.1% rec-1 are mostly:
+1. Unique glyphs (no shared-dict twin) — promotion candidates need ≥ N
+   page repetitions, by definition rare for these
+2. Glyphs that fail the same-(w, h) bucket constraint
+   (cross-size matching is `find_refinement_ref`'s explicit
+   limitation, see jb2_encode.rs:611)
+
+So the most plausible Phase 2.5 win is **cross-size refinement**, not
+per-CC profitability. That's a substantially larger change (requires
+resampling for Hamming scoring) and is what the open #194 follow-up
+should track. Per-CC profitability against the existing same-size
+shortlist is unlikely to add anything material — the rec-6 hits we
+already get are tight enough that a profitability gate would barely
+exclude any of them.
+
 ### #185 — perf(jb2): bit-pack Jbm to 1 bit/pixel — **Kept** (2026-04-18)
 
 **Approach.** Changed the internal `Jbm` working bitmap from 1 byte/pixel

--- a/examples/encode_quality_djbz.rs
+++ b/examples/encode_quality_djbz.rs
@@ -29,8 +29,9 @@ use std::process::ExitCode;
 use djvu_rs::{
     Bitmap, DjVuDocument,
     jb2_encode::{
-        cluster_shared_symbols_tunable, encode_djvm_bundle_jb2_with_shared, encode_jb2_dict,
-        encode_jb2_dict_with_shared, encode_jb2_djbz,
+        CcStats, analyze_jb2_cc_stats, cluster_shared_symbols_tunable,
+        encode_djvm_bundle_jb2_with_shared, encode_jb2_dict, encode_jb2_dict_with_shared,
+        encode_jb2_djbz,
     },
 };
 
@@ -76,7 +77,57 @@ fn collect_pages(path: &Path) -> Option<(Vec<Bitmap>, usize, (u32, u32))> {
     Some((pages, orig_total, avg))
 }
 
-fn process_file(path: &Path, threshold: usize, diff_fraction: u32) -> Option<FileResult> {
+/// Aggregate per-page CC stats across all pages of a bundle.
+fn aggregate_cc_stats(pages: &[Bitmap], shared: &[Bitmap]) -> CcStats {
+    let mut agg = CcStats::default();
+    for p in pages {
+        let s = analyze_jb2_cc_stats(p, shared);
+        agg.total_ccs += s.total_ccs;
+        agg.rec_7_exact += s.rec_7_exact;
+        agg.rec_6_refine_shared += s.rec_6_refine_shared;
+        agg.rec_6_refine_local += s.rec_6_refine_local;
+        agg.rec_1_new += s.rec_1_new;
+        agg.pixels_rec_1 += s.pixels_rec_1;
+        agg.pixels_rec_6 += s.pixels_rec_6;
+        agg.pixels_rec_7 += s.pixels_rec_7;
+        agg.rec_6_hamming.extend(s.rec_6_hamming);
+    }
+    agg
+}
+
+/// Print a fixed-bin Hamming-distance histogram for rec-6 emissions.
+/// Bins are in % of pixel-count (Hamming / pixel_count × 100), with the
+/// caveat that we don't have per-CC pixel context in the aggregate, so
+/// we report by absolute Hamming distance bucketed into power-of-two bins.
+fn print_hamming_histogram(hamming: &[u32]) {
+    if hamming.is_empty() {
+        eprintln!("  rec-6 Hamming histogram: (no rec-6 emissions)");
+        return;
+    }
+    let bins: [(u32, u32, &str); 7] = [
+        (0, 0, "=0"),
+        (1, 4, "1-4"),
+        (5, 16, "5-16"),
+        (17, 64, "17-64"),
+        (65, 256, "65-256"),
+        (257, 1024, "257-1024"),
+        (1025, u32::MAX, ">1024"),
+    ];
+    let total = hamming.len();
+    eprintln!("  rec-6 Hamming histogram ({} matches):", total);
+    for (lo, hi, label) in bins {
+        let n = hamming.iter().filter(|&&h| h >= lo && h <= hi).count();
+        let pct = n as f64 / total as f64 * 100.0;
+        eprintln!("    {:>10}: {:>6} ({:>5.1}%)", label, n, pct);
+    }
+}
+
+fn process_file(
+    path: &Path,
+    threshold: usize,
+    diff_fraction: u32,
+    cc_stats: bool,
+) -> Option<FileResult> {
     let (pages, orig_total, avg) = match collect_pages(path) {
         Some(t) => t,
         None => {
@@ -117,6 +168,28 @@ fn process_file(path: &Path, threshold: usize, diff_fraction: u32) -> Option<Fil
         bundle_total.saturating_sub(djbz_bytes + sjbz_total),
     );
 
+    if cc_stats {
+        let agg = aggregate_cc_stats(&pages, &shared);
+        eprintln!(
+            "  CC accounting: total={} rec-1={} ({:.1}%) rec-6_shared={} ({:.1}%) \
+             rec-6_local={} ({:.1}%) rec-7_exact={} ({:.1}%)",
+            agg.total_ccs,
+            agg.rec_1_new,
+            agg.rec_1_new as f64 / agg.total_ccs.max(1) as f64 * 100.0,
+            agg.rec_6_refine_shared,
+            agg.rec_6_refine_shared as f64 / agg.total_ccs.max(1) as f64 * 100.0,
+            agg.rec_6_refine_local,
+            agg.rec_6_refine_local as f64 / agg.total_ccs.max(1) as f64 * 100.0,
+            agg.rec_7_exact,
+            agg.rec_7_exact as f64 / agg.total_ccs.max(1) as f64 * 100.0,
+        );
+        eprintln!(
+            "  pixel volume: rec-1={} px  rec-6={} px  rec-7={} px",
+            agg.pixels_rec_1, agg.pixels_rec_6, agg.pixels_rec_7,
+        );
+        print_hamming_histogram(&agg.rec_6_hamming);
+    }
+
     // Verify round-trip — every page must decode pixel-exact.
     let roundtrip_ok = match DjVuDocument::parse(&bundle) {
         Ok(doc) if doc.page_count() == pages.len() => {
@@ -149,6 +222,7 @@ fn main() -> ExitCode {
     // Default 0 = byte-exact, the shipped clustering. Higher values opt
     // into Hamming clustering for experimentation.
     let mut diff_fraction: u32 = 0;
+    let mut cc_stats = false;
     let mut files: Vec<String> = Vec::new();
     let mut args = std::env::args().skip(1);
     while let Some(a) = args.next() {
@@ -162,6 +236,8 @@ fn main() -> ExitCode {
                 .next()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(diff_fraction);
+        } else if a == "--cc-stats" {
+            cc_stats = true;
         } else {
             files.push(a);
         }
@@ -169,20 +245,21 @@ fn main() -> ExitCode {
 
     if files.is_empty() {
         eprintln!(
-            "usage: encode_quality_djbz [--threshold N] [--diff-fraction P] <file.djvu> [...]\n\
+            "usage: encode_quality_djbz [--threshold N] [--diff-fraction P] [--cc-stats] <file.djvu> [...]\n\
              \n\
              Encodes every multi-page input via encode_djvm_bundle_jb2 and\n\
              reports total bytes vs. independent per-page dict + original Sjbz.\n\
              \n\
              --threshold N      promote glyph clusters that span >= N pages (default 2)\n\
-             --diff-fraction P  Hamming distance allowance, percent of pixels (0..=10, default 0 = byte-exact)"
+             --diff-fraction P  Hamming distance allowance, percent of pixels (0..=10, default 0 = byte-exact)\n\
+             --cc-stats         print per-CC record-type accounting + Hamming histogram (#194 Phase 2.5)"
         );
         return ExitCode::from(2);
     }
 
     let mut all = Vec::new();
     for f in &files {
-        if let Some(r) = process_file(Path::new(f), threshold, diff_fraction) {
+        if let Some(r) = process_file(Path::new(f), threshold, diff_fraction, cc_stats) {
             all.push(r);
         }
     }

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -1055,6 +1055,118 @@ pub fn cluster_shared_symbols_tunable(
     promoted.into_iter().map(|c| c.rep).collect()
 }
 
+/// Per-CC accounting of which JB2 record type a single page would emit
+/// against a given shared dictionary, without performing the actual encode.
+///
+/// Phase 2.5 measurement aid (#194): mirrors the action-selection branch in
+/// [`encode_jb2_dict_with_shared`] (rec-7 exact / rec-6 refinement / rec-1
+/// new) and reports counts, pixel totals, and Hamming-distance distribution
+/// for the rec-6 emissions, distinguishing references that resolve into the
+/// shared Djbz vs ones that resolve into the page-local running dict.
+///
+/// Use this to answer questions like "how many CCs would actually benefit
+/// from a tighter refinement threshold" or "how large is the rec-7 win
+/// from the shared dict on this corpus" without round-tripping bytes.
+#[derive(Debug, Default, Clone)]
+pub struct CcStats {
+    pub total_ccs: usize,
+    /// rec-7: byte-exact match found in the running dict.
+    pub rec_7_exact: usize,
+    /// rec-6 against a slot inside the shared (cross-page) Djbz.
+    pub rec_6_refine_shared: usize,
+    /// rec-6 against a slot emitted earlier on the same page.
+    pub rec_6_refine_local: usize,
+    /// rec-1: no usable match, fresh emission.
+    pub rec_1_new: usize,
+    /// Hamming distances of rec-6 matches (one entry per rec-6 CC).
+    pub rec_6_hamming: Vec<u32>,
+    /// Pixel-count totals split by record type.
+    pub pixels_rec_1: u64,
+    pub pixels_rec_6: u64,
+    pub pixels_rec_7: u64,
+}
+
+/// Walk `page`'s connected components in encoder order and accumulate
+/// per-CC accounting against `shared_symbols` using the same action-
+/// selection rules as [`encode_jb2_dict_with_shared`]. Pure observation —
+/// no bytes are emitted.
+pub fn analyze_jb2_cc_stats(page: &Bitmap, shared_symbols: &[Bitmap]) -> CcStats {
+    let mut stats = CcStats::default();
+    if page.width == 0 || page.height == 0 {
+        return stats;
+    }
+
+    let ccs = extract_ccs(page);
+    let mut order: Vec<usize> = (0..ccs.len()).collect();
+    let bucket = (SAME_LINE_BASELINE_TOL.max(1)) as u32;
+    order.sort_by_key(|&i| {
+        let cc = &ccs[i];
+        let bottom = cc.y + cc.bitmap.height;
+        (bottom / bucket, cc.x)
+    });
+
+    let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
+    let mut dict_entries: Vec<Bitmap> = Vec::new();
+    let mut by_size: BTreeMap<(u32, u32), Vec<usize>> = BTreeMap::new();
+    let shared_len = shared_symbols.len();
+    for sym in shared_symbols {
+        let idx = dict_entries.len();
+        dedup.insert((sym.width, sym.height, sym.data.clone()), idx);
+        by_size
+            .entry((sym.width, sym.height))
+            .or_default()
+            .push(idx);
+        dict_entries.push(sym.clone());
+    }
+
+    for &cc_idx in &order {
+        let cc = &ccs[cc_idx];
+        let pixels = (cc.bitmap.width as u64) * (cc.bitmap.height as u64);
+        stats.total_ccs += 1;
+
+        let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
+        if let Some(idx) = dedup.get(&key).copied() {
+            stats.rec_7_exact += 1;
+            stats.pixels_rec_7 += pixels;
+            // rec-7 emits no new dict entry, no need to update tables.
+            let _ = idx;
+            continue;
+        }
+
+        let candidates = by_size
+            .get(&(cc.bitmap.width, cc.bitmap.height))
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+        match find_refinement_ref(&cc.bitmap, &dict_entries, candidates) {
+            Some(ref_idx) => {
+                let ref_bm = &dict_entries[ref_idx];
+                let d = packed_hamming(&cc.bitmap.data, &ref_bm.data);
+                stats.rec_6_hamming.push(d);
+                if ref_idx < shared_len {
+                    stats.rec_6_refine_shared += 1;
+                } else {
+                    stats.rec_6_refine_local += 1;
+                }
+                stats.pixels_rec_6 += pixels;
+                // rec-6 emits no new dict entry — the refinement is blit-only.
+            }
+            None => {
+                stats.rec_1_new += 1;
+                stats.pixels_rec_1 += pixels;
+                let idx = dict_entries.len();
+                dedup.insert(key, idx);
+                by_size
+                    .entry((cc.bitmap.width, cc.bitmap.height))
+                    .or_default()
+                    .push(idx);
+                dict_entries.push(cc.bitmap.clone());
+            }
+        }
+    }
+
+    stats
+}
+
 /// Encode a multi-page bilevel document as a bundled DJVM with a shared Djbz.
 ///
 /// CCs that appear on at least `shared_dict_page_threshold` distinct input
@@ -1868,5 +1980,59 @@ mod tests {
             .expect("mask 1 present");
         assert_decoded_eq(&p1, &d1);
         assert_decoded_eq(&p2, &d2);
+    }
+
+    #[test]
+    fn analyze_jb2_cc_stats_classifies_records() {
+        // Three CCs on one page, each well-separated:
+        //   1. solid 6×6 block             → byte-exact match against shared (rec-7)
+        //   2. solid 6×6 minus one pixel   → Hamming-1 match against shared  (rec-6)
+        //   3. solid 5×5 block             → unrelated, no same-size match   (rec-1)
+        //
+        // REFINEMENT_MIN_PIXELS = 32 forces the 5×5 path through rec-1 even
+        // if the dict had a same-size entry. The 6×6 entries (36 pixels each)
+        // are eligible for rec-6 against the shared dict.
+        let shared_glyph = make_bitmap(6, 6, |_, _| true);
+        let near_dup = make_bitmap(6, 6, |x, y| !(x == 3 && y == 3));
+        let unrelated = make_bitmap(5, 5, |_, _| true);
+
+        let stamp = |page: &mut Bitmap, ox: u32, oy: u32, src: &Bitmap| {
+            for y in 0..src.height {
+                for x in 0..src.width {
+                    if src.get(x, y) {
+                        page.set(ox + x, oy + y, true);
+                    }
+                }
+            }
+        };
+        let mut page = make_bitmap(40, 12, |_, _| false);
+        stamp(&mut page, 2, 2, &shared_glyph);
+        stamp(&mut page, 14, 2, &near_dup);
+        stamp(&mut page, 26, 2, &unrelated);
+
+        let stats = analyze_jb2_cc_stats(&page, &[shared_glyph]);
+        assert_eq!(stats.rec_7_exact, 1, "expected one byte-exact rec-7 hit");
+        assert_eq!(
+            stats.rec_6_refine_shared, 1,
+            "expected one refinement against the shared dict slot"
+        );
+        assert_eq!(stats.rec_6_refine_local, 0);
+        assert!(
+            stats.rec_1_new >= 1,
+            "expected at least one rec-1 (got {})",
+            stats.rec_1_new
+        );
+        assert_eq!(stats.rec_6_hamming.len(), 1);
+        assert_eq!(stats.rec_6_hamming[0], 1);
+        assert!(stats.pixels_rec_7 > 0);
+        assert!(stats.pixels_rec_6 > 0);
+        assert!(stats.pixels_rec_1 > 0);
+        assert_eq!(
+            stats.total_ccs,
+            stats.rec_1_new
+                + stats.rec_6_refine_local
+                + stats.rec_6_refine_shared
+                + stats.rec_7_exact
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds the measurement layer the #194 Phase 2.5 follow-up needs before deciding whether a per-CC profitability model is worth implementing. Pure instrumentation — no encoder behavior change.

- **New `pub fn analyze_jb2_cc_stats(page, &shared) -> CcStats`** in `jb2_encode.rs`. Mirrors the rec-1 / rec-6 / rec-7 action-selection logic in `encode_jb2_dict_with_shared` without emitting bytes. Returns per-record counts, pixel volumes, and a Hamming-distance vector for rec-6 emissions, distinguishing references that resolve into the shared (cross-page) Djbz from references that resolve into the page-local running dict.
- **`examples/encode_quality_djbz.rs` gets `--cc-stats` flag** printing the per-file CC breakdown plus a fixed-bin Hamming histogram.
- **Unit test** `analyze_jb2_cc_stats_classifies_records` covers all three record types and the shared-vs-local distinction.

## Findings

Run on `tests/corpus/*.djvu` (36 pages, 4 books, recorded in CLAUDE.md):

| File | rec-1 fresh | rec-6 shared | rec-6 local | rec-7 exact |
|---|---:|---:|---:|---:|
| `cable_1973_100133.djvu` | 12.4% | 0.0% | 4.7% | 82.8% |
| `conquete_paix.djvu` | 40.7% | 0.2% | 2.1% | 56.9% |
| `watchmaker.djvu` | 6.1% | 24.7% | 1.8% | 67.5% |

rec-6 Hamming distribution on `watchmaker` (6256 matches, dominant case): **49.7% in [1, 4], 47.7% in [5, 16], 2.5% in [17, 64], 0% above**.

## What this tells us about Phase 2.5 viability

The rec-6 Hamming distribution is already very tight on the dominant shared-dict beneficiary. The existing 4%-of-pixels threshold in `find_refinement_ref` is approximately right; there's little headroom for a "tighter" or "smarter" same-size profitability gate to materially change anything.

The plausible Phase 2.5 win is **cross-size refinement matching**, not per-CC profitability against the same-size shortlist. That's a substantially larger change (requires resampling for Hamming scoring) and the open #194 follow-up should track it.

## Test plan

- [x] `cargo test --lib jb2_encode` — 31/31 pass
- [x] `cargo clippy --lib --tests -- -D warnings` — clean
- [x] `cargo clippy --example encode_quality_djbz --features cli -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run --release --example encode_quality_djbz --features cli -- --cc-stats tests/corpus/*.djvu` — produces the table above; all bundle round-trips pixel-exact

🤖 Generated with [Claude Code](https://claude.com/claude-code)