### PR TITLE
chore(workspace): extract djvu-zp into standalone crate (PR1 of #229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,86 @@ Referenced from issue templates ("Record result in CLAUDE.md (Kept or Reverted +
 
 Each entry: issue, approach, numbers, decision, reason.
 
+### #229 PR1 — extract `djvu-zp` into a standalone workspace crate — **Kept** (2026-04-30)
+
+**Approach.** Moved `src/zp/{mod,encoder,tables}.rs` into a new
+`crates/djvu-zp/` workspace member with its own `Cargo.toml`. The new
+crate:
+
+- Defines `pub enum ZpError { TooShort }` instead of leaking `BzzError`
+  back into ZP. Decoupling ZP from `crate::error` is what makes the
+  extraction publishable.
+- Promotes every `pub(crate)` to `pub` (the audit the issue body warns
+  about): `ZpDecoder`, `ZpDecoder::{a, c, fence, bit_buf, bit_count, data,
+  pos}` fields, `decode_bit`, `decode_passthrough`, `decode_passthrough_iw44`,
+  `is_exhausted`, `ZpEncoder` + its methods, and the four format-constant
+  tables (`PROB`, `THRESHOLD`, `MPS_NEXT`, `LPS_NEXT`).
+- Has a `default = ["std"]` feature that gates the encoder (which needs
+  `Vec<u8>`). Decoder works in `no_std` builds and never allocates.
+- Adds a `Default` impl on `ZpEncoder` (clippy `new_without_default` for
+  the now-public `new` method).
+
+`src/lib.rs` keeps the historical internal name via
+`pub(crate) use djvu_zp as zp_impl;` so every existing import
+(`crate::zp_impl::ZpDecoder`, `crate::zp_impl::tables::PROB`, etc) keeps
+working unchanged. `From<djvu_zp::ZpError> for BzzError` makes the `?`
+operator in `bzz_new::bzz_decode` continue to work without per-callsite
+edits.
+
+`src/zp/` is removed; the `#[path = "zp/mod.rs"] pub(crate) mod zp_impl;`
+attribute in `src/lib.rs` was replaced with the `use` re-export. Workspace
+`members = [".", "djvu-py", "crates/djvu-zp"]`.
+
+**Tests.** Per-crate test counts:
+
+- `djvu-rs` (umbrella): 393 lib tests pass (down from 405 — the 4 ZP
+  decoder tests + 7 ZP encoder roundtrip tests moved into the new crate).
+- `djvu-zp`: 11 unit tests pass (`zp_decoder_*`, `zp_tables_spot_check`,
+  7 roundtrip tests in the encoder module). Two doctest examples
+  (`ZpDecoder::new` from a 2-byte slice, `ZpEncoder` round-trip).
+- `djvu-py`: builds. No tests defined.
+- Workspace `cargo build --no-default-features --lib` (host
+  no-std-compatible build) green; no_std smoke test
+  (`tests/no_std_smoke`) builds green against the new dependency graph.
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- `cargo fmt --check` clean.
+
+**Scope of `pub` audit.** Every newly-`pub` item was an internal
+`pub(crate)` before — there is no new behavioural surface, just a wider
+visibility. Specifically:
+
+| Was            | Now           | Justification                                               |
+| -------------- | ------------- | ----------------------------------------------------------- |
+| `ZpDecoder`    | `pub`         | Required for cross-crate use                                |
+| Decoder fields | `pub`         | Hot-path field access from JB2/IW44/BZZ in djvu-rs internals |
+| `ZpEncoder`    | `pub`         | Required for cross-crate use                                |
+| `PROB` etc.    | `pub` (in `pub mod tables`) | Used by JB2/IW44/BZZ saturation-bound tests in djvu-rs |
+
+The decoder field exposure is the only mildly load-bearing widening: it
+lets djvu-rs internals manipulate the registers directly during
+saturated-decode fast paths. Wrapping each in a getter would force every
+hot-path access through a function call. Acceptable for an internal-
+collaboration sub-crate and matches the precedent set by `wide` /
+`bytemuck` / similar low-level numerics crates.
+
+**Reason kept.** Lossless extraction of ~780 LOC into a publishable
+sub-crate, no behavioural change for djvu-rs consumers, all tests pass,
+no_std build still works. This is the canonical "is this approach
+viable" first step of #229; PR2 (`djvu-bzz`), PR3 (`djvu-iff`), PR4-5
+(`djvu-jb2`, `djvu-iw44`), and PR6 (umbrella re-export shim) follow the
+same pattern.
+
+**Open follow-ups.**
+1. The `From<ZpError> for BzzError` mapping collapses to `BzzError::TooShort`
+   — fine for now since `ZpError::TooShort` is the only variant. If
+   future ZP-coder errors are added, the mapping needs a more specific
+   `BzzError` variant (likely `BzzError::ZpError`-already-exists).
+2. Publish to crates.io once the API is reviewed. The `version = "0.1.0"`
+   reflects new-crate convention, not djvu-rs's `0.14.0` line.
+3. Consider whether the encoder fields (`a`, `subend`, `buffer`, `nrun`,
+   `delay`, `byte`, `scount`, `output`) need to be `pub`. Currently they
+   stay private — only methods are exposed.
+
 ### #189 Phase 3 — x86_64 AVX2 ports of `prelim_flags_bucket` + `prelim_flags_band0` — **Kept** (2026-04-30)
 
 **Approach.** Two new AVX2 functions mirroring the existing aarch64 NEON

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "djvu-py"]
+members = [".", "djvu-py", "crates/djvu-zp"]
 exclude = ["fuzz", "tests/no_std_smoke"]
 
 [package]
