### PR TITLE
fix(iw44): correct vext lane in prelim_flags_band0_neon horizontal-OR

### DIFF
--- a/src/iw44_new.rs
+++ b/src/iw44_new.rs
@@ -1141,7 +1141,7 @@ unsafe fn prelim_flags_band0_neon(block: &[i16; 1024], old_flags: &mut [u8; 16])
     let hi = vget_high_u8(result);
     let v4 = vorr_u8(lo, hi);
     let v2 = vorr_u8(v4, vext_u8::<4>(v4, v4));
-    let v1 = vorr_u8(v2, vext_u8::<1>(v1, v1));
+    let v1 = vorr_u8(v2, vext_u8::<2>(v2, v2));
     let v0 = vorr_u8(v1, vext_u8::<1>(v1, v1));
     vget_lane_u8::<0>(v0)
 }


### PR DESCRIPTION
## Summary

`prelim_flags_band0_neon` (introduced in #261) had a copy-paste bug in the 8→4-byte fold of its horizontal OR reduction:

```rust
let v2 = vorr_u8(v4, vext_u8::<4>(v4, v4));
let v1 = vorr_u8(v2, vext_u8::<1>(v1, v1));   // <-- references v1 before def, wrong shift
let v0 = vorr_u8(v1, vext_u8::<1>(v1, v1));
```

Two issues:
1. The middle line reads `v1` before it is defined (currently a build error on aarch64).
2. The shift should be `<2>`, not `<1>` — the canonical reduce ladder is 4 → 2 → 1.

The sibling helper `prelim_flags_bucket_neon` at the same file shows the correct pattern (`vext_u8::<2>(v2, v2)`).

## Why CI didn't catch it

`.github/workflows/ci.yml` only runs `runs-on: ubuntu-latest` (x86_64). The NEON code path is gated on `cfg(target_arch = "aarch64")`, so the regression was invisible to CI but breaks every Apple-Silicon developer's build.

## Test plan

- [x] `cargo build --release` (was failing with E0425, now clean)
- [x] `cargo test --release --lib iw44` — 30 passed
- [ ] Worth considering: add an `aarch64`/`macos-latest` job to ci.yml so this class of bug fails fast (out of scope for this hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)