### PR TITLE
ci(fuzz): skip cargo install on cargo-fuzz cache hit

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,12 +40,14 @@ jobs:
 
       # Cache the cargo-fuzz binary so cargo install --locked is a no-op on cache hit
       - name: Cache cargo-fuzz binary
+        id: cargo-fuzz-cache
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-fuzz
           key: cargo-fuzz-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.lock') }}
 
       - name: Install cargo-fuzz
+        if: steps.cargo-fuzz-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --locked
 
       # Restore corpus from previous runs so coverage improves over time


### PR DESCRIPTION
## Summary
- Gate `cargo install cargo-fuzz --locked` on `cache-hit != 'true'`
- Without this, every Fuzz job after the first cache write fails with `error: binary cargo-fuzz already exists in destination` (the cache restored the binary, but `cargo install` won't overwrite it without `--force`)

Observed in run [25158463844](https://github.com/matyushkin/djvu-rs/actions/runs/25158463844): all 5 matrix jobs (`fuzz_iff`, `fuzz_bzz`, `fuzz_jb2`, `fuzz_iw44`, `fuzz_full`) failed at the install step.

## Test plan
- [ ] First push: cache miss → install runs, binary cached, fuzz runs
- [ ] Second push: cache hit → install step skipped, fuzz runs immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)