### PR TITLE
perf: add JB2 cross-size refinement probe

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -739,6 +739,47 @@ uses byte-exact clustering for every threshold. In addition, inherited
 shared-Djbz symbols are used only for exact record-7 hits, and lossless
 near matches fall back to record-1 rather than rec-6 refinement.
 
+### #283 — cross-size JB2 refinement probe — **Kept instrumentation, default unchanged** (2026-05-12)
+
+**Approach.** Added `analyze_jb2_cross_size_refinement(page, shared,
+max_dim_delta, max_hamming_fraction)`, an experiment-only accounting helper
+that mirrors `encode_jb2_dict_with_shared` dictionary growth but does not
+emit bytes. For fresh record-1 candidates, it scans dictionary symbols whose
+width/height differ by at most 2 px, normalizes the reference into the
+candidate box with nearest-neighbor sampling, and reports how many candidates
+land within a 5% normalized Hamming budget. The existing
+`examples/encode_quality_djbz.rs` harness now exposes this via
+`--cross-size-stats`.
+
+**Command.**
+
+```text
+cargo run --release --example encode_quality_djbz -- \
+  --cc-stats --cross-size-stats \
+  tests/corpus/watchmaker.djvu \
+  tests/corpus/pathogenic_bacteria_1896.djvu
+```
+
+**Numbers.**
+
+| File | Pages | bundle / independent | round-trip | fresh CCs | cross-size candidates | near @ 5% |
+|------|-------|----------------------|------------|-----------|-----------------------|-----------|
+| `watchmaker.djvu` | 12 | 0.945× | ✓ | 2,652 | 2,331 | 547 (20.65%) |
+| `pathogenic_bacteria_1896.djvu` | 517 | 0.976× | ✓ | 759,291 | 686,402 | 61,485 (8.73%) |
+
+Aggregate bundled bytes for the two-file run were 33,553,108 vs 34,384,941
+for independent per-page JB2 dict encoding (0.976×, −2.4%). Pixel round-trip
+stayed exact because the probe is observational only.
+
+**Decision.** Keep the probe, but do not change the default encoder. The
+candidate counts prove there is real cross-size shape similarity, especially
+on `watchmaker`, but they are only an upper bound: record-6 would still carry
+refinement bitmap bytes plus symbol-index/context overhead, and the previous
+same-size/shared-rec-6 experiments showed that plausible-looking Hamming
+matches can lose bytes or create invalid streams. A shipped cross-size
+encoder path needs a byte-cost model and explicit lossy/lossless semantics;
+until then `encode_djvm_bundle_jb2` remains exact rec-7 + fresh rec-1 only.
+
 ### #233 — async lazy first-page probe — **Kept** (2026-05-04)
 
 **Approach.** Added `examples/async_lazy_first_page.rs`, a small native

--- a/examples/encode_quality_djbz.rs
+++ b/examples/encode_quality_djbz.rs
@@ -26,6 +26,7 @@
 use std::path::Path;
 use std::process::ExitCode;
 
