### PR TITLE
feat(cli/ocr): embed OCR text layers in DjVu output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng libtesseract-dev libleptonica-dev
 
       - name: Build (ocr-tesseract feature)
-        run: cargo build --features ocr-tesseract
+        run: cargo build --features cli,ocr-tesseract
 
       - name: Test (ocr-tesseract integration)
-        run: cargo test --test ocr_tesseract --features ocr-tesseract
+        run: cargo test --test ocr_tesseract --features cli,ocr-tesseract
 
   # ── Licenses & security audit (combined — both are fast, one runner) ─────────
   deps-check:

--- a/src/bin/djvu.rs
+++ b/src/bin/djvu.rs
@@ -805,17 +805,18 @@ fn cmd_ocr(
     let ocr_backend = build_ocr_backend(backend, model_path)?;
 
     let data = std::fs::read(path)?;
-    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&data)?;
+    let mut doc_mut = djvu_rs::djvu_mut::DjVuDocumentMut::from_bytes(&data)?;
+    let _ = doc_mut.page_mut(0)?;
 
     let options = OcrOptions {
         languages: lang.to_string(),
         dpi: 300,
     };
 
-    // OCR each page and collect text layers
-    let count = doc.page_count();
-    let mut text_chunks: Vec<Vec<u8>> = Vec::new();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&data)?;
 
+    // OCR each page and inject the recognized text layer.
+    let count = doc.page_count();
     for i in 0..count {
         let page = doc.page(i)?;
         let w = page.width() as u32;
@@ -835,25 +836,19 @@ fn cmd_ocr(
             text_layer.zones.len()
         );
 
-        let encoded = djvu_rs::text_encode::encode_text_layer(&text_layer, h);
-        text_chunks.push(encoded);
+        doc_mut.page_mut(i)?.set_text_layer(&text_layer)?;
     }
 
