### PR TITLE
ci(publish): publish djvu-zp before djvu-rs (#229 follow-up)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,29 +53,60 @@ jobs:
             exit 1
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          ZP_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/djvu-zp/Cargo.toml | head -1)
+          echo "ZP_VERSION=$ZP_VERSION" >> "$GITHUB_ENV"
 
-      - name: Check if already published
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+      - name: Run tests
+        run: cargo nextest run --profile ci --workspace
+
+      # ── djvu-zp (published first; djvu-rs depends on it) ────────────────
+      - name: Check if djvu-zp already published
+        run: |
+          if cargo search "djvu-zp" --limit 1 2>/dev/null | grep -q "^djvu-zp = \"$ZP_VERSION\""; then
+            echo "ZP_ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+            echo "djvu-zp $ZP_VERSION already on crates.io — skipping."
+          else
+            echo "ZP_ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish djvu-zp to crates.io
+        if: env.ZP_ALREADY_PUBLISHED == 'false'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p djvu-zp
+
+      - name: Wait for djvu-zp to appear in the index
+        if: env.ZP_ALREADY_PUBLISHED == 'false'
+        run: |
+          for i in $(seq 1 30); do
+            if cargo search "djvu-zp" --limit 1 2>/dev/null | grep -q "^djvu-zp = \"$ZP_VERSION\""; then
+              echo "djvu-zp $ZP_VERSION is live."
+              exit 0
+            fi
+            echo "[$i/30] waiting for djvu-zp $ZP_VERSION on crates.io…"
+            sleep 10
+          done
+          echo "::error::djvu-zp $ZP_VERSION did not appear on crates.io within 5 minutes"
+          exit 1
+
+      # ── djvu-rs (workspace root) ────────────────────────────────────────
+      - name: Check if djvu-rs already published
         run: |
           if cargo search "djvu-rs" --limit 1 2>/dev/null | grep -q "^djvu-rs = \"$VERSION\""; then
             echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
-            echo "Version $VERSION already on crates.io — skipping publish."
+            echo "djvu-rs $VERSION already on crates.io — skipping."
           else
             echo "ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
           fi
 
-      - name: Dry-run package
+      - name: Dry-run package djvu-rs
         if: env.ALREADY_PUBLISHED == 'false'
-        run: cargo package --allow-dirty
+        run: cargo package -p djvu-rs --allow-dirty
 
-      - name: Install cargo-nextest
-        if: env.ALREADY_PUBLISHED == 'false'
-        uses: taiki-e/install-action@cargo-nextest
-      - name: Run tests
-        if: env.ALREADY_PUBLISHED == 'false'
-        run: cargo nextest run --profile ci --workspace
-
-      - name: Publish to crates.io
+      - name: Publish djvu-rs to crates.io
         if: env.ALREADY_PUBLISHED == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
+        run: cargo publish -p djvu-rs


### PR DESCRIPTION
## Summary

After #229 extracted `djvu-zp` into a standalone workspace crate, `djvu-rs 0.15.0` (currently queued in #234) declares `djvu-zp = \"…\"` as a real crates.io dependency. The current publish workflow only runs `cargo publish` on the root crate, which would fail: the verify build for `djvu-rs` cannot resolve `djvu-zp` from crates.io because it has never been published there.

Without this fix, merging #234 will produce a broken release: the publish workflow fails, or worse, publishes a `djvu-rs 0.15.0` whose dependency cannot be resolved by users.

## Changes

`.github/workflows/publish.yml` — split publish into two ordered phases:

1. **`djvu-zp` first**, with skip-if-already-published. After publish, poll the crates.io index for up to 5 minutes until the version appears (avoids the verify-build race against the slowly-propagating index).
2. **`djvu-rs` second**, also skip-if-already-published. Now its verify build can resolve `djvu-zp` from crates.io.

Tests run once up-front against workspace path deps, before either publish step (avoids running them twice).

Both phases are idempotent on re-run, matching the existing skip-on-duplicate behavior.

## Test plan

- [ ] Merge this PR before merging the release-please PR (#234).
- [ ] Then merge #234. The resulting `v0.15.0` tag should publish `djvu-zp` first, then `djvu-rs`, both visible on crates.io.
- [ ] Re-run on the same tag should be a no-op (both crates already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)