+use djvu_rs::jb2_encode::analyze_jb2_cross_size_refinement;
 use djvu_rs::{
     Bitmap, DjVuDocument,
     jb2_encode::{
@@ -127,6 +128,7 @@ fn process_file(
     threshold: usize,
     diff_fraction: u32,
     cc_stats: bool,
+    cross_size_stats: bool,
 ) -> Option<FileResult> {
     let (pages, orig_total, avg) = match collect_pages(path) {
         Some(t) => t,
@@ -188,6 +190,35 @@ fn process_file(
             agg.pixels_rec_1, agg.pixels_rec_6, agg.pixels_rec_7,
         );
         print_hamming_histogram(&agg.rec_6_hamming);
+    }
+    if cross_size_stats {
+        let mut total = djvu_rs::jb2_encode::CrossSizeRefinementStats::default();
+        for p in &pages {
+            let s = analyze_jb2_cross_size_refinement(p, &shared, 2, 0.05);
+            total.total_ccs += s.total_ccs;
+            total.fresh_ccs += s.fresh_ccs;
+            total.eligible_fresh_ccs += s.eligible_fresh_ccs;
+            total.candidate_ccs += s.candidate_ccs;
+            total.near_matches += s.near_matches;
+            total.near_match_pixels += s.near_match_pixels;
+            total.best_hamming.extend(s.best_hamming);
+        }
+        let median = if total.best_hamming.is_empty() {
+            0
+        } else {
+            total.best_hamming.sort_unstable();
+            total.best_hamming[total.best_hamming.len() / 2]
+        };
+        eprintln!(
+            "  cross-size probe: fresh={} eligible={} candidates={} near_5pct={} ({:.2}%) near_pixels={} median_best_hamming={}",
+            total.fresh_ccs,
+            total.eligible_fresh_ccs,
+            total.candidate_ccs,
+            total.near_matches,
+            total.near_matches as f64 / total.eligible_fresh_ccs.max(1) as f64 * 100.0,
+            total.near_match_pixels,
+            median,
+        );
     }
 
     // Verify round-trip — every page must decode pixel-exact.
@@ -264,6 +295,7 @@ fn main() -> ExitCode {
     // into Hamming clustering for experimentation.
     let mut diff_fraction: u32 = 0;
     let mut cc_stats = false;
+    let mut cross_size_stats = false;
     let mut files: Vec<String> = Vec::new();
     let mut args = std::env::args().skip(1);
     while let Some(a) = args.next() {
@@ -279,6 +311,8 @@ fn main() -> ExitCode {
                 .unwrap_or(diff_fraction);
         } else if a == "--cc-stats" {
             cc_stats = true;
+        } else if a == "--cross-size-stats" {
+            cross_size_stats = true;
         } else {
             files.push(a);
         }
@@ -286,21 +320,28 @@ fn main() -> ExitCode {
 
     if files.is_empty() {
         eprintln!(
-            "usage: encode_quality_djbz [--threshold N] [--diff-fraction P] [--cc-stats] <file.djvu> [...]\n\
+            "usage: encode_quality_djbz [--threshold N] [--diff-fraction P] [--cc-stats] [--cross-size-stats] <file.djvu> [...]\n\
              \n\
              Encodes every multi-page input via encode_djvm_bundle_jb2 and\n\
              reports total bytes vs. independent per-page dict + original Sjbz.\n\
              \n\
              --threshold N      promote glyph clusters that span >= N pages (default 2)\n\
              --diff-fraction P  Hamming distance allowance, percent of pixels (0..=10, default 0 = byte-exact)\n\
-             --cc-stats         print per-CC record-type accounting + Hamming histogram (#194 Phase 2.5)"
+             --cc-stats         print per-CC record-type accounting + Hamming histogram (#194 Phase 2.5)\n\
+             --cross-size-stats print experiment-only cross-size refinement headroom (#283)"
         );
         return ExitCode::from(2);
     }
 
     let mut all = Vec::new();
     for f in &files {
-        if let Some(r) = process_file(Path::new(f), threshold, diff_fraction, cc_stats) {
+        if let Some(r) = process_file(
+            Path::new(f),
+            threshold,
+            diff_fraction,
+            cc_stats,
+            cross_size_stats,
+        ) {
             all.push(r);
         }
     }

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -442,6 +442,30 @@ struct Cc {
     bitmap: Bitmap,
 }
 
+/// Summary of an experiment-only cross-size refinement search.
+///
+/// This does not affect encoding. It estimates how many components currently
+/// emitted as fresh record-1 symbols have a nearly matching dictionary symbol
+/// with a slightly different bounding box.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CrossSizeRefinementStats {
+    /// Total connected components seen in reading order.
+    pub total_ccs: usize,
+    /// Components that do not have an exact same-size dictionary hit.
+    pub fresh_ccs: usize,
+    /// Fresh components large enough to consider for refinement.
+    pub eligible_fresh_ccs: usize,
+    /// Eligible fresh components with at least one near-size candidate.
+    pub candidate_ccs: usize,
+    /// Candidate components whose best normalized Hamming score is within
+    /// the caller-provided pixel fraction.
+    pub near_matches: usize,
+    /// Sum of source component pixels for near matches.
+    pub near_match_pixels: u64,
+    /// Best normalized Hamming score observed for every near-size candidate.
+    pub best_hamming: Vec<u32>,
+}
+
 /// Extract all 8-connected components of black pixels from `bitmap`.
 ///
 /// Uses iterative DFS on an unpacked byte grid; each component's cropped
@@ -552,6 +576,122 @@ fn packed_hamming(a: &[u8], b: &[u8]) -> u32 {
 /// record-6 (matched-refinement coordinate header + 11-bit refinement
 /// context state) outweighs any saving even at low Hamming distance.
 const REFINEMENT_MIN_PIXELS: u64 = 32;
+
+fn scaled_hamming(cand: &Bitmap, reference: &Bitmap) -> u32 {
+    let mut diff = 0u32;
+    for y in 0..cand.height {
+        let ry = (u64::from(y) * u64::from(reference.height) / u64::from(cand.height)) as u32;
+        for x in 0..cand.width {
+            let rx = (u64::from(x) * u64::from(reference.width) / u64::from(cand.width)) as u32;
+            if cand.get(x, y) != reference.get(rx, ry) {
+                diff += 1;
+            }
+        }
+    }
+    diff
+}
+
+/// Estimate cross-size refinement headroom without changing encoder output.
+///
+/// The JB2 format can encode record-6 refinements where the reference symbol
+/// has a different `(w, h)`, but the shipped encoder intentionally only uses
+/// exact record-7 copies. This helper mirrors the dictionary growth of
+/// [`encode_jb2_dict_with_shared`] and, for fresh symbols, scores nearby
+/// dictionary entries after nearest-neighbor normalization into the candidate
+/// component's dimensions.
+///
+/// `max_dim_delta` limits candidates to entries with width/height differing
+/// by at most that many pixels. `max_hamming_fraction` is the accepted
+/// normalized Hamming budget relative to the candidate's pixel count.
+pub fn analyze_jb2_cross_size_refinement(
+    bitmap: &Bitmap,
+    shared_symbols: &[Bitmap],
+    max_dim_delta: u32,
+    max_hamming_fraction: f32,
+) -> CrossSizeRefinementStats {
+    let mut stats = CrossSizeRefinementStats::default();
+    if bitmap.width == 0 || bitmap.height == 0 {
+        return stats;
+    }
+
+    let ccs = extract_ccs(bitmap);
+    let mut order: Vec<usize> = (0..ccs.len()).collect();
+    let bucket = (SAME_LINE_BASELINE_TOL.max(1)) as u32;
+    order.sort_by_key(|&i| {
+        let cc = &ccs[i];
+        let bottom = cc.y + cc.bitmap.height;
+        (bottom / bucket, cc.x)
+    });
+
+    let mut dedup: BTreeMap<(u32, u32, Vec<u8>), usize> = BTreeMap::new();
+    let mut dict_entries: Vec<Bitmap> = Vec::new();
+    for sym in shared_symbols {
+        let idx = dict_entries.len();
+        dedup.insert((sym.width, sym.height, sym.data.clone()), idx);
+        dict_entries.push(sym.clone());
+    }
+    let mut by_size: BTreeMap<(u32, u32), Vec<usize>> = BTreeMap::new();
+    for (idx, sym) in dict_entries.iter().enumerate() {
+        by_size
+            .entry((sym.width, sym.height))
+            .or_default()
+            .push(idx);
+    }
+
+    for &cc_idx in &order {
+        let cc = &ccs[cc_idx];
+        stats.total_ccs += 1;
+
+        let key = (cc.bitmap.width, cc.bitmap.height, cc.bitmap.data.clone());
+        if dedup.contains_key(&key) {
+            continue;
+        }
+
+        stats.fresh_ccs += 1;
+        let pixels = u64::from(cc.bitmap.width) * u64::from(cc.bitmap.height);
+        if pixels >= REFINEMENT_MIN_PIXELS {
+            stats.eligible_fresh_ccs += 1;
+            let mut best: Option<u32> = None;
+            let min_w = cc.bitmap.width.saturating_sub(max_dim_delta);
+            let max_w = cc.bitmap.width.saturating_add(max_dim_delta);
+            let min_h = cc.bitmap.height.saturating_sub(max_dim_delta);
+            let max_h = cc.bitmap.height.saturating_add(max_dim_delta);
+            for w in min_w..=max_w {
+                for h in min_h..=max_h {
+                    if w == cc.bitmap.width && h == cc.bitmap.height {
+                        continue;
+                    }
+                    let Some(indices) = by_size.get(&(w, h)) else {
+                        continue;
+                    };
+                    for &idx in indices {
+                        let d = scaled_hamming(&cc.bitmap, &dict_entries[idx]);
+                        best = Some(best.map_or(d, |b| b.min(d)));
+                    }
+                }
+            }
+            if let Some(best) = best {
+                stats.candidate_ccs += 1;
+                stats.best_hamming.push(best);
+                let max_diff = ((pixels as f64) * (max_hamming_fraction as f64)).round() as u32;
+                if best <= max_diff {
+                    stats.near_matches += 1;
+                    stats.near_match_pixels += pixels;
+                }
+            }
+        }
+
+        let next_idx = dict_entries.len();
+        dedup.insert(key, next_idx);
+        by_size
+            .entry((cc.bitmap.width, cc.bitmap.height))
+            .or_default()
+            .push(next_idx);
+        dict_entries.push(cc.bitmap.clone());
+    }
+
+    stats
+}
 
 /// Find the closest same-size dict entry within a Hamming-distance budget,
 /// for use as a **lossy copy** target (record-7) — the encoder pretends the
@@ -2174,6 +2314,35 @@ mod tests {
                 + stats.rec_6_refine_local
                 + stats.rec_6_refine_shared
                 + stats.rec_7_exact
+        );
+    }
+
+    #[test]
+    fn analyze_cross_size_refinement_counts_near_size_candidates() {
+        let shared_glyph = make_bitmap(6, 6, |_, _| true);
+        let taller_near = make_bitmap(6, 7, |_, _| true);
+        let unrelated = make_bitmap(12, 12, |x, y| x == y);
+
+        let stamp = |page: &mut Bitmap, ox: u32, oy: u32, src: &Bitmap| {
+            for y in 0..src.height {
+                for x in 0..src.width {
+                    if src.get(x, y) {
+                        page.set(ox + x, oy + y, true);
+                    }
+                }
+            }
+        };
+        let mut page = make_bitmap(40, 16, |_, _| false);
+        stamp(&mut page, 2, 2, &shared_glyph);
+        stamp(&mut page, 14, 2, &taller_near);
+        stamp(&mut page, 26, 2, &unrelated);
+
+        let stats = analyze_jb2_cross_size_refinement(&page, &[shared_glyph], 1, 0.05);
+        assert_eq!(stats.near_matches, 1);
+        assert_eq!(stats.near_match_pixels, 42);
+        assert!(
+            stats.candidate_ccs >= stats.near_matches,
+            "near matches must be a subset of cross-size candidates"
         );
     }
 


### PR DESCRIPTION
## Summary
- add an experiment-only JB2 cross-size refinement accounting helper
- expose the probe through encode_quality_djbz --cross-size-stats
- record #283 measurements and keep the default encoder unchanged

Closes #283

## Verification
- cargo fmt --check
- cargo test -q jb2_encode
- cargo clippy --example encode_quality_djbz -- -D warnings
- cargo run --release --example encode_quality_djbz -- --cc-stats --cross-size-stats tests/corpus/watchmaker.djvu tests/corpus/pathogenic_bacteria_1896.djvu