### PR TITLE
chore(gitignore): cover _*-prefixed examples + personal scratch harnesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,14 @@ examples/wasm/pkg/
 /0
 /rust_out
 
-# Local debug/profiling examples kept out-of-tree
-/examples/_debug_*.rs
+# Local debug/profiling examples kept out-of-tree (any leading-underscore prefix)
+/examples/_*.rs
+
+# Personal profiling/comparison harnesses (scratch, hardcoded paths)
+/examples/bench_render_lib.rs
+/examples/compare_render.rs
+/examples/profile_jb2.rs
+/examples/zp_call_counter.rs
 
 # Claude Code local state (user-specific, never shared)
 .claude/settings.local.json


### PR DESCRIPTION
## Summary
- Generalize `/examples/_debug_*.rs` to `/examples/_*.rs` to cover all underscore-prefixed scratch (`_bisect_*`, `_inspect_*`, `_pixel_*`, `_probe_*`, `_render_*`)
- Ignore four personal harnesses with hardcoded paths (`bench_render_lib`, `compare_render`, `profile_jb2`, `zp_call_counter`) that have been sitting untracked across sessions

## Test plan
- [ ] `git status` after merge: working tree clean except `.claude/` and `grant_application.txt`
- [ ] No tracked files matched/removed (rule only affects untracked files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)