### PR TITLE
feat: add archival FGbz scan profile

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -780,6 +780,36 @@ matches can lose bytes or create invalid streams. A shipped cross-size
 encoder path needs a byte-cost model and explicit lossy/lossless semantics;
 until then `encode_djvm_bundle_jb2` remains exact rec-7 + fresh rec-1 only.
 
+### #278 PR1 — single-page Quality/Archival FGbz profiles — **Kept** (2026-05-12)
+
+**Approach.** Completed the conservative single-page color profile path:
+`Quality` still uses the existing deterministic segmentation and
+`INFO + Sjbz + BG44...` shape, but now adds an `FGbz` foreground palette
+when the detected foreground color is not black. `Archival` no longer
+returns `Unsupported` for color input; it emits the same layered shape with
+a denser background sample grid (`bg_subsample = 6` instead of 12).
+
+This deliberately does not change the multi-page directory encoder, which
+still uses the lossless shared-Djbz path only, and does not revive Hamming
+shared-Djbz clustering.
+
+**Tests.**
+
+- `cargo test -q djvu_encode::tests`
+- `cargo test -q --features cli --test cli_encode -- --nocapture`
+
+The CLI regression fixture is generated in `tests/cli_encode.rs` as a
+white RGB PNG with a dark red foreground block. `--quality quality` and
+`--quality archival` both produce parseable single-page DjVu files with
+`Sjbz`, at least one `BG44`, and `FGbz`.
+
+**Decision.** Kept as PR1 scope. This removes the user-visible
+`Archival` unsupported path for single PNGs and gives colored foreground
+documents a foreground color layer. Remaining quality work should be split
+into focused follow-ups: adaptive binarization/inpainting, per-blit FGbz
+indices or FG44 for multi-color foregrounds, and layered multi-page DJVM
+encoding.
+
 ### #233 — async lazy first-page probe — **Kept** (2026-05-04)
 
 **Approach.** Added `examples/async_lazy_first_page.rs`, a small native

--- a/README.md
+++ b/README.md
@@ -273,8 +273,11 @@ djvu text file.djvu --all
 # Encode a PNG image into a single-page DjVu (bilevel JB2, lossless)
 djvu encode scan.png --output scan.djvu --dpi 300
 
-# Encode a PNG image into a layered lossy DjVu (JB2 mask + IW44 background)
+# Encode a PNG image into a layered lossy DjVu (JB2 mask + IW44 background + FGbz foreground color)
 djvu encode scan.png --quality quality --output scan.djvu --dpi 300
+
+# Use the conservative archival color profile for a single PNG
+djvu encode scan.png --quality archival --output scan.djvu --dpi 300
 
 # Encode a directory of PNGs into a bundled DJVM with shared Djbz
 djvu encode pages/ --output book.djvu --shared-dict-pages 2
@@ -282,9 +285,10 @@ djvu encode pages/ --output book.djvu --shared-dict-pages 2
 
 For single PNG input, `--quality lossless` luminance-thresholds the image into a
 JB2 mask and writes `INFO + Sjbz`; `--quality quality` uses the layered encoder
-(`INFO + Sjbz + BG44...`) for color input. `--quality archival` is still
-reserved for a future FGbz/profitability model. Directory input currently uses
-the lossless multi-page JB2 path only.
+(`INFO + Sjbz + BG44...` plus `FGbz` when colored foreground is detected) for
+color input. `--quality archival` uses the same layered shape with a denser
+background sample grid. Directory input currently uses the lossless multi-page
+JB2 path only.
 
 ## hOCR and ALTO XML export
 

