### PR TITLE
feat(cli): expose adaptive segmentation flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ djvu encode scan.png --quality quality --output scan.djvu --dpi 300
 # Use the conservative archival color profile for a single PNG
 djvu encode scan.png --quality archival --output scan.djvu --dpi 300
 
+# Opt into adaptive mask segmentation for uneven scans
+djvu encode scan.png --quality quality --binarization sauvola --bg-inpaint --output scan.djvu
+
 # Encode a directory of PNGs into a bundled DJVM with shared Djbz
 djvu encode pages/ --output book.djvu --shared-dict-pages 2
 ```
@@ -293,11 +296,13 @@ independently encoded layered pages so each page keeps its own `Sjbz`, `BG44`,
 and optional `FGbz` chunks. The `--shared-dict-pages` knob only affects the
 lossless directory path.
 
-Library callers can override color segmentation with `PageEncoder::with_segment_options`.
-The default remains fixed BT.601 thresholding; `SegmentOptions` also exposes
-Sauvola adaptive binarisation and fully-masked background-block inpainting for
-mixed text/photo scans where a single global threshold masks dark paper or misses
-light ink.
+Layered `quality` / `archival` encodes default to fixed BT.601 thresholding.
+`--binarization sauvola` opts into adaptive local thresholding for mixed or
+uneven lighting; tune it with `--sauvola-window` and `--sauvola-k`.
+`--bg-inpaint` fills fully masked background blocks from neighbouring unmasked
+pixels, which can reduce dark boxes under heavy text strokes. These knobs are
+opt-in, only affect layered profiles, and do not change lossless JB2 defaults.
+Library callers can use the same controls with `PageEncoder::with_segment_options`.
 
 ## hOCR and ALTO XML export
 

--- a/src/bin/djvu.rs
+++ b/src/bin/djvu.rs
@@ -129,6 +129,18 @@ enum Cmd {
         /// Encoding profile.
         #[arg(short, long, default_value = "lossless", value_enum)]
         quality: EncodeQualityArg,
+        /// Mask binarization for layered quality/archival encodes.
+        #[arg(long, default_value = "fixed", value_enum)]
+        binarization: BinarizationArg,
+        /// Sauvola local window size in pixels, used with --binarization sauvola.
+        #[arg(long, default_value = "25")]
+        sauvola_window: u32,
+        /// Sauvola k factor, used with --binarization sauvola.
+        #[arg(long, default_value = "0.34")]
+        sauvola_k: f32,
+        /// Inpaint fully masked background blocks for layered encodes.
+        #[arg(long)]
+        bg_inpaint: bool,
         /// (Multi-page only.) Promote a connected component to the
         /// shared Djbz dictionary if it appears on at least this many
         /// distinct pages. Default: 2.
@@ -210,6 +222,14 @@ enum EncodeQualityArg {
     Archival,
 }
 
+#[derive(Clone, Copy, ValueEnum, PartialEq, Eq)]
+enum BinarizationArg {
+    /// Fixed BT.601 luminance threshold.
+    Fixed,
+    /// Sauvola local adaptive threshold.
+    Sauvola,
+}
+
 #[derive(Clone, ValueEnum)]
 enum Layer {
     /// Full composite render (default).
@@ -276,8 +296,24 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             output,
             dpi,
             quality,
+            binarization,
+            sauvola_window,
+            sauvola_k,
+            bg_inpaint,
             shared_dict_pages,
-        } => cmd_encode(&input, &output, dpi, quality, shared_dict_pages),
+        } => cmd_encode(
+            &input,
+            &output,
+            dpi,
+            quality,
+            EncodeSegmentArgs {
+                binarization,
+                sauvola_window,
+                sauvola_k,
+                bg_inpaint,
+            },
+            shared_dict_pages,
+        ),
     }
 }
 
@@ -1041,6 +1077,7 @@ fn cmd_encode(
     output: &Path,
     dpi: u16,
     quality: EncodeQualityArg,
+    segment_args: EncodeSegmentArgs,
     shared_dict_pages: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use djvu_rs::djvu_encode::{EncodeQuality, PageEncoder};
@@ -1052,6 +1089,7 @@ fn cmd_encode(
         EncodeQualityArg::Quality => EncodeQuality::Quality,
         EncodeQualityArg::Archival => EncodeQuality::Archival,
     };
+    let segment_options = segment_args.to_options(q)?;
 
     if input.is_dir() {
         let entries = directory_png_entries(input)?;
@@ -1085,9 +1123,13 @@ fn cmd_encode(
         let mut pages = Vec::with_capacity(entries.len());
         for path in &entries {
             let pixmap = decode_png_to_pixmap(path)?;
-            let page = PageEncoder::from_pixmap(&pixmap)
+            let mut encoder = PageEncoder::from_pixmap(&pixmap)
                 .with_dpi(dpi)
-                .with_quality(q)
+                .with_quality(q);
+            if let Some(opts) = segment_options {
+                encoder = encoder.with_segment_options(opts);
+            }
+            let page = encoder
                 .encode()
                 .map_err(|e| format!("{}: {e}", path.display()))?;
             pages.push(page);
@@ -1115,10 +1157,15 @@ fn cmd_encode(
                 .with_quality(EncodeQuality::Lossless)
                 .encode()
         }
-        EncodeQuality::Quality | EncodeQuality::Archival => PageEncoder::from_pixmap(&pixmap)
-            .with_dpi(dpi)
-            .with_quality(q)
-            .encode(),
+        EncodeQuality::Quality | EncodeQuality::Archival => {
+            let mut encoder = PageEncoder::from_pixmap(&pixmap)
+                .with_dpi(dpi)
+                .with_quality(q);
+            if let Some(opts) = segment_options {
+                encoder = encoder.with_segment_options(opts);
+            }
+            encoder.encode()
+        }
     }
     .map_err(|e| format!("encode: {e}"))?;
 
@@ -1132,6 +1179,53 @@ fn cmd_encode(
         bytes.len(),
     );
     Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct EncodeSegmentArgs {
+    binarization: BinarizationArg,
+    sauvola_window: u32,
+    sauvola_k: f32,
+    bg_inpaint: bool,
+}
+
+impl EncodeSegmentArgs {
+    fn to_options(
+        self,
+        quality: djvu_rs::djvu_encode::EncodeQuality,
+    ) -> Result<Option<djvu_rs::segment::SegmentOptions>, Box<dyn std::error::Error>> {
+        use djvu_rs::djvu_encode::EncodeQuality;
+        use djvu_rs::segment::{Binarization, SegmentOptions};
+
+        let has_segment_flags = self.binarization != BinarizationArg::Fixed || self.bg_inpaint;
+        if !has_segment_flags {
+            return Ok(None);
+        }
+        if matches!(quality, EncodeQuality::Lossless) {
+            return Err(
+                "--binarization and --bg-inpaint require --quality quality or --quality archival"
+                    .into(),
+            );
+        }
+
+        let mut opts = match quality {
+            EncodeQuality::Quality => SegmentOptions::default(),
+            EncodeQuality::Archival => SegmentOptions {
+                bg_subsample: 6,
+                ..SegmentOptions::default()
+            },
+            EncodeQuality::Lossless => unreachable!(),
+        };
+        opts.binarization = match self.binarization {
+            BinarizationArg::Fixed => Binarization::Fixed,
+            BinarizationArg::Sauvola => Binarization::Sauvola {
+                window: self.sauvola_window,
+                k: self.sauvola_k,
+            },
+        };
+        opts.bg_inpaint = self.bg_inpaint;
+        Ok(Some(opts))
+    }
 }
 
 fn directory_png_entries(dir: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {

--- a/tests/cli_encode.rs
+++ b/tests/cli_encode.rs
@@ -63,6 +63,53 @@ fn write_two_color_ink_png(path: &Path, w: u32, h: u32) {
     writer.write_image_data(&data).unwrap();
 }
 
+fn write_mixed_lighting_png(path: &Path, w: u32, h: u32) {
+    let file = std::fs::File::create(path).unwrap();
+    let writer = std::io::BufWriter::new(file);
+    let mut encoder = png::Encoder::new(writer, w, h);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().unwrap();
+    let mut data = Vec::with_capacity((w * h * 3) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let on_dark_half = x < w / 2;
+            let mut v = if on_dark_half { 105 } else { 235 };
+            if (8..24).contains(&x) && (8..24).contains(&y) {
+                v = 72;
+            } else if (40..56).contains(&x) && (8..24).contains(&y) {
+                v = 185;
+            }
+            data.extend_from_slice(&[v, v, v]);
+        }
+    }
+    writer.write_image_data(&data).unwrap();
+}
+
+fn mask_ink_pixels(path: &Path) -> u32 {
+    let bytes = std::fs::read(path).unwrap();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&bytes).unwrap();
+    let page = doc.page(0).unwrap();
+    let mask = page.extract_mask().unwrap().expect("mask");
+    let mut ink = 0;
+    for y in 0..mask.height {
+        for x in 0..mask.width {
+            ink += u32::from(mask.get(x, y));
+        }
+    }
+    ink
+}
+
+fn first_background_pixel(path: &Path) -> (u8, u8, u8) {
+    let bytes = std::fs::read(path).unwrap();
+    let doc = djvu_rs::djvu_document::DjVuDocument::parse(&bytes).unwrap();
+    let page = doc.page(0).unwrap();
+    page.extract_background()
+        .unwrap()
+        .expect("background")
+        .get_rgb(0, 0)
+}
+
 #[test]
 fn encode_creates_djvu_file() {
     let dir = tempfile::tempdir().unwrap();
@@ -197,6 +244,159 @@ fn encode_archival_profile_emits_layered_djvu() {
     assert!(page.raw_chunk(b"Sjbz").is_some());
     assert!(!page.all_chunks(b"BG44").is_empty());
     assert!(page.raw_chunk(b"FGbz").is_some());
+}
+
+#[test]
+fn encode_quality_binarization_flags_affect_layered_mask() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("mixed.png");
+    let fixed_output = dir.path().join("fixed.djvu");
+    let sauvola_output = dir.path().join("sauvola.djvu");
+    write_mixed_lighting_png(&input, 64, 32);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            fixed_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            sauvola_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+            "--binarization",
+            "sauvola",
+            "--sauvola-window",
+            "9",
+            "--sauvola-k",
+            "0.34",
+        ])
+        .assert()
+        .success();
+
+    assert_ne!(
+        mask_ink_pixels(&fixed_output),
+        mask_ink_pixels(&sauvola_output)
+    );
+}
+
+#[test]
+fn encode_quality_fixed_binarization_keeps_default_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("mixed.png");
+    let default_output = dir.path().join("default.djvu");
+    let fixed_output = dir.path().join("fixed.djvu");
+    write_mixed_lighting_png(&input, 64, 32);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            default_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            fixed_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+            "--binarization",
+            "fixed",
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        std::fs::read(default_output).unwrap(),
+        std::fs::read(fixed_output).unwrap()
+    );
+}
+
+#[test]
+fn encode_quality_bg_inpaint_affects_layered_background() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("ink.png");
+    let default_output = dir.path().join("default.djvu");
+    let inpaint_output = dir.path().join("inpaint.djvu");
+    write_test_png(&input, 24, 24);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            default_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            inpaint_output.to_str().unwrap(),
+            "--quality",
+            "quality",
+            "--bg-inpaint",
+        ])
+        .assert()
+        .success();
+
+    assert_ne!(
+        first_background_pixel(&default_output),
+        first_background_pixel(&inpaint_output)
+    );
+}
+
+#[test]
+fn encode_lossless_rejects_segmentation_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    let input = dir.path().join("in.png");
+    let output = dir.path().join("out.djvu");
+    write_test_png(&input, 32, 32);
+
+    Command::cargo_bin("djvu")
+        .unwrap()
+        .args([
+            "encode",
+            input.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+            "--binarization",
+            "sauvola",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--binarization and --bg-inpaint require --quality quality or --quality archival",
+        ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `djvu encode` flags for layered segmentation: `--binarization fixed|sauvola`, `--sauvola-window`, `--sauvola-k`, and `--bg-inpaint`
- apply custom `SegmentOptions` only to `quality` / `archival` layered encodes while preserving defaults and lossless behavior
- document the opt-in tradeoffs in README and CLI help

Fixes #297

## Validation
- `cargo fmt --check`
- `cargo test --test cli_encode --features cli`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --no-default-features`
- `cargo nextest run --profile ci --workspace --exclude djvu-py --features cli`
- `cargo run --quiet --features cli -- encode --help`
- `git diff --check`

## Review
- self-review completed against #297 acceptance criteria
- independent read-only review found no blockers; noted only that `--sauvola-window` / `--sauvola-k` are ignored unless `--binarization sauvola`, which is documented in help

## Experiments
No benchmark, probe, quality sweep, or A/B experiment was run. The synthetic CLI tests assert behavior only, so no `PERF_EXPERIMENTS.md` entry is required.