@@ -35,6 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 thiserror = "2"
 wide = "0.7"
+djvu-zp = { version = "0.1.0", path = "crates/djvu-zp", default-features = false }
 # Used only by the djvu CLI binary.
 clap = { version = "4", features = ["derive"], optional = true }
 png = { version = "0.17", optional = true }
@@ -63,7 +64,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["std"]
-std = ["dep:png", "dep:zip", "dep:miniz_oxide", "dep:zune-jpeg", "dep:jpeg-encoder"]
+std = ["dep:png", "dep:zip", "dep:miniz_oxide", "dep:zune-jpeg", "dep:jpeg-encoder", "djvu-zp/std"]
 cli = ["std", "dep:clap"]
 jpeg = ["dep:zune-jpeg"]
 tiff = ["dep:tiff", "std"]

--- a/crates/djvu-zp/Cargo.toml
+++ b/crates/djvu-zp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "djvu-zp"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+license = "MIT"
+description = "ZP adaptive binary arithmetic coder for the DjVu format — pure-Rust clean-room implementation, no_std-capable decoder."
+repository = "https://github.com/matyushkin/djvu-rs"
+documentation = "https://docs.rs/djvu-zp"
+readme = "README.md"
+keywords = ["djvu", "arithmetic-coder", "compression", "no-std"]
+categories = ["compression", "no-std"]
+publish = true
+
+[features]
+default = ["std"]
+# `std` enables the encoder (which needs `Vec<u8>`).  Disable for no_std
+# decode-only consumers — the decoder itself does not allocate.
+std = []
+
+[dependencies]
+thiserror = { version = "2", default-features = false }