--- a/src/bin/djvu.rs
+++ b/src/bin/djvu.rs
@@ -206,9 +206,9 @@ enum RotateArg {
 enum EncodeQualityArg {
     /// Pixel-exact bilevel JB2 (`INFO + Sjbz`).
     Lossless,
-    /// Layered FG/BG with lossy IW44 BG. Currently unsupported — see #220.
+    /// Layered FG/BG with lossy IW44 BG.
     Quality,
-    /// Archival profile with FGbz palette. Currently unsupported — see #194 Phase 2.5.
+    /// Conservative layered profile with denser BG sampling and FGbz palette.
     Archival,
 }
 
@@ -1033,7 +1033,7 @@ fn cmd_encode(
         if !matches!(quality, EncodeQualityArg::Lossless) {
             return Err(
                 "multi-page encode currently supports --quality lossless only \
-                        (#220 follow-ups for layered Quality / Archival)"
+                        (layered Quality / Archival bundles are tracked separately)"
                     .into(),
             );
         }

--- a/src/djvu_encode.rs
+++ b/src/djvu_encode.rs
@@ -42,17 +42,18 @@
 //! # Status
 //!
 //! - `Lossless` from a [`Bitmap`]: ships `INFO + Sjbz`. Pixel-exact.
-//! - `Quality` from a [`Pixmap`]: ships `INFO + Sjbz + BG44…` —
-//!   layered mask + sub-sampled IW44 background. Lossy by codec
-//!   definition; output is decodable end-to-end. FG layer and FGbz
-//!   palette are #220 follow-ups.
-//! - `Archival`: still [`EncodeError::Unsupported`] — wants the per-CC
-//!   profitability model from #194 Phase 2.5.
+//! - `Quality` from a [`Pixmap`]: ships `INFO + Sjbz + BG44… + FGbz`
+//!   when foreground ink is detected. Lossy by codec definition; output
+//!   is decodable end-to-end.
+//! - `Archival` from a [`Pixmap`]: same layered chunk shape as `Quality`,
+//!   with a denser background sample grid. This is a conservative archival
+//!   profile, not a DjVuLibre-equivalent color text optimiser.
 //! - `Lossless` from a [`Pixmap`] / `Quality` from a [`Bitmap`] are
 //!   rejected: the combinations are mathematically meaningless
 //!   (IW44 is lossy; bilevel input has nothing to put in BG44).
 
 use crate::bitmap::Bitmap;
+use crate::fgbz_encode::{FgbzColor, encode_fgbz};
 use crate::iff::{Chunk, DjvuFile, emit};
 use crate::iw44_encode::{Iw44EncodeOptions, encode_iw44_color};
 use crate::jb2_encode;
@@ -85,12 +86,11 @@ pub enum EncodeQuality {
     Lossless,
     /// Layered foreground/background encoding. Requires color input
     /// ([`PageEncoder::from_pixmap`]); writes `INFO + Sjbz + BG44…`
-    /// (mask + sub-sampled IW44 background). FG layer and FGbz palette
-    /// are #220 follow-ups.
+    /// plus `FGbz` when foreground ink is detected.
     Quality,
-    /// Archival profile with FGbz palette + aggressive lossy JB2
-    /// refinement matching. *Not yet supported* — needs the per-CC
-    /// profitability model (#194 Phase 2.5).
+    /// Conservative archival color profile. Requires color input; writes
+    /// the same layered chunks as `Quality`, but keeps a denser background
+    /// sample grid. Bilevel input should use `Lossless`.
     Archival,
 }
 
@@ -181,11 +181,24 @@ impl<'a> PageEncoder<'a> {
                     data: jb2_encode::encode_jb2(bm),
                 },
             ])),
