### PR TITLE
fix(iff): preserve FORM length parity for byte-identical mutation (PR4 of #222)

### DIFF
--- a/src/djvu_mut.rs
+++ b/src/djvu_mut.rs
@@ -1242,4 +1242,74 @@ mod tests {
             "TXTz chunk should be present on page 2 after set_text_layer"
         );
     }
+
+    /// PR4 of #222: editing one page in a bundled DJVM must leave every
+    /// other page's bytes unchanged. The mutated page itself may grow
+    /// (e.g. a new METz chunk), but unmutated FORM:DJVU/DJVI components
+    /// must round-trip byte-identical.
+    #[test]
+    fn unmutated_pages_byte_identical_after_metadata_edit() {
+        use crate::metadata::DjVuMetadata;
+
+        let original = read_corpus("DjVu3Spec_bundled.djvu");
+
+        let orig_ranges = top_form_ranges(&original);
+
+        let mut doc = DjVuDocumentMut::from_bytes(&original).unwrap();
+        let meta = DjVuMetadata {
+            title: Some("PR4 byte-identical probe".into()),
+            ..Default::default()
+        };
+        doc.page_mut(0).unwrap().set_metadata(&meta);
+        let edited = doc.into_bytes();
+
+        let edited_ranges = top_form_ranges(&edited);
+        assert_eq!(orig_ranges.len(), edited_ranges.len());
+
+        // The first FORM:DJVU child corresponds to page 0 (the one we edited);
+        // it is allowed to differ. All others must be byte-identical.
+        let mut djvu_idx = 0usize;
+        for (i, (or, er)) in orig_ranges.iter().zip(edited_ranges.iter()).enumerate() {
+            // Only enforce identity on FORM:DJVU/DJVI components — bare leaves
+            // (DIRM, NAVM) legitimately change when offsets shift.
+            let is_form_djvu = &original[or.start..or.start + 4] == b"FORM"
+                && (&original[or.start + 8..or.start + 12] == b"DJVU"
+                    || &original[or.start + 8..or.start + 12] == b"DJVI");
+            if !is_form_djvu {
+                continue;
+            }
+            let is_edited_page = djvu_idx == 0;
+            djvu_idx += 1;
+            if is_edited_page {
+                continue;
+            }
+            assert_eq!(
+                &original[or.clone()],
+                &edited[er.clone()],
+                "FORM at top-level child #{i} must be byte-identical after edit"
+            );
+        }
+    }
+
+    /// Walk top-level children of the outer FORM and return their absolute
+    /// byte ranges (header+payload+pad).
+    fn top_form_ranges(data: &[u8]) -> Vec<core::ops::Range<usize>> {
+        assert_eq!(&data[..4], b"AT&T");
+        let form_len = u32::from_be_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let body_end = 12 + form_len;
+        let mut pos = 16usize; // skip AT&T(4) + FORM(4) + len(4) + secondary_id(4)
+        let mut out = Vec::new();
+        while pos + 8 <= body_end {
+            let len =
+                u32::from_be_bytes([data[pos + 4], data[pos + 5], data[pos + 6], data[pos + 7]])
+                    as usize;
+            let mut next = pos + 8 + len;
+            if next & 1 == 1 && next < body_end {
+                next += 1;
+            }
+            out.push(pos..next);
+            pos = next;
+        }
+        out
+    }
 }

--- a/src/iff.rs
+++ b/src/iff.rs
@@ -233,30 +233,40 @@ pub fn emit(file: &DjvuFile) -> Vec<u8> {
 }
 
 fn emit_chunk(chunk: &Chunk, out: &mut Vec<u8>) {
+    emit_chunk_inner(chunk, out, false);
+}
+
+fn emit_chunk_inner(chunk: &Chunk, out: &mut Vec<u8>, suppress_inner_pad: bool) {
     match chunk {
         Chunk::Form {
             secondary_id,
-            length: _,
+            length: stored_length,
             children,
         } => {
-            // Compute payload = secondary_id (4 bytes) + concat(emit(child)).
-            // Recompute length from children rather than trusting the stored
-            // value — the parser's `length` covers the original on-disk size,
-            // but children may have grown/shrunk if the caller mutated the
-            // tree. The proptest harness only feeds back unmodified trees,
-            // so both forms agree there.
+            // Two valid IFF layouts exist for a FORM whose last child has odd
+            // payload length:
+            //   (A) FORM declared length is odd, no pad after last child;
+            //       the outer/parent loop writes the alignment byte.
+            //   (B) FORM declared length is even, includes a pad byte after
+            //       the last child inside the FORM body.
+            // Real DjVu files mix both styles. Preserve the parser's stored
+            // length parity so unmutated subtrees round-trip byte-identical.
+            let suppress_last_pad = (*stored_length & 1) == 1;
             let mut payload: Vec<u8> = Vec::new();
             payload.extend_from_slice(secondary_id);
-            for child in children {
-                emit_chunk(child, &mut payload);
+            let n = children.len();
+            for (i, child) in children.iter().enumerate() {
+                let last = i + 1 == n;
+                emit_chunk_inner(child, &mut payload, last && suppress_last_pad);
             }
             let len = payload.len() as u32;
             out.extend_from_slice(b"FORM");
             out.extend_from_slice(&len.to_be_bytes());
             out.extend_from_slice(&payload);
-            // Word-align: pad to even total chunk size.
+            // Outer pad to align the next sibling in our parent. Skip when
+            // our parent told us they'll provide alignment for us.
             let total = 8 + payload.len();
-            if total % 2 == 1 {
+            if !suppress_inner_pad && total % 2 == 1 {
                 out.push(0);
             }
         }
@@ -266,7 +276,7 @@ fn emit_chunk(chunk: &Chunk, out: &mut Vec<u8>) {
             out.extend_from_slice(&len.to_be_bytes());
             out.extend_from_slice(data);
             let total = 8 + data.len();
-            if total % 2 == 1 {
+            if !suppress_inner_pad && total % 2 == 1 {
                 out.push(0);
             }
         }


### PR DESCRIPTION
## Summary

PR4 of #222. Closes the byte-identical-edit gap in `DjVuDocumentMut`: editing one page in a bundled DJVM now leaves every other page's bytes unchanged.

The IFF spec allows two valid layouts when a FORM's last child has odd payload length:
- (A) declare FORM length odd, let the parent's loop write the alignment byte
- (B) declare even, include the pad byte inside the FORM body

Real DjVu files mix both styles. The bundled `DjVu3Spec_bundled.djvu` fixture has 78 pages in style (B) and 5 pages (21, 48, 50, 59, 78) in style (A). The legacy emitter always produced (B), which flipped the FORM length-LSB on those 5 pages after any mutation — breaking the PR4 byte-identical guarantee for unmutated pages.

The fix: `iff::emit` honors the parser's stored length parity. When the original FORM declared odd length, suppress the trailing internal pad on the last child (style A); otherwise keep current behavior (style B). The outer pad still always fires so the parent loop sees correct alignment.

## Test plan
- [x] New `unmutated_pages_byte_identical_after_metadata_edit` test on the bundled fixture
- [x] All existing PR3 DIRM-offset tests still pass (`cargo test --quiet`: 579 passed, 6 ignored)
- [x] `iff_roundtrip` proptest in `tests/proptest_codecs.rs` still passes (synthetic trees use `length: 0`, an even value, so behavior is unchanged for them)
- [x] `cargo clippy --lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)