--- a/crates/djvu-zp/README.md
+++ b/crates/djvu-zp/README.md
@@ -1,0 +1,56 @@
+# djvu-zp
+
+Pure-Rust clean-room implementation of the **ZP adaptive binary arithmetic
+coder** specified in the [DjVu v3 specification](https://www.sndjvu.org/spec.html).
+
+ZP is the entropy coder underlying every codec in a DjVu file:
+[BZZ](https://crates.io/crates/djvu-rs) (text-chunk compression),
+[JB2](https://crates.io/crates/djvu-rs) (bilevel image),
+and [IW44](https://crates.io/crates/djvu-rs) (wavelet color/grey image).
+
+This crate exposes the coder primitives so codec implementations and other
+downstream consumers (e.g. format-conformance tools, fuzz harnesses) can
+share one well-tested implementation.
+
+## Status
+
+Extracted from the [`djvu-rs`](https://crates.io/crates/djvu-rs) umbrella
+crate as part of issue [#229](https://github.com/matyushkin/djvu-rs/issues/229).
+The decoder is the same code shipped in `djvu-rs ≥ 0.14`, vetted by the
+project's full corpus + property + fuzz suite.
+
+## Usage
+
+### Decoder (no-std capable, no allocations)
+
+```rust
+use djvu_zp::ZpDecoder;
+
+let compressed: &[u8] = &[0x00, 0x00];
+let mut dec = ZpDecoder::new(compressed)?;
+let mut ctx = 0u8;
+let _bit = dec.decode_bit(&mut ctx);
+# Ok::<(), djvu_zp::ZpError>(())
+```
+
+### Encoder (requires `std`, default-on)
+
+```rust
+use djvu_zp::encoder::ZpEncoder;
+
+let mut enc = ZpEncoder::new();
+let mut ctx = 0u8;
+enc.encode_bit(&mut ctx, true);
+let bytes: Vec<u8> = enc.finish();
+```
+
+## Features
+
+| Feature | Default | Effect |
+| ------- | ------- | ------ |
+| `std`   | ✓       | Enables [`encoder::ZpEncoder`]. The decoder works either way and never allocates. |
+
+## License
+
+MIT — see the upstream [`djvu-rs`](https://github.com/matyushkin/djvu-rs)
+repository.

--- a/crates/djvu-zp/src/encoder.rs
+++ b/crates/djvu-zp/src/encoder.rs
@@ -11,7 +11,7 @@ use super::tables::{LPS_NEXT, MPS_NEXT, PROB, THRESHOLD};
 /// `unsigned int` types. They hold u16-range values but intermediate
 /// arithmetic can exceed 0xFFFF, which is critical for correct carry
 /// propagation in `zemit`.
-pub(crate) struct ZpEncoder {
+pub struct ZpEncoder {
     /// Current interval width — stored as u32 but logically u16 after shifts.
     a: u32,
     /// Sub-interval lower bound for bit emission — u32 for carry propagation.
@@ -30,8 +30,14 @@ pub(crate) struct ZpEncoder {
     output: Vec<u8>,
 }
 
+impl Default for ZpEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ZpEncoder {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             a: 0,
             subend: 0,
@@ -50,7 +56,7 @@ impl ZpEncoder {
     /// - LPS always calls encode_lps
     /// - MPS with z >= 0x8000 calls encode_mps
     /// - MPS with z < 0x8000 takes fast path (a = z, no shift)
-    pub(crate) fn encode_bit(&mut self, ctx: &mut u8, bit: bool) {
+    pub fn encode_bit(&mut self, ctx: &mut u8, bit: bool) {
         let state = *ctx as usize;
         let mps_bit = (state & 1) != 0;
         let z = self.a + PROB[state] as u32;
@@ -69,7 +75,7 @@ impl ZpEncoder {
     ///
     /// Counterpart to [`ZpDecoder::decode_passthrough_iw44`]; must produce a
     /// stream that it correctly decodes.
-    pub(crate) fn encode_passthrough_iw44(&mut self, bit: bool) {
+    pub fn encode_passthrough_iw44(&mut self, bit: bool) {
         let z = 0x8000 + (3 * self.a / 8);
         // Invariant: self.a < 0x8000 (all encode paths maintain this).
         // Therefore z = 0x8000 + 3a/8 ∈ [0x8000, 0xB000) — always ≥ 0x8000.
@@ -91,7 +97,7 @@ impl ZpEncoder {
         }
     }
 
-    pub(crate) fn encode_passthrough(&mut self, bit: bool) {
+    pub fn encode_passthrough(&mut self, bit: bool) {
         let z = 0x8000 + (self.a >> 1);
         // Invariant: self.a < 0x8000, so z = 0x8000 + a/2 ∈ [0x8000, 0xC000) — always ≥ 0x8000.
         if !bit {
@@ -114,7 +120,7 @@ impl ZpEncoder {
     }
 
     /// Flush the encoder and return the compressed byte stream.
-    pub(crate) fn finish(mut self) -> Vec<u8> {
+    pub fn finish(mut self) -> Vec<u8> {
         // eflush: round subend up to disambiguate
         if self.subend > 0x8000 {
             self.subend = 0x10000;
@@ -223,7 +229,7 @@ impl ZpEncoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::zp_impl::ZpDecoder;
+    use crate::ZpDecoder;
 
     #[test]
     fn zp_roundtrip_passthrough_false() {

--- a/crates/djvu-zp/src/lib.rs
+++ b/crates/djvu-zp/src/lib.rs
@@ -1,17 +1,56 @@
 //! ZP adaptive binary arithmetic coder — pure-Rust clean-room implementation.
 //!
-//! This module implements the ZP (Z-Prime) adaptive binary arithmetic decoder
-//! from the DjVu v3 specification (<https://www.sndjvu.org/spec.html>).
+//! This crate implements the ZP (Z-Prime) adaptive binary arithmetic coder
+//! from the DjVu v3 specification (<https://www.sndjvu.org/spec.html>),
+//! used by the JB2, IW44, and BZZ codecs that make up a DjVu file.
 //!
-//! Key public types:
-//! - [`ZpDecoder`] — the ZP decoder state machine
+//! ## Usage
+//!
+//! Decoder (no_std-capable, no allocations):
+//!
+//! ```
+//! use djvu_zp::ZpDecoder;
+//! let compressed: &[u8] = &[0x00, 0x00];
+//! let mut dec = ZpDecoder::new(compressed)?;
+//! let mut ctx = 0u8;
+//! let _bit = dec.decode_bit(&mut ctx);
+//! # Ok::<(), djvu_zp::ZpError>(())
+//! ```
+//!
+//! Encoder (requires `std` feature, default-on):
+//!
+//! ```
+//! # #[cfg(feature = "std")]
+//! # {
+//! use djvu_zp::encoder::ZpEncoder;
+//! let mut enc = ZpEncoder::new();
+//! let mut ctx = 0u8;
+//! enc.encode_bit(&mut ctx, true);
+//! let _bytes: Vec<u8> = enc.finish();
+//! # }
+//! ```
+//!
+//! ## Features
+//!
+//! - `std` (default) — enables [`encoder::ZpEncoder`].  The decoder works
+//!   with or without `std` and never allocates.
+
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
-pub(crate) mod encoder;
-pub(crate) mod tables;
+pub mod encoder;
+pub mod tables;
 
-use crate::error::BzzError;
 use tables::{LPS_NEXT, MPS_NEXT, PROB, THRESHOLD};
+
+/// Errors that can occur while initializing or decoding a ZP stream.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ZpError {
+    /// Input is too short — the ZP coder needs at least 2 bytes to load the
+    /// initial code register.
+    #[error("ZP input is too short (need at least 2 bytes)")]
+    TooShort,
+}
 
 /// ZP (Z-Prime) adaptive binary arithmetic decoder.
 ///
@@ -22,21 +61,21 @@ use tables::{LPS_NEXT, MPS_NEXT, PROB, THRESHOLD};
 /// Context bytes encode both the probability state index and the current MPS
 /// (most probable symbol) value. The low bit of the context byte indicates
 /// the current MPS; the remaining bits encode the probability state.
-pub(crate) struct ZpDecoder<'a> {
+pub struct ZpDecoder<'a> {
     /// Current interval width register (16-bit value held in low 16 bits).
-    pub(crate) a: u32,
+    pub a: u32,
     /// Current code (value within the interval) register (16-bit value held in low 16 bits).
-    pub(crate) c: u32,
+    pub c: u32,
     /// Cached upper bound for the fast decode path (= min(c, 0x7fff)).
-    pub(crate) fence: u32,
+    pub fence: u32,
     /// Bit buffer for feeding bits into the code register.
-    pub(crate) bit_buf: u32,
+    pub bit_buf: u32,
     /// Number of valid bits remaining in `bit_buf`.
-    pub(crate) bit_count: i32,
+    pub bit_count: i32,
     /// Compressed input bytes.
-    pub(crate) data: &'a [u8],
+    pub data: &'a [u8],
     /// Current read position within `data`.
-    pub(crate) pos: usize,
+    pub pos: usize,
 }
 
 impl<'a> ZpDecoder<'a> {
@@ -46,10 +85,10 @@ impl<'a> ZpDecoder<'a> {
     ///
     /// # Errors
     ///
-    /// Returns [`BzzError::TooShort`] if `data` has fewer than 2 bytes.
-    pub(crate) fn new(data: &'a [u8]) -> Result<Self, BzzError> {
+    /// Returns [`ZpError::TooShort`] if `data` has fewer than 2 bytes.
+    pub fn new(data: &'a [u8]) -> Result<Self, ZpError> {
         if data.len() < 2 {
-            return Err(BzzError::TooShort);
+            return Err(ZpError::TooShort);
         }
 
         let mut dec = ZpDecoder {
@@ -105,7 +144,7 @@ impl<'a> ZpDecoder<'a> {
     ///
     /// Returns `true` if the decoded bit is 1.
     #[inline(always)]
-    pub(crate) fn decode_bit(&mut self, ctx: &mut u8) -> bool {
+    pub fn decode_bit(&mut self, ctx: &mut u8) -> bool {
         let state = *ctx as usize;
         let mps_bit = state & 1; // low bit encodes the current MPS
         let z = self.a + PROB[state] as u32;
@@ -150,7 +189,7 @@ impl<'a> ZpDecoder<'a> {
     /// After exhaustion the coder returns `0xFF` bytes indefinitely, producing
     /// deterministic but meaningless bits. Callers may use this to skip
     /// remaining work that would otherwise loop on constant input.
-    pub(crate) fn is_exhausted(&self) -> bool {
+    pub fn is_exhausted(&self) -> bool {
         self.pos >= self.data.len()
     }
 
@@ -161,7 +200,7 @@ impl<'a> ZpDecoder<'a> {
     ///
     /// Returns `true` if the decoded bit is 1.
     #[inline(always)]
-    pub(crate) fn decode_passthrough(&mut self) -> bool {
+    pub fn decode_passthrough(&mut self) -> bool {
         let z = (0x8000u32 + (self.a >> 1)) as u16;
         self.passthrough_with_threshold(z)
     }
@@ -172,7 +211,7 @@ impl<'a> ZpDecoder<'a> {
     ///
     /// Returns `true` if the decoded bit is 1.
     #[inline(always)]
-    pub(crate) fn decode_passthrough_iw44(&mut self) -> bool {
+    pub fn decode_passthrough_iw44(&mut self) -> bool {
         let z = (0x8000u32 + (3u32 * self.a) / 8) as u16;
         self.passthrough_with_threshold(z)
     }
@@ -221,16 +260,15 @@ impl<'a> ZpDecoder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::BzzError;
 
     #[test]
     fn zp_decoder_rejects_empty_input() {
-        assert!(matches!(ZpDecoder::new(&[]), Err(BzzError::TooShort)));
+        assert!(matches!(ZpDecoder::new(&[]), Err(ZpError::TooShort)));
     }
 
     #[test]
     fn zp_decoder_rejects_one_byte_input() {
-        assert!(matches!(ZpDecoder::new(&[0x00]), Err(BzzError::TooShort)));
+        assert!(matches!(ZpDecoder::new(&[0x00]), Err(ZpError::TooShort)));
     }
 
     #[test]

--- a/crates/djvu-zp/src/tables.rs
+++ b/crates/djvu-zp/src/tables.rs
@@ -4,7 +4,7 @@
 //! ZP arithmetic coder. The tables are defined in the DjVu v3 specification at
 //! <https://www.sndjvu.org/spec.html>.
 //!
-//! Key public types (all `pub(crate)` constants):
+//! Public exports:
 //! - [`PROB`] — probability estimates (256 entries, u16)
 //! - [`THRESHOLD`] — adaptation thresholds (256 entries, u16)
 //! - [`MPS_NEXT`] — state transitions on MPS (most probable symbol) (256 entries, u8)
@@ -18,7 +18,7 @@
 /// 251 valid entries + 5 padding entries (indices 251–255, never accessed).
 /// Each entry gives the probability that the next decoded bit is the MPS (most
 /// probable symbol). Values are unsigned 16-bit fractions in the range [0, 0x8000].
-pub(crate) const PROB: [u16; 256] = [
+pub const PROB: [u16; 256] = [
     0x8000, 0x8000, 0x8000, 0x6bbd, 0x6bbd, 0x5d45, 0x5d45, 0x51b9, 0x51b9, 0x4813, 0x4813, 0x3fd5,
     0x3fd5, 0x38b1, 0x38b1, 0x3275, 0x3275, 0x2cfd, 0x2cfd, 0x2825, 0x2825, 0x23ab, 0x23ab, 0x1f87,
     0x1f87, 0x1bbb, 0x1bbb, 0x1845, 0x1845, 0x1523, 0x1523, 0x1253, 0x1253, 0x0fcf, 0x0fcf, 0x0d95,
@@ -50,7 +50,7 @@ pub(crate) const PROB: [u16; 256] = [
 ///
 /// When `a >= m[state]`, the MPS transition updates the context state using
 /// [`MPS_NEXT`]. Entries beyond state 82 are 0 (no threshold-based update).
-pub(crate) const THRESHOLD: [u16; 256] = [
+pub const THRESHOLD: [u16; 256] = [
     0x0000, 0x0000, 0x0000, 0x10a5, 0x10a5, 0x1f28, 0x1f28, 0x2bd3, 0x2bd3, 0x36e3, 0x36e3, 0x408c,
     0x408c, 0x48fd, 0x48fd, 0x505d, 0x505d, 0x56d0, 0x56d0, 0x5c71, 0x5c71, 0x615b, 0x615b, 0x65a5,
     0x65a5, 0x6962, 0x6962, 0x6ca2, 0x6ca2, 0x6f74, 0x6f74, 0x71e6, 0x71e6, 0x7404, 0x7404, 0x75d6,
@@ -80,7 +80,7 @@ pub(crate) const THRESHOLD: [u16; 256] = [
 ///
 /// When the decoded bit matches the MPS and `a >= m[state]`, the context is
 /// updated to `MPS_NEXT[state]`.
-pub(crate) const MPS_NEXT: [u8; 256] = [
+pub const MPS_NEXT: [u8; 256] = [
     84, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
     27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
     51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74,
@@ -101,7 +101,7 @@ pub(crate) const MPS_NEXT: [u8; 256] = [
 ///
 /// When the decoded bit does not match the MPS, the context is updated to
 /// `LPS_NEXT[state]`.
-pub(crate) const LPS_NEXT: [u8; 256] = [
+pub const LPS_NEXT: [u8; 256] = [
     145, 4, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
     24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
     48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,

--- a/src/error.rs
+++ b/src/error.rs
@@ -217,6 +217,14 @@ pub enum BzzError {
     OutputTooLarge,
 }
 
+/// Map ZP-coder init errors into [`BzzError`] so callers using `?` keep working
+/// after the ZP coder moved into the standalone `djvu-zp` crate (#229 PR1).
+impl From<djvu_zp::ZpError> for BzzError {
+    fn from(_: djvu_zp::ZpError) -> Self {
+        BzzError::TooShort
+    }
+}
+
 // ---- Legacy error type (kept for backward compatibility) --------------------
 
 /// Original error type used by the legacy implementation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,11 +72,12 @@ pub mod error;
 /// INFO chunk parser (phase 1).
 pub(crate) mod info;
 
-/// ZP arithmetic coder — clean-room implementation (phase 2a).
+/// ZP arithmetic coder — clean-room implementation.
 ///
-/// Provides `ZpDecoder` used by BZZ, JB2, and IW44 decoders.
-#[path = "zp/mod.rs"]
-pub(crate) mod zp_impl;
+/// Lives in the standalone [`djvu_zp`] sub-crate (workspace member) since
+/// PR1 of #229.  Re-exported here as `zp_impl` for backwards compatibility
+/// with the historical internal path used by BZZ, JB2, and IW44.
+pub(crate) use djvu_zp as zp_impl;
 
 /// BZZ decompressor — clean-room implementation.
 ///


### PR DESCRIPTION
PR1 of #229 — workspace split sequence.

## Summary

Moves `src/zp/{mod,encoder,tables}.rs` into a new workspace member at `crates/djvu-zp/` so the ZP arithmetic coder can be published, fuzzed, and consumed independently. The decoder is no_std-capable; the encoder needs `Vec<u8>` so it sits behind the default-on `std` feature.

## Public surface

- `pub enum ZpError { TooShort }` — decoupled from `crate::error::BzzError`
- `pub struct ZpDecoder<'a>` + decoder methods (`decode_bit`, `decode_passthrough`, `decode_passthrough_iw44`, `is_exhausted`)
- `pub mod encoder` (std-gated) → `pub struct ZpEncoder`
- `pub mod tables` → `PROB`, `THRESHOLD`, `MPS_NEXT`, `LPS_NEXT`

## Backwards compatibility

- `pub(crate) use djvu_zp as zp_impl;` in `src/lib.rs` keeps every existing `crate::zp_impl::*` import working unchanged.
- `From<djvu_zp::ZpError> for BzzError` makes the `?` operator in `bzz_new::bzz_decode` keep working without per-callsite edits.

No behavioural change for djvu-rs consumers; this is a pure code reorganization.

## Surface widening audit

Every now-`pub` item was `pub(crate)` before. The mildly load-bearing widening is the decoder fields (`a`, `c`, `fence`, …): hot paths in djvu-rs internals manipulate them directly during saturated-decode fast paths. Gating them through getters would add a function-call cost per access. Acceptable for an internal-collaboration sub-crate, matches the precedent set by `wide` / `bytemuck`.

## Test plan

- [x] `cargo test --workspace` (393 djvu-rs lib tests + 11 djvu-zp tests + 2 doctests, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --no-default-features --lib` (no_std-compatible build) green
- [x] `tests/no_std_smoke` builds green against the new dependency graph
- [x] djvu-py builds

The 4 ZP decoder tests + 7 encoder roundtrip tests moved from `djvu-rs::zp_impl::tests` into the new crate (so `djvu-rs` test count drops from 405 → 393). All assertions kept verbatim; only the import paths and error-type references changed.

## Open follow-ups

- The `From<ZpError> for BzzError` mapping collapses to `BzzError::TooShort` since `ZpError::TooShort` is the only variant. If future ZP-coder errors are added the mapping needs a more specific `BzzError` variant (potentially the existing `BzzError::ZpError`).
- Publish to crates.io once the API is reviewed.

PR2 (`djvu-bzz`), PR3 (`djvu-iff`), PR4-5 (`djvu-jb2`, `djvu-iw44`), PR6 (umbrella re-export shim) follow the same pattern but each gets its own PR.

CLAUDE.md updated with `### #229 PR1 — Kept (2026-04-30)`.

https://claude.ai/code/session_01UVQNy1StBVvjfYn5m3Wuth

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVQNy1StBVvjfYn5m3Wuth)_