-            (Source::Pixmap(pm), EncodeQuality::Quality) => {
-                let seg = segment_page(pm, &SegmentOptions::default());
+            (Source::Pixmap(pm), EncodeQuality::Quality | EncodeQuality::Archival) => {
+                let segment_options = match self.quality {
+                    EncodeQuality::Quality => SegmentOptions::default(),
+                    EncodeQuality::Archival => SegmentOptions {
+                        bg_subsample: 6,
+                        ..SegmentOptions::default()
+                    },
+                    EncodeQuality::Lossless => unreachable!(),
+                };
+                let seg = segment_page(pm, &segment_options);
                 let sjbz = jb2_encode::encode_jb2(&seg.mask);
                 let bg44_chunks = encode_iw44_color(&seg.bg, &Iw44EncodeOptions::default());
-                let mut chunks = Vec::with_capacity(2 + bg44_chunks.len());
+                let fgbz = foreground_palette(pm, &seg.mask)
+                    .filter(|palette| foreground_palette_is_useful(palette))
+                    .map(|palette| encode_fgbz(&palette, None));
+
+                let mut chunks =
+                    Vec::with_capacity(2 + bg44_chunks.len() + usize::from(fgbz.is_some()));
                 chunks.push(Chunk::Leaf {
                     id: *b"INFO",
                     data: info,
@@ -200,6 +213,9 @@ impl<'a> PageEncoder<'a> {
                         data: body,
                     });
                 }
+                if let Some(data) = fgbz {
+                    chunks.push(Chunk::Leaf { id: *b"FGbz", data });
+                }
                 Ok(encode_form_djvu(chunks))
             }
             (Source::Pixmap(_), EncodeQuality::Lossless) => Err(EncodeError::Unsupported(
@@ -208,8 +224,8 @@ impl<'a> PageEncoder<'a> {
             (Source::Bitmap(_), EncodeQuality::Quality) => Err(EncodeError::Unsupported(
                 "Quality requires colour input — use from_pixmap or switch to Lossless",
             )),
-            (_, EncodeQuality::Archival) => Err(EncodeError::Unsupported(
-                "Archival profile requires the per-CC profitability model (#194 Phase 2.5)",
+            (Source::Bitmap(_), EncodeQuality::Archival) => Err(EncodeError::Unsupported(
+                "Archival requires colour input — use from_pixmap or switch to Lossless",
             )),
         }
     }
@@ -243,6 +259,33 @@ fn encode_info(width: u16, height: u16, dpi: u16) -> Vec<u8> {
     b[8] = 22; // gamma byte: 22 → 2.2
     b[9] = 0x00; // flags: no rotation
     b
+}
+
+fn foreground_palette(pm: &Pixmap, mask: &Bitmap) -> Option<Vec<FgbzColor>> {
+    let (mut r, mut g, mut b, mut n) = (0u64, 0u64, 0u64, 0u64);
+    for y in 0..mask.height {
+        for x in 0..mask.width {
+            if mask.get(x, y) {
+                let (pr, pg, pb) = pm.get_rgb(x, y);
+                r += u64::from(pr);
+                g += u64::from(pg);
+                b += u64::from(pb);
+                n += 1;
+            }
+        }
+    }
+    if n == 0 {
+        return None;
+    }
+    Some(vec![FgbzColor {
+        r: (r / n) as u8,
+        g: (g / n) as u8,
+        b: (b / n) as u8,
+    }])
+}
+
+fn foreground_palette_is_useful(palette: &[FgbzColor]) -> bool {
+    palette.iter().any(|c| c.r != 0 || c.g != 0 || c.b != 0)
 }
 
 #[cfg(test)]
@@ -325,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn archival_profile_still_unsupported() {
+    fn archival_bitmap_rejected() {
         let bm = Bitmap::new(16, 16);
         let err = PageEncoder::from_bitmap(&bm)
             .with_quality(EncodeQuality::Archival)
@@ -379,6 +422,53 @@ mod tests {
             bg44_count > 0,
             "expected at least one BG44 chunk, got {bg44_count}"
         );
+    }
+
+    #[test]
+    fn quality_color_emits_fgbz_for_colored_foreground() {
+        let mut pm = Pixmap::white(64, 64);
+        for y in 16..32 {
+            for x in 16..32 {
+                pm.set_rgb(x, y, 180, 20, 20);
+            }
+        }
+
+        let bytes = PageEncoder::from_pixmap(&pm)
+            .with_quality(EncodeQuality::Quality)
+            .encode()
+            .expect("encode");
+
+        let form = parse_form(&bytes).expect("parse_form");
+        let fgbz = form
+            .chunks
+            .iter()
+            .find(|chunk| &chunk.id == b"FGbz")
+            .expect("FGbz chunk present");
+        let (palette, indices) = crate::fgbz_encode::decode_fgbz(fgbz.data).expect("decode FGbz");
+        assert_eq!(palette.len(), 1);
+        assert!(indices.is_empty());
+        assert!(palette[0].r > 0, "foreground red should be preserved");
+    }
+
+    #[test]
+    fn archival_color_emits_layered_djvu_with_fgbz() {
+        let mut pm = Pixmap::white(48, 48);
+        for y in 12..24 {
+            for x in 12..24 {
+                pm.set_rgb(x, y, 0, 90, 180);
+            }
+        }
+
+        let bytes = PageEncoder::from_pixmap(&pm)
+            .with_quality(EncodeQuality::Archival)
+            .encode()
+            .expect("encode");
+
+        let doc = crate::djvu_document::DjVuDocument::parse(&bytes).expect("parse");
+        let page = doc.page(0).expect("page");
+        assert!(page.raw_chunk(b"Sjbz").is_some());
+        assert!(!page.all_chunks(b"BG44").is_empty());
+        assert!(page.raw_chunk(b"FGbz").is_some());
     }
 
     #[test]

--- a/tests/cli_encode.rs
+++ b/tests/cli_encode.rs
@@ -21,6 +21,26 @@ fn write_test_png(path: &Path, w: u32, h: u32) {
     writer.write_image_data(&data).unwrap();
 }
 
+fn write_colored_ink_png(path: &Path, w: u32, h: u32) {
+    let file = std::fs::File::create(path).unwrap();
+    let writer = std::io::BufWriter::new(file);
+    let mut encoder = png::Encoder::new(writer, w, h);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().unwrap();
+    let mut data = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            if x >= w / 4 && x < w / 2 && y >= h / 4 && y < h / 2 {
+                data.extend_from_slice(&[160, 20, 20]);
+            } else {
+                data.extend_from_slice(&[255, 255, 255]);
+            }
+        }
+    }
+    writer.write_image_data(&data).unwrap();
+}
+
 #[test]
 fn encode_creates_djvu_file() {
     let dir = tempfile::tempdir().unwrap();
@@ -101,11 +121,37 @@ fn encode_quality_profile_emits_layered_djvu() {
 }
 
 #[test]
-fn encode_archival_profile_still_unsupported() {
+fn encode_quality_profile_emits_fgbz_for_colored_ink() {
     let dir = tempfile::tempdir().unwrap();
     let input = dir.path().join("in.png");
     let output = dir.path().join("out.djvu");
-    write_test_png(&input, 16, 16);
+    write_colored_ink_png(&input, 32, 32);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "--quality",
+            "quality",
+        ])
+        .assert()
+        .success();
+
+    let bytes = std::fs::read(&output).unwrap();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&bytes).unwrap();
+    let page = doc.page(0).unwrap();
+    assert!(page.raw_chunk(b"FGbz").is_some());
+}
+
+#[test]
+fn encode_archival_profile_emits_layered_djvu() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.png");
+    let output = dir.path().join("out.djvu");
+    write_colored_ink_png(&input, 32, 32);
 
     Command::cargo_bin("djvu")
         .unwrap()
@@ -118,8 +164,14 @@ fn encode_archival_profile_still_unsupported() {
             "archival",
         ])
         .assert()
-        .failure()
-        .stderr(predicates::str::contains("Archival"));
+        .success();
+
+    let bytes = std::fs::read(&output).unwrap();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&bytes).unwrap();
+    let page = doc.page(0).unwrap();
+    assert!(page.raw_chunk(b"Sjbz").is_some());
+    assert!(!page.all_chunks(b"BG44").is_empty());
+    assert!(page.raw_chunk(b"FGbz").is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add FGbz foreground palette output for single-page color Quality encoding when colored foreground is detected
- make single-page color Archival encode a conservative layered profile instead of returning Unsupported
- update CLI docs/tests and record the PR1 result in PERF_EXPERIMENTS.md

Part of #278. This intentionally leaves adaptive segmentation, per-blit/FG44 foreground color, and layered multi-page bundles for follow-up work.

## Verification
- cargo fmt --check
- cargo test -q djvu_encode::tests
- cargo test -q --features cli --test cli_encode -- --nocapture
- cargo clippy --lib --tests -- -D warnings