### PR TITLE
ci(release-please): publish djvu-zp before djvu-rs in inline publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,9 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
       - name: Run tests
-        run: cargo nextest run --profile ci --workspace
+        # Mirrors the CI Test (stable) job on main — the `cli` feature gates
+        # the `djvu` binary that several integration tests need.
+        run: cargo nextest run --profile ci --workspace --exclude djvu-py --features cli
 
       # ── djvu-zp (published first; djvu-rs depends on it) ────────────────
       - name: Check if djvu-zp already published

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,55 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Publish to crates.io
-        run: cargo publish --no-verify
+      - name: Read crate versions
+        run: |
+          VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          ZP_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/djvu-zp/Cargo.toml | head -1)
+          echo "ZP_VERSION=$ZP_VERSION" >> "$GITHUB_ENV"
+
+      # ── djvu-zp (must publish first; djvu-rs depends on it) ─────────────
+      - name: Check if djvu-zp already published
+        run: |
+          if cargo search "djvu-zp" --limit 1 2>/dev/null | grep -q "^djvu-zp = \"$ZP_VERSION\""; then
+            echo "ZP_ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+            echo "djvu-zp $ZP_VERSION already on crates.io — skipping."
+          else
+            echo "ZP_ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish djvu-zp
+        if: env.ZP_ALREADY_PUBLISHED == 'false'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p djvu-zp --no-verify
+
+      - name: Wait for djvu-zp to appear in the index
+        if: env.ZP_ALREADY_PUBLISHED == 'false'
+        run: |
+          for i in $(seq 1 30); do
+            if cargo search "djvu-zp" --limit 1 2>/dev/null | grep -q "^djvu-zp = \"$ZP_VERSION\""; then
+              echo "djvu-zp $ZP_VERSION is live."
+              exit 0
+            fi
+            echo "[$i/30] waiting for djvu-zp $ZP_VERSION on crates.io…"
+            sleep 10
+          done
+          echo "::error::djvu-zp $ZP_VERSION did not appear on crates.io within 5 minutes"
+          exit 1
+
+      # ── djvu-rs (workspace root) ────────────────────────────────────────
+      - name: Check if djvu-rs already published
+        run: |
+          if cargo search "djvu-rs" --limit 1 2>/dev/null | grep -q "^djvu-rs = \"$VERSION\""; then
+            echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+            echo "djvu-rs $VERSION already on crates.io — skipping."
+          else
+            echo "ALREADY_PUBLISHED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish djvu-rs
+        if: env.ALREADY_PUBLISHED == 'false'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p djvu-rs --no-verify


### PR DESCRIPTION
## Summary

The v0.15.0 release exposed a duplication in publish wiring. `release-please.yml` has its **own inline `publish` job** chained via `needs:` (lines 27-41), separate from `publish.yml`. This inline job runs after release-please creates the GitHub release — and it has to, because releases created by `GITHUB_TOKEN` don't trigger downstream workflows (so `publish.yml`'s `release: published` trigger never fires for release-please-driven releases).

#272 fixed the two-phase publish in `publish.yml` but missed this inline duplicate. Result: the v0.15.0 publish step failed with:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named \`djvu-zp\` found
  location searched: crates.io index
  required by package \`djvu-rs v0.15.0\`
```

## Changes

`.github/workflows/release-please.yml` — mirror the two-phase publish from `publish.yml`:

1. Read both crate versions from their `Cargo.toml`s.
2. Publish `djvu-zp` first (skip-if-published, `--no-verify`).
3. Poll crates.io index for up to 5 minutes until `djvu-zp` appears.
4. Publish `djvu-rs` (skip-if-published, `--no-verify`).

`--no-verify` matches the original behavior here. Tests are still run by CI on every commit; the verify build inside `cargo publish` is redundant.

## Test plan

- [ ] Merge before next release-please release.
- [ ] Manual `workflow_dispatch` on `publish.yml` for `v0.15.0` already in flight to recover the broken 0.15.0 release.
- [ ] Future tagged releases should run cleanly via this inline path.

## Follow-up

Eventually unify both entry points via `workflow_call` — `publish.yml` becomes the single source of truth, `release-please.yml` calls it. Out of scope for this hot-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)