-    // Write output: copy original file and inject TXTa chunks
-    // For now, write the encoded text layers as standalone files
-    // (full DjVu rewriting requires IFF mutation which is future work)
     if let Some(parent) = output.parent()
         && !parent.as_os_str().is_empty()
     {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Copy original file, then append text chunks info
-    std::fs::copy(path, output)?;
-    eprintln!("OCR complete. Output written to {}", output.display());
+    std::fs::write(output, doc_mut.try_into_bytes()?)?;
     eprintln!(
-        "Note: text layer injection into DjVu IFF is pending; \
-         encoded TXTa data available via djvu_rs::text_encode"
+        "OCR complete. Embedded text layers for {count} page(s) into {}",
+        output.display()
     );
 
     Ok(())

--- a/src/djvu_mut.rs
+++ b/src/djvu_mut.rs
@@ -332,12 +332,12 @@ impl DjVuDocumentMut {
     ///   indirect (non-bundled) `FORM:DJVM` — page bytes live in external
     ///   files, so editing in place is not supported by this primitive.
     pub fn page_mut(&mut self, index: usize) -> Result<PageMut<'_>, MutError> {
-        let count = self.page_count();
-        if index >= count {
-            return Err(MutError::PageOutOfRange { index, count });
-        }
         let root_form_type = *self.root_form_type().expect("from_bytes validated FORM");
         if &root_form_type == b"DJVU" {
+            let count = self.page_count();
+            if index >= count {
+                return Err(MutError::PageOutOfRange { index, count });
+            }
             debug_assert_eq!(index, 0);
             return Ok(PageMut {
                 form: &mut self.file.root,
@@ -347,6 +347,10 @@ impl DjVuDocumentMut {
         debug_assert_eq!(&root_form_type, b"DJVM");
         if !is_bundled_djvm(&self.file.root) {
             return Err(MutError::IndirectDjvmUnsupported);
+        }
+        let count = self.page_count();
+        if index >= count {
+            return Err(MutError::PageOutOfRange { index, count });
         }
         // Walk the root's children, returning the index-th FORM:DJVU.
         let children = match &mut self.file.root {
@@ -814,6 +818,45 @@ mod tests {
         let count = doc.page_count();
         let err = doc.page_mut(count).err().unwrap();
         assert!(matches!(err, MutError::PageOutOfRange { .. }));
+    }
+
+    #[test]
+    fn page_mut_indirect_djvm_returns_unsupported_before_range_check() {
+        let mut doc = DjVuDocumentMut::from_bytes(&indirect_djvm_bytes()).unwrap();
+        let err = doc.page_mut(0).err().unwrap();
+        assert!(matches!(err, MutError::IndirectDjvmUnsupported));
+    }
+
+    fn indirect_djvm_bytes() -> Vec<u8> {
+        let bzz_meta: &[u8] = &[
+            0xff, 0xff, 0xed, 0xbf, 0x8a, 0x1f, 0xbe, 0xad, 0x14, 0x57, 0x10, 0xc9, 0x63, 0x19,
+            0x11, 0xf0, 0x85, 0x28, 0x12, 0x8a, 0xbf,
+        ];
+
+        let mut dirm_data = Vec::new();
+        dirm_data.push(0x00);
+        dirm_data.push(0x00);
+        dirm_data.push(0x01);
+        dirm_data.extend_from_slice(bzz_meta);
+
+        let mut dirm_chunk = Vec::new();
+        dirm_chunk.extend_from_slice(b"DIRM");
+        dirm_chunk.extend_from_slice(&(dirm_data.len() as u32).to_be_bytes());
+        dirm_chunk.extend_from_slice(&dirm_data);
+        if !dirm_data.len().is_multiple_of(2) {
+            dirm_chunk.push(0);
+        }
+
+        let mut form_body = Vec::new();
+        form_body.extend_from_slice(b"DJVM");
+        form_body.extend_from_slice(&dirm_chunk);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"AT&T");
+        out.extend_from_slice(b"FORM");
+        out.extend_from_slice(&(form_body.len() as u32).to_be_bytes());
+        out.extend_from_slice(&form_body);
+        out
     }
 
     #[test]

--- a/tests/ocr_tesseract.rs
+++ b/tests/ocr_tesseract.rs
@@ -7,6 +7,11 @@
 mod tesseract_tests {
     use std::path::PathBuf;
 
+    #[cfg(feature = "cli")]
+    use assert_cmd::Command;
+    #[cfg(feature = "cli")]
+    use predicates::prelude::*;
+
     use djvu_rs::{
         DjVuDocument,
         djvu_render::{RenderOptions, render_pixmap},
@@ -16,6 +21,11 @@ mod tesseract_tests {
 
     fn assets_path() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("references/djvujs/library/assets")
+    }
+
+    #[cfg(feature = "cli")]
+    fn corpus_path() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
     }
 
     #[test]
@@ -62,5 +72,82 @@ mod tesseract_tests {
         let _ = layer.text;
         // zones field is present and does not panic
         let _ = layer.zones;
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn cli_ocr_embeds_text_layer_into_single_page_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("boy_ocr.djvu");
+
+        Command::cargo_bin("djvu")
+            .unwrap()
+            .args([
+                "ocr",
+                assets_path().join("boy.djvu").to_str().unwrap(),
+                "--output",
+                out.to_str().unwrap(),
+            ])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Embedded text layers for 1 page"));
+
+        let data = std::fs::read(&out).expect("OCR output must exist");
+        let doc = DjVuDocument::parse(&data).expect("OCR output must parse");
+        assert!(
+            doc.page(0)
+                .expect("page 0")
+                .text_layer()
+                .expect("text layer parse")
+                .is_some(),
+            "OCR output should contain a TXTz/TXTa text layer"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn cli_ocr_embeds_text_layer_into_bundled_output_and_text_cli_reads_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("cable_ocr.djvu");
+
+        Command::cargo_bin("djvu")
+            .unwrap()
+            .args([
+                "ocr",
+                corpus_path()
+                    .join("cable_1973_100133.djvu")
+                    .to_str()
+                    .unwrap(),
+                "--output",
+                out.to_str().unwrap(),
+            ])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Embedded text layers for 2 page"));
+
+        let data = std::fs::read(&out).expect("OCR output must exist");
+        let doc = DjVuDocument::parse(&data).expect("OCR output must parse");
+        assert_eq!(doc.page_count(), 2);
+        for i in 0..2 {
+            assert!(
+                doc.page(i)
+                    .expect("page")
+                    .text_layer()
+                    .expect("text layer parse")
+                    .is_some(),
+                "page {i} should contain a TXTz/TXTa text layer"
+            );
+        }
+
+        Command::cargo_bin("djvu")
+            .unwrap()
+            .args(["text", out.to_str().unwrap(), "--all"])
+            .assert()
+            .success()
+            .stdout(
+                predicate::str::contains("--- Page 1 ---")
+                    .and(predicate::str::contains("--- Page 2 ---"))
+                    .and(predicate::str::contains("No text layer").not()),
+            );
     }
 }


### PR DESCRIPTION
Closes #296

Summary:
- Changed djvu ocr --output to rewrite the DjVu with recognized TextLayer data via DjVuDocumentMut::page_mut(...).set_text_layer(...).
- Supports single-page FORM:DJVU and bundled FORM:DJVM through the existing mutation API.
- Keeps indirect DJVM unsupported through MutError::IndirectDjvmUnsupported before OCR work starts.
- Removed the old text layer injection pending message and replaced it with an embedded-text success message.
- Updated the OCR CI job to exercise the CLI feature with Tesseract.

Validation:
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --test ocr_tesseract --features cli,ocr-tesseract -- -D warnings
- cargo build --no-default-features
- cargo test --test cli_ocr --features cli,ocr-onnx
- cargo test --features ocr-tesseract --test ocr_tesseract
- cargo test --features cli,ocr-tesseract --test ocr_tesseract
- cargo test djvu_mut::tests::page_mut_indirect_djvm_returns_unsupported_before_range_check --features cli
- cargo nextest run --profile ci --workspace --exclude djvu-py --features cli
- git diff --check

Review:
- Self-review completed against #296 acceptance criteria.
- Independent read-only review found two issues: ocr-tesseract-only test gating and indirect DJVM preflight ordering. Both were fixed and repro commands now pass.

Known follow-ups:
- Indirect DJVM mutation remains out of scope for this issue.