### PR TITLE
bench: record row-scratch render A/B

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -5,6 +5,60 @@ numbers, decision, reason. Referenced from issue templates ("Record result
 in `PERF_EXPERIMENTS.md` (Kept or Reverted + reason)") and from
 `.github/workflows/bench.yml`.
 
+### #294 — thumbnail row-scratch A/B — **Rejected** (2026-05-17)
+
+**Approach.** Added a `render_row_scratch_ab` Criterion group to compare the
+current strict direct `render_into` path against a row-scratch adapter that
+copies `render_streaming` rows into the final RGBA buffer. The comparison uses
+the issue's thumbnail and native targets with warmed decode caches.
+
+**Platform.**
+- OS: macOS 26.3.1 (Darwin 25.3)
+- CPU: Apple M1 Max, 10 cores
+- target_arch: `aarch64`
+- target_feature(s): ARM64 baseline; NEON available on Apple Silicon
+- Rust: 1.92.0 stable
+- RUSTFLAGS: unset
+- Source artifact: local run on `codex/issue-294-row-scratch-ab`
+
+**Command(s).**
+
+```sh
+cargo bench --bench render -- render_row_scratch_ab \
+  --warm-up-time 1 --measurement-time 2 --sample-size 10
+```
+
+**Numbers.**
+
+First run:
+
+| Target | Direct `render_into` | Row-scratch copy | Decision signal |
+|--------|---------------------:|-----------------:|-----------------|
+| `thumbnail_dpi72` | 248.21 µs | 205.35 µs | row-scratch faster |
+| `thumbnail_half_bilinear` | 153.55 µs | 399.13 µs | row-scratch much slower |
+| `colorbook_downscale` | 23.674 ms | 18.925 ms | row-scratch faster, noisy |
+| `corpus_color_native` | 207.96 ms | 248.74 ms | native regression |
+| `corpus_bilevel_native` | 150.93 ms | 198.23 ms | native regression |
+
+Rerun after bounding the A/B group to keep full CI benchmark runtime stable:
+
+| Target | Direct `render_into` | Row-scratch copy | Decision signal |
+|--------|---------------------:|-----------------:|-----------------|
+| `thumbnail_dpi72` | 306.59 µs | 199.09 µs | row-scratch faster |
+| `thumbnail_half_bilinear` | 143.84 µs | 124.58 µs | row-scratch faster |
+| `colorbook_downscale` | 15.966 ms | 11.861 ms | row-scratch faster, noisy |
+| `corpus_color_native` | 155.40 ms | 135.02 ms | row-scratch faster, noisy |
+| `corpus_bilevel_native` | 146.10 ms | 160.35 ms | no clear signal |
+
+**Decision.** Rejected as a render heuristic. No production render path changed.
+The A/B harness is kept so future thumbnail work can rerun the comparison.
+
+**Reason.** The repeated short A/B runs are too noisy and inconsistent to justify
+a production heuristic: the first run showed a thumbnail loss and native
+regressions, while the rerun showed broader wins but still no clean bilevel
+native signal. A threshold heuristic would be fragile without a more stable
+predictor than output size alone.
+
 ### #293 — compositor-only render baselines — **Kept** (2026-05-17)
 
 **Approach.** Added a `render_compositor_only` Criterion group to

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -4,6 +4,7 @@
 //! Benchmarks are skipped gracefully if the test files are not found.
 
 use std::hint::black_box;
+use std::time::Duration;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::path::PathBuf;
@@ -399,6 +400,109 @@ fn bench_render_compositor_only(c: &mut Criterion) {
     group.finish();
 }
 
+/// A/B current direct `render_into` against a row-scratch adapter that copies
+/// `render_streaming` rows into the final RGBA buffer. This is intentionally a
+/// measurement harness for #294; render behavior is unchanged by the bench.
+fn bench_render_row_scratch_ab(c: &mut Criterion) {
+    let cases = [
+        (
+            "thumbnail_dpi72",
+            assets_path().join("boy.djvu"),
+            72.0_f32 / 100.0_f32,
+        ),
+        (
+            "thumbnail_half_bilinear",
+            assets_path().join("boy.djvu"),
+            0.5_f32,
+        ),
+        (
+            "colorbook_downscale",
+            assets_path().join("colorbook.djvu"),
+            150.0_f32 / 400.0_f32,
+        ),
+        (
+            "corpus_color_native",
+            corpus_path().join("watchmaker.djvu"),
+            1.0_f32,
+        ),
+        (
+            "corpus_bilevel_native",
+            corpus_path().join("cable_1973_100133.djvu"),
+            1.0_f32,
+        ),
+    ];
+
+    let mut group = c.benchmark_group("render_row_scratch_ab");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(2));
+
+    for (label, path, scale) in cases {
+        let data = match std::fs::read(&path) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!(
+                    "skipping render_row_scratch_ab/{label}: {} not found",
+                    path.display()
+                );
+                continue;
+            }
+        };
+        let doc = match djvu_rs::DjVuDocument::parse(&data) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!("skipping render_row_scratch_ab/{label}: parse failed");
+                continue;
+            }
+        };
+        let page = match doc.page(0) {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("skipping render_row_scratch_ab/{label}: page 0 missing");
+                continue;
+            }
+        };
+
+        let width = ((page.width() as f32 * scale).round() as u32).max(1);
+        let height = ((page.height() as f32 * scale).round() as u32).max(1);
+        let opts = render_opts(width, height, scale);
+        let mut direct_buf = vec![0u8; width as usize * height as usize * 4];
+        let mut scratch_buf = vec![0u8; direct_buf.len()];
+
+        djvu_rs::djvu_render::render_pixmap(black_box(page), black_box(&opts))
+            .expect("warm render caches");
+
+        group.bench_function(BenchmarkId::new("direct_render_into", label), |b| {
+            b.iter(|| {
+                djvu_rs::djvu_render::render_into(
+                    black_box(page),
+                    black_box(&opts),
+                    black_box(direct_buf.as_mut_slice()),
+                )
+                .expect("render_into");
+                black_box(&direct_buf);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("row_scratch_copy", label), |b| {
+            b.iter(|| {
+                djvu_rs::djvu_render::render_streaming(
+                    black_box(page),
+                    black_box(&opts),
+                    |y, row| {
+                        let start = y * width as usize * 4;
+                        scratch_buf[start..start + row.len()].copy_from_slice(row);
+                    },
+                )
+                .expect("render_streaming");
+                black_box(&scratch_buf);
+            });
+        });
+    }
+
+    group.finish();
+}
+
 /// Benchmark 0.5× scaling with Bilinear vs Lanczos3 resampling on a color page.
 ///
 /// Lanczos3 re-renders at native resolution first, so the difference reveals
@@ -670,6 +774,7 @@ criterion_group!(
     bench_render_corpus_bilevel,
     bench_render_native_stage_breakdown,
     bench_render_compositor_only,
+    bench_render_row_scratch_ab,
     bench_render_scaled,
     bench_pdf_export,
 );


### PR DESCRIPTION
## Summary
- Add a render_row_scratch_ab Criterion group comparing direct render_into with a row-scratch copy adapter
- Cover the requested thumbnail, colorbook downscale, color native, and bilevel native targets
- Record the Apple M1 Max A/B result in PERF_EXPERIMENTS.md as Rejected
- Leave production render behavior unchanged because the result is mixed and native paths regress

Closes #294.

## Validation
- cargo bench --bench render -- render_row_scratch_ab --warm-up-time 1 --measurement-time 2 --sample-size 10
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --no-default-features
- cargo nextest run --profile ci --workspace --exclude djvu-py --features cli
- git diff --check

## Review
- Self-review completed against #294 acceptance criteria
- Independent read-only review completed with no findings