### PR TITLE
feat(api): DjVuDocumentMut::from_bytes — chunk-replacement primitive (PR1 of #222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,76 @@ Referenced from issue templates ("Record result in CLAUDE.md (Kept or Reverted +
 
 Each entry: issue, approach, numbers, decision, reason.
 
+### #222 PR1 — `DjVuDocumentMut::from_bytes` + chunk-replacement primitive — **Kept** (2026-04-30)
+
+**Approach.** New `src/djvu_mut.rs` module gated on `feature = "std"` with
+the foundation layer for in-place document mutation. Public surface:
+
+- `pub struct DjVuDocumentMut` — owns a parsed `DjvuFile` tree plus the
+  original byte buffer.
+- `pub fn from_bytes(data: &[u8]) -> Result<Self, MutError>` — parses (via
+  `iff::parse`, the legacy tree-based parser) and retains the input bytes.
+- `pub fn into_bytes(self) -> Vec<u8>` — fast path: when no mutation has
+  happened, returns the original bytes verbatim. After any mutation, falls
+  through to `iff::emit`.
+- `pub fn replace_leaf(&mut self, path: &[usize], new_data: Vec<u8>)` —
+  walks the tree by child indices and rewrites the leaf payload.
+- `pub fn chunk_at_path(&self, path: &[usize]) -> Result<&Chunk, _>` —
+  read-only walker, used by tests and (future) inspectors.
+- Utility: `root_child_count`, `root_form_type`, `is_dirty`.
+- `pub enum MutError`: `Parse(LegacyError)`, `PathOutOfRange`,
+  `PathTraversesLeaf`, `NotALeaf`, `EmptyPath`.
+
+The byte-identical-no-edit guarantee is achieved by holding the original
+`Vec<u8>` and short-circuiting `into_bytes` when `!is_dirty`. After any
+mutation `iff::emit` is invoked, which **does not** guarantee byte-identity
+even for unmutated chunks (it recomputes FORM lengths from children) — but
+this case is explicitly out of scope for PR1 and tracked as a follow-up
+for PR3 (proper byte-range patching).
+
+**Tests.** Ten new unit tests in `djvu_mut::tests`:
+
+- Round-trip byte-identical (no edit) on four corpus fixtures:
+  - `chicken.djvu` — color FORM:DJVU
+  - `boy_jb2.djvu` — bilevel FORM:DJVU
+  - `DjVu3Spec_bundled.djvu` — multi-page FORM:DJVM
+  - `navm_fgbz.djvu` — FORM:DJVU with NAVM + FGbz
+- `replace_leaf_changes_emitted_bytes` — replaces INFO with a marker, parses
+  the output, verifies the marker came back.
+- Negative paths: `EmptyPath`, `PathOutOfRange`, `PathTraversesLeaf`,
+  `NotALeaf` (last picks the last child of a DJVM bundle, which is a
+  page FORM).
+- `root_form_type_djvu_single_page` — sanity on the tree-introspection API.
+
+All 402 lib tests pass (393 → 402; `+10` djvu_mut, `-1` ignored count
+shifted). `cargo clippy --workspace --all-targets -- -D warnings` clean,
+`cargo fmt --check` clean.
+
+**Reason kept.** PR1 of #222 establishes the byte-identical contract and
+the chunk-walking primitive that PR2-4 build on (per the issue body's
+sequencing comment). The implementation is intentionally minimal — wrap
+the existing IFF parser, hold raw bytes for fast path, expose one
+mutation primitive — to ship a focused first slice without committing to
+the high-level setter design (`set_metadata`, `set_bookmarks`,
+`page_mut(i).set_text_layer`). Those settings each compose
+`replace_leaf` with one of the existing chunk encoders
+(`encode_navm`, `encode_annotations*`, `encode_metadata`,
+`encode_text_layer`).
+
+**Open follow-ups (PR2-4 of #222 sequence).**
+1. **PR2**: high-level setters (`set_metadata`, `set_bookmarks`,
+   `page_mut(i).set_text_layer`, `…set_annotations`) on top of
+   `replace_leaf`.
+2. **PR3**: byte-range patching for true byte-identical round-trip even
+   *with* edits (only changed chunks are rewritten; unchanged regions are
+   memcpy'd). Currently any mutation triggers a full `iff::emit` which
+   may differ from the original byte layout in incidental ways (FORM
+   length recomputation, padding).
+3. **PR4**: indirect DJVM support — the issue's "per-file rewrite vs
+   re-bundle" decision still needs a concrete answer.
+4. `librarian` consumer migration off `djvused` shell-out (#158
+   follow-up) — depends on PR2 setters.
+
 ### #229 PR1 — extract `djvu-zp` into a standalone workspace crate — **Kept** (2026-04-30)
 
 **Approach.** Moved `src/zp/{mod,encoder,tables}.rs` into a new

--- a/src/djvu_mut.rs
+++ b/src/djvu_mut.rs
@@ -1,0 +1,343 @@
+//! In-place DjVu document mutation — byte-preserving rewrite of the IFF tree.
+//!
+//! PR1 of [#222](https://github.com/matyushkin/djvu-rs/issues/222). This is the
+//! foundation layer: parse a document into an editable tree, walk to a leaf
+//! chunk by path, replace its data, and serialise back. When no mutations have
+//! happened, [`DjVuDocumentMut::into_bytes`] returns the original bytes
+//! verbatim (byte-identical round-trip).
+//!
+//! Future PRs in the [#222](https://github.com/matyushkin/djvu-rs/issues/222)
+//! sequence add high-level setters (`set_metadata`, `set_bookmarks`,
+//! `page_mut(i).set_text_layer`, `…set_annotations`) plus indirect-DJVM
+//! support, which all build on the chunk-replacement primitive defined here.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use djvu_rs::djvu_mut::DjVuDocumentMut;
+//!
+//! let original = std::fs::read("doc.djvu").unwrap();
+//! let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+//!
+//! // Round-trip byte-identical without edits:
+//! assert_eq!(doc.clone().into_bytes(), original);
+//!
+//! // Replace a leaf chunk's payload by path:
+//! doc.replace_leaf(&[0], b"new payload".to_vec()).unwrap();
+//! let edited = doc.into_bytes();
+//! ```
+//!
+//! ## Path format
+//!
+//! A `path: &[usize]` is a sequence of child indices to walk from the root
+//! `FORM` chunk. The root itself is never indexed — `[0]` selects the first
+//! child of the root.
+//!
+//! For a single-page `FORM:DJVU`: `[i]` selects the i-th leaf chunk
+//! (e.g. `INFO`, `Sjbz`, `BG44`). For a bundled `FORM:DJVM`:
+//! `[0]` selects the `DIRM` chunk, `[1]` selects the `NAVM` chunk (if
+//! present), `[i]` thereafter selects the i-th component `FORM:DJVU`. To
+//! reach a leaf inside that component: `[i, j]`.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::error::LegacyError;
+use crate::iff::{self, Chunk, DjvuFile};
+
+/// Errors produced by [`DjVuDocumentMut`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum MutError {
+    /// IFF parse error during [`DjVuDocumentMut::from_bytes`].
+    #[error("IFF parse error: {0}")]
+    Parse(#[from] LegacyError),
+
+    /// The path indexed past the end of a FORM's children.
+    #[error("chunk path out of range: index {index} at depth {depth} (form has {len} children)")]
+    PathOutOfRange {
+        index: usize,
+        depth: usize,
+        len: usize,
+    },
+
+    /// The path traversed into a leaf chunk and tried to keep going.
+    #[error("chunk path enters a leaf at depth {depth} but is {len} levels long")]
+    PathTraversesLeaf { depth: usize, len: usize },
+
+    /// `replace_leaf` was called with a path that ends on a `FORM` chunk
+    /// rather than a leaf.
+    #[error("path ends on a FORM, not a leaf chunk")]
+    NotALeaf,
+
+    /// The path is empty — must contain at least one index.
+    #[error("path must not be empty")]
+    EmptyPath,
+}
+
+/// A DjVu document opened for in-place mutation.
+///
+/// Holds a parsed [`DjvuFile`] tree plus the original byte buffer, so that
+/// [`Self::into_bytes`] returns a byte-identical copy when no edits have been
+/// made. After any mutation the dirty flag is set and serialisation falls
+/// through to [`iff::emit`], which reconstructs the IFF stream from the tree
+/// (see the parser/emitter contract in `src/iff.rs`).
+#[derive(Debug, Clone)]
+pub struct DjVuDocumentMut {
+    file: DjvuFile,
+    /// Original bytes of the document.  Held so an unedited round-trip is
+    /// byte-identical without re-emitting through `iff::emit` (which
+    /// recomputes FORM lengths and would not necessarily match the original
+    /// byte layout for documents with inconsistent headers).
+    original_bytes: Vec<u8>,
+    dirty: bool,
+}
+
+impl DjVuDocumentMut {
+    /// Parse a DjVu document for mutation. Validates the IFF tree.
+    ///
+    /// The original bytes are retained so that a no-edit round-trip via
+    /// [`Self::into_bytes`] is byte-identical to the input.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, MutError> {
+        let file = iff::parse(data)?;
+        Ok(Self {
+            file,
+            original_bytes: data.to_vec(),
+            dirty: false,
+        })
+    }
+
+    /// Number of direct children of the root FORM chunk.
+    ///
+    /// For a single-page `FORM:DJVU` this is the number of leaf chunks
+    /// (`INFO`, `Sjbz`, …). For a bundled `FORM:DJVM` it is `DIRM` + optional
+    /// `NAVM` + per-page component `FORM`s.
+    pub fn root_child_count(&self) -> usize {
+        self.file.root.children().len()
+    }
+
+    /// Return the 4-byte FORM type of the root (e.g. `b"DJVU"`, `b"DJVM"`).
+    /// Returns `None` if the root is somehow a leaf — should never happen on
+    /// a well-formed input that survived `from_bytes`.
+    pub fn root_form_type(&self) -> Option<&[u8; 4]> {
+        match &self.file.root {
+            Chunk::Form { secondary_id, .. } => Some(secondary_id),
+            Chunk::Leaf { .. } => None,
+        }
+    }
+
+    /// Replace the data of the leaf chunk reached by `path`.
+    ///
+    /// `path` is a sequence of child indices walked from the root FORM's
+    /// children. The walk descends into any FORM it encounters at an
+    /// intermediate index; the final index must address a leaf.
+    ///
+    /// # Errors
+    ///
+    /// - [`MutError::EmptyPath`] if `path.is_empty()`.
+    /// - [`MutError::PathOutOfRange`] if any index exceeds a FORM's child count.
+    /// - [`MutError::PathTraversesLeaf`] if the path tries to descend past a leaf.
+    /// - [`MutError::NotALeaf`] if the final chunk is a FORM rather than a leaf.
+    pub fn replace_leaf(&mut self, path: &[usize], new_data: Vec<u8>) -> Result<(), MutError> {
+        let chunk = self.chunk_at_path_mut(path)?;
+        match chunk {
+            Chunk::Leaf { data, .. } => {
+                *data = new_data;
+                self.dirty = true;
+                Ok(())
+            }
+            Chunk::Form { .. } => Err(MutError::NotALeaf),
+        }
+    }
+
+    /// Return the chunk at `path` for inspection (without mutation).
+    pub fn chunk_at_path(&self, path: &[usize]) -> Result<&Chunk, MutError> {
+        if path.is_empty() {
+            return Err(MutError::EmptyPath);
+        }
+        let mut current = &self.file.root;
+        for (depth, &idx) in path.iter().enumerate() {
+            let children = current.children();
+            if children.is_empty() && depth < path.len() - 1 {
+                // We're inside a leaf but the path keeps going.
+                return Err(MutError::PathTraversesLeaf {
+                    depth,
+                    len: path.len(),
+                });
+            }
+            if let Chunk::Leaf { .. } = current {
+                return Err(MutError::PathTraversesLeaf {
+                    depth,
+                    len: path.len(),
+                });
+            }
+            if idx >= children.len() {
+                return Err(MutError::PathOutOfRange {
+                    index: idx,
+                    depth,
+                    len: children.len(),
+                });
+            }
+            current = &children[idx];
+        }
+        Ok(current)
+    }
+
+    fn chunk_at_path_mut(&mut self, path: &[usize]) -> Result<&mut Chunk, MutError> {
+        if path.is_empty() {
+            return Err(MutError::EmptyPath);
+        }
+        // Validate path first using the immutable walk.  This avoids the
+        // borrow-checker dance of validating during a mutable walk.
+        let _ = self.chunk_at_path(path)?;
+        // Now walk for real with `&mut`.
+        let mut current = &mut self.file.root;
+        for &idx in path {
+            // Validation above guarantees the indices are in range and that
+            // we never index into a leaf, so this match is total.
+            match current {
+                Chunk::Form { children, .. } => {
+                    current = &mut children[idx];
+                }
+                Chunk::Leaf { .. } => unreachable!("validated by chunk_at_path"),
+            }
+        }
+        Ok(current)
+    }
+
+    /// Whether any mutation has been applied since `from_bytes`.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Serialise the document back to bytes.
+    ///
+    /// When [`Self::is_dirty`] is `false`, this returns the bytes passed to
+    /// [`Self::from_bytes`] verbatim. After any mutation it falls through to
+    /// [`iff::emit`] which reconstructs the IFF stream from the parsed tree.
+    pub fn into_bytes(self) -> Vec<u8> {
+        if self.dirty {
+            iff::emit(&self.file)
+        } else {
+            self.original_bytes
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn corpus_path(name: &str) -> PathBuf {
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("tests/fixtures");
+        p.push(name);
+        p
+    }
+
+    fn read_corpus(name: &str) -> Vec<u8> {
+        std::fs::read(corpus_path(name)).expect("corpus fixture missing")
+    }
+
+    /// Round-trip without edits is byte-identical on a single-page document.
+    #[test]
+    fn roundtrip_byte_identical_chicken() {
+        let original = read_corpus("chicken.djvu");
+        let doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        assert!(!doc.is_dirty());
+        assert_eq!(doc.into_bytes(), original);
+    }
+
+    /// Round-trip without edits is byte-identical on a bilevel JB2 document.
+    #[test]
+    fn roundtrip_byte_identical_boy_jb2() {
+        let original = read_corpus("boy_jb2.djvu");
+        let doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        assert_eq!(doc.into_bytes(), original);
+    }
+
+    /// Round-trip without edits is byte-identical on a multi-page DJVM bundle.
+    #[test]
+    fn roundtrip_byte_identical_djvm_bundle() {
+        let original = read_corpus("DjVu3Spec_bundled.djvu");
+        let doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        assert_eq!(doc.root_form_type(), Some(b"DJVM"));
+        assert_eq!(doc.into_bytes(), original);
+    }
+
+    /// Round-trip without edits is byte-identical on a navm/fgbz document.
+    #[test]
+    fn roundtrip_byte_identical_navm() {
+        let original = read_corpus("navm_fgbz.djvu");
+        let doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        assert_eq!(doc.into_bytes(), original);
+    }
+
+    /// `replace_leaf` mutates in place and the serialised output reflects it.
+    #[test]
+    fn replace_leaf_changes_emitted_bytes() {
+        let original = read_corpus("chicken.djvu");
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+
+        // Walk to the first leaf — for chicken.djvu (FORM:DJVU) this is INFO.
+        let first = doc.chunk_at_path(&[0]).unwrap();
+        let original_first_data = first.data().to_vec();
+        assert!(!original_first_data.is_empty());
+
+        // Replace with a marker and serialise.
+        let marker = b"PR1_TEST_MARKER".to_vec();
+        doc.replace_leaf(&[0], marker.clone()).unwrap();
+        assert!(doc.is_dirty());
+
+        let edited = doc.into_bytes();
+
+        // Re-parse the edited bytes and confirm the leaf payload changed.
+        let reparsed = DjVuDocumentMut::from_bytes(&edited).unwrap();
+        let new_first = reparsed.chunk_at_path(&[0]).unwrap();
+        assert_eq!(new_first.data(), marker.as_slice());
+    }
+
+    #[test]
+    fn replace_leaf_rejects_empty_path() {
+        let original = read_corpus("chicken.djvu");
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        let err = doc.replace_leaf(&[], vec![]).unwrap_err();
+        assert!(matches!(err, MutError::EmptyPath));
+    }
+
+    #[test]
+    fn replace_leaf_rejects_out_of_range() {
+        let original = read_corpus("chicken.djvu");
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        let err = doc.replace_leaf(&[9999], vec![]).unwrap_err();
+        assert!(matches!(err, MutError::PathOutOfRange { .. }));
+    }
+
+    #[test]
+    fn replace_leaf_rejects_traversing_leaf() {
+        let original = read_corpus("chicken.djvu");
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        // [0] is a leaf (INFO).  [0, 0] tries to descend past it.
+        let err = doc.replace_leaf(&[0, 0], vec![]).unwrap_err();
+        assert!(matches!(err, MutError::PathTraversesLeaf { .. }));
+    }
+
+    #[test]
+    fn replace_leaf_rejects_form_target() {
+        // For a DJVM bundle, [N] for some N points at a FORM:DJVU page,
+        // not a leaf.  Picking the last child of DjVu3Spec_bundled (which
+        // is a page FORM) demonstrates NotALeaf.
+        let original = read_corpus("DjVu3Spec_bundled.djvu");
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        let last_idx = doc.root_child_count() - 1;
+        let err = doc.replace_leaf(&[last_idx], vec![]).unwrap_err();
+        assert!(matches!(err, MutError::NotALeaf));
+    }
+
+    #[test]
+    fn root_form_type_djvu_single_page() {
+        let original = read_corpus("chicken.djvu");
+        let doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        assert_eq!(doc.root_form_type(), Some(b"DJVU"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,13 @@ pub mod segment;
 /// [`DjVuBookmark`] (NAVM table-of-contents entry).
 pub mod djvu_document;
 
+/// In-place document mutation — byte-preserving rewrite primitive (PR1 of #222).
+///
+/// Provides [`djvu_mut::DjVuDocumentMut`] for editing a DjVu document while
+/// preserving the bytes of every chunk that wasn't touched.
+#[cfg(feature = "std")]
+pub mod djvu_mut;
+
 /// Rendering pipeline for [`DjVuPage`] — phase 5.
 ///
 /// Provides `djvu_render::RenderOptions`, `djvu_render::RenderRect`,


### PR DESCRIPTION
PR1 of #222 — in-place document mutation sequence.

## Summary

New `src/djvu_mut.rs` module (gated on `feature = "std"`) with the foundation layer for in-place document mutation:

- `DjVuDocumentMut::from_bytes(data)` — parses via `iff::parse` and retains the input bytes for a byte-identical no-edit round-trip
- `DjVuDocumentMut::into_bytes(self)` — fast path returns the original bytes verbatim when `!is_dirty`; falls through to `iff::emit` after any mutation
- `replace_leaf(path, new_data)` — walks the tree by child indices and rewrites the leaf payload
- `chunk_at_path(path)` — read-only walker
- Utility: `root_child_count`, `root_form_type`, `is_dirty`
- `pub enum MutError`: `Parse`, `PathOutOfRange`, `PathTraversesLeaf`, `NotALeaf`, `EmptyPath`

## Path format

`path: &[usize]` is walked from the root FORM's children. `[i]` selects the i-th leaf in a single-page `FORM:DJVU`; `[i, j]` descends into the j-th leaf of the i-th component `FORM` in a `FORM:DJVM` bundle.

## Test plan

- [x] `cargo test --lib` (402 lib tests, 10 new in `djvu_mut::tests`)
- [x] Byte-identical no-edit round-trip on four corpus fixtures:
  - `chicken.djvu` — color FORM:DJVU
  - `boy_jb2.djvu` — bilevel FORM:DJVU
  - `DjVu3Spec_bundled.djvu` — multi-page FORM:DJVM
  - `navm_fgbz.djvu` — FORM:DJVU with NAVM + FGbz
- [x] `replace_leaf` round-trip via re-parse (verifies the marker came back)
- [x] Four error paths (`EmptyPath`, `PathOutOfRange`, `PathTraversesLeaf`, `NotALeaf`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

## What this PR doesn't do

- **High-level setters** (`set_metadata`, `set_bookmarks`, `page_mut(i).set_text_layer`, …): deferred to PR2. They each compose `replace_leaf` with the existing chunk encoders (`encode_navm`, `encode_annotations*`, `encode_metadata`, `encode_text_layer`).
- **True byte-identical with edits**: the fast path is byte-identical only when `!is_dirty`. After a mutation, `iff::emit` recomputes FORM lengths and may produce a slightly different byte layout for unchanged regions (incidental padding, header rounding). PR3 will add per-chunk byte-range patching.
- **Indirect DJVM**: PR4 — the issue's "per-file rewrite vs re-bundle" decision needs a concrete answer first.

CLAUDE.md updated with `### #222 PR1 — Kept (2026-04-30)`.

https://claude.ai/code/session_01UVQNy1StBVvjfYn5m3Wuth

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVQNy1StBVvjfYn5m3Wuth)_