### PR TITLE
ci: repair release and fuzz workflows

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
 
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
       # Per-target key: each fuzz binary compiles different code, avoid cache contention
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -48,7 +51,7 @@ jobs:
 
       - name: Install cargo-fuzz
         if: steps.cargo-fuzz-cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-fuzz --locked
+        run: cargo +stable install cargo-fuzz --locked
 
       # Restore corpus from previous runs so coverage improves over time
       - name: Restore fuzz corpus
@@ -59,7 +62,7 @@ jobs:
           restore-keys: fuzz-corpus-${{ matrix.target }}-
 
       - name: Run ${{ matrix.target }} for 60 s
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -timeout=10
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60 -timeout=10
 
       # Save updated corpus (unique key ensures this run's findings are always stored)
       - name: Save fuzz corpus

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    environment: crates-io
     steps:
       - uses: actions/checkout@v6
 

--- a/examples/encode_quality_djbz.rs
+++ b/examples/encode_quality_djbz.rs
@@ -193,16 +193,57 @@ fn process_file(
     // Verify round-trip — every page must decode pixel-exact.
     let roundtrip_ok = match DjVuDocument::parse(&bundle) {
         Ok(doc) if doc.page_count() == pages.len() => {
-            (0..pages.len()).all(|i| match doc.page(i).and_then(|p| p.extract_mask()) {
-                Ok(Some(d)) => {
-                    d.width == pages[i].width
-                        && d.height == pages[i].height
-                        && d.data == pages[i].data
+            let mut all_ok = true;
+            for (i, page) in pages.iter().enumerate() {
+                let decoded = match doc.page(i).and_then(|p| p.extract_mask()) {
+                    Ok(Some(d)) => d,
+                    Ok(None) => {
+                        eprintln!("  MISMATCH page {i}: extract_mask returned None (no Sjbz?)");
+                        all_ok = false;
+                        continue;
+                    }
+                    Err(e) => {
+                        eprintln!("  MISMATCH page {i}: extract_mask error: {e:?}");
+                        all_ok = false;
+                        continue;
+                    }
+                };
+                let dim_ok = decoded.width == page.width && decoded.height == page.height;
+                let diff_px = if dim_ok {
+                    let mut diff = 0u32;
+                    for y in 0..page.height {
+                        for x in 0..page.width {
+                            if page.get(x, y) != decoded.get(x, y) {
+                                diff += 1;
+                            }
+                        }
+                    }
+                    diff
+                } else {
+                    0
+                };
+                if !dim_ok || diff_px != 0 {
+                    eprintln!(
+                        "  MISMATCH page {i}: {}×{} → {}×{} diff_px={}",
+                        page.width, page.height, decoded.width, decoded.height, diff_px
+                    );
+                    all_ok = false;
                 }
-                _ => false,
-            })
+            }
+            all_ok
         }
-        _ => false,
+        Ok(doc) => {
+            eprintln!(
+                "  page_count mismatch: bundle={} expected={}",
+                doc.page_count(),
+                pages.len()
+            );
+            false
+        }
+        Err(e) => {
+            eprintln!("  DjVuDocument::parse failed: {e:?}");
+            false
+        }
     };
 
     Some(FileResult {


### PR DESCRIPTION
## Summary

- install cargo-fuzz with stable while running fuzz targets with nightly, matching the observed GitHub Actions failure in the Fuzz workflow
- add the crates-io environment gate to the inline release-please publish job so it uses the same protected publish context as publish.yml
- improve encode_quality_djbz round-trip diagnostics so future corpus failures report page, dimensions, and pixel diff count

## Verification

- cargo fmt --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/fuzz.yml .github/workflows/release-please.yml
- cargo test -q jb2_encode
- cargo +stable install cargo-fuzz --locked --root /private/tmp/cargo-fuzz-install-test
- cargo run --release --example encode_quality_djbz -- tests/corpus/pathogenic_bacteria_1896.djvu --diff-fraction 3

## Notes

The failed release run reached crates.io upload and got 403 from the registry token. This PR fixes the repo-side environment selection; the secret itself may still need maintainer-side permission repair if the environment token is also stale.