### PR TITLE
perf(pdf): record export memory baseline

### DIFF
--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -254,6 +254,12 @@ requested output rectangle is larger than the native page.
 - JB2 and IW44 pure decode are sub-millisecond to low-millisecond for typical pages.
 - Full native-resolution render (2550×3301 px): ~67–70 ms.
 - Corpus benchmarks use public domain files from Internet Archive.
+- PDF export baseline for `tests/corpus/watchmaker.djvu` (12 pages, 150 dpi,
+  JPEG-80, Apple M1 Max / macOS arm64, Rust 1.92, 2026-05-17):
+  `pdf_export_sequential` median **955 ms**, `pdf_export_parallel` median
+  **154 ms**. Memory probe peak RSS: sequential **76.7 MiB**, parallel
+  **228.9 MiB**. See `PERF_EXPERIMENTS.md` entry #298 for commands and
+  per-stage byte counts.
 - `render_large_doc_first_page` improved from ~43 ms → 10.4 ms across v0.5.2–v0.5.3:
   - `Pixmap::new` fill changed from per-pixel push to `vec![fill; n]`
   - JB2 symbol dictionary cached via `RwLock<HashMap<usize, Arc<JB2Dict>>>`

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -1263,3 +1263,71 @@ block and one public cross-architecture result schema for #306, #307, and #308.
 **Reason.** Normalizing the table first avoids each downstream architecture
 issue inventing a different platform format, while preserving measurement
 discipline by distinguishing current numbers from missing/untrusted cells.
+
+### #298 — PDF export memory and parallel baseline — **Needs follow-up** (2026-05-17)
+
+**Approach.** Measured the existing PDF export pipeline before any streaming
+rewrite. Criterion measured the stable `pdf_export_sequential` and
+`pdf_export_parallel` benches on `tests/corpus/watchmaker.djvu` (12 pages,
+default PDF options: 150 dpi, JPEG-80). A new reproducible
+`examples/pdf_memory_probe.rs` harness recorded read/parse, one-page
+render/RGB/JPEG staging, full PDF export time, PDF bytes, and peak RSS via
+`/usr/bin/time -l`.
+
+**Platform.**
+- OS: macOS 26.3.1 / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple M1 Max, 10 cores
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: Apple ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- RUSTFLAGS: unset
+- Source artifact: local run on `codex/issue-298-pdf-baseline`
+
+**Command(s).**
+
+```sh
+cargo bench --bench render --features std -- pdf_export_sequential
+cargo bench --bench render --features std,parallel -- pdf_export_parallel
+
+/usr/bin/time -l cargo run --release --example pdf_memory_probe -- \
+  tests/corpus/watchmaker.djvu
+
+/usr/bin/time -l cargo run --release --features parallel \
+  --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+```
+
+**Numbers.**
+
+| Measurement | Sequential | Parallel |
+|-------------|-----------:|---------:|
+| Criterion `pdf_export_*` | 955.42 ms median (`916.16..999.54 ms`) | 154.05 ms median (`153.41..154.66 ms`) |
+| Probe `pdf_export_ms` | 893.827 ms | 187.183 ms |
+| Peak RSS (`maximum resident set size`) | 80,379,904 bytes (76.7 MiB) | 240,058,368 bytes (228.9 MiB) |
+| Peak memory footprint | 79,479,872 bytes (75.8 MiB) | 239,175,232 bytes (228.1 MiB) |
+| Output PDF bytes | 6,651,085 | 6,651,085 |
+
+Single-page breakdown from the same probe, page 0 rendered at 150 dpi
+(`1275x1651`):
+
+| Stage | Time | Bytes |
+|-------|-----:|------:|
+| Read input | 0.075 ms | 183,352 |
+| Parse document | 0.152 ms | - |
+| Render full RGBA pixmap | 43.822 ms | 8,420,100 |
+| Convert RGBA to RGB staging buffer | 2.904 ms | 6,315,075 |
+| JPEG-80 encode staging buffer | 13.065 ms | 312,922 |
+
+The parallel probe uses the same one-page breakdown before full export; that
+single-page section stayed essentially unchanged (`render_pixmap_ms=44.410`,
+`rgb_stage_ms=3.183`, `jpeg_stage_ms=13.228`) while full export dropped to
+`187.183 ms` and peak RSS rose to `228.9 MiB`.
+
+**Decision.** Needs follow-up.
+
+**Reason.** Parallel export is about 5.3-6.2x faster on the 12-page color
+fixture, but it increases peak RSS by about 3.0x because `djvu_to_pdf_impl`
+collects every `RenderedPage` before sequential object emission. The concrete
+baseline for #299 is therefore: beat ~894 ms sequential wall time and reduce
+or cap the ~76.7 MiB sequential peak RSS / ~228.9 MiB parallel peak RSS by
+streaming page render/RGB/JPEG data into PDF objects instead of retaining all
+encoded page bodies at once.

--- a/examples/pdf_memory_probe.rs
+++ b/examples/pdf_memory_probe.rs
@@ -1,0 +1,128 @@
+//! PDF export timing and memory probe.
+//!
+//! Usage:
+//!   cargo run --release --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+//!   cargo run --release --features parallel --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+//!
+//! For peak RSS, wrap the command with the platform time tool, for example:
+//!   /usr/bin/time -l cargo run --release --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+//!   /usr/bin/time -v cargo run --release --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use djvu_rs::djvu_document::DjVuDocument;
+use djvu_rs::djvu_render::{RenderOptions, render_pixmap};
+use djvu_rs::pdf::djvu_to_pdf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args_os().skip(1);
+    let path = args.next().map(PathBuf::from).ok_or_else(|| {
+        "usage: pdf_memory_probe <file.djvu> [page-index-for-breakdown]".to_string()
+    })?;
+    let page_index = args
+        .next()
+        .map(|v| v.to_string_lossy().parse::<usize>())
+        .transpose()?
+        .unwrap_or(0);
+
+    let read_start = Instant::now();
+    let data = std::fs::read(&path)?;
+    let read_ms = read_start.elapsed().as_secs_f64() * 1000.0;
+
+    let parse_start = Instant::now();
+    let doc = DjVuDocument::parse(&data)?;
+    let parse_ms = parse_start.elapsed().as_secs_f64() * 1000.0;
+
+    let page_count = doc.page_count();
+    let page = doc.page(page_index)?;
+    let (rw, rh) = render_dims(
+        u32::from(page.width()),
+        u32::from(page.height()),
+        u32::from(page.dpi().max(1)),
+        150,
+    );
+
+    let (render_ms, rgba_bytes, rgb_ms, rgb_bytes, jpeg_ms, jpeg_len) = {
+        let render_start = Instant::now();
+        let pixmap = render_pixmap(
+            page,
+            &RenderOptions {
+                width: rw,
+                height: rh,
+                ..RenderOptions::default()
+            },
+        )?;
+        let render_ms = render_start.elapsed().as_secs_f64() * 1000.0;
+        let rgba_bytes = pixmap.data.len();
+
+        let rgb_start = Instant::now();
+        let rgb = pixmap.to_rgb();
+        let rgb_ms = rgb_start.elapsed().as_secs_f64() * 1000.0;
+        let rgb_bytes = rgb.len();
+
+        let jpeg_start = Instant::now();
+        let jpeg_len = encode_rgb_to_jpeg_len(&rgb, rw, rh, 80);
+        let jpeg_ms = jpeg_start.elapsed().as_secs_f64() * 1000.0;
+
+        (render_ms, rgba_bytes, rgb_ms, rgb_bytes, jpeg_ms, jpeg_len)
+    };
+
+    let pdf_start = Instant::now();
+    let pdf = djvu_to_pdf(&doc)?;
+    let pdf_ms = pdf_start.elapsed().as_secs_f64() * 1000.0;
+
+    println!("file={}", path.display());
+    println!("input_bytes={}", data.len());
+    println!("pages={page_count}");
+    println!("read_ms={read_ms:.3}");
+    println!("parse_ms={parse_ms:.3}");
+    println!("breakdown_page={page_index}");
+    println!("render_dims={}x{}", rw, rh);
+    println!("render_pixmap_ms={render_ms:.3}");
+    println!("rgba_bytes={rgba_bytes}");
+    println!("rgb_stage_ms={rgb_ms:.3}");
+    println!("rgb_bytes={rgb_bytes}");
+    println!("jpeg_stage_ms={jpeg_ms:.3}");
+    println!("jpeg_bytes={jpeg_len}");
+    println!("pdf_export_ms={pdf_ms:.3}");
+    println!("pdf_bytes={}", pdf.len());
+    println!(
+        "parallel_feature={}",
+        if cfg!(feature = "parallel") {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+
+    Ok(())
+}
+
+fn render_dims(width: u32, height: u32, page_dpi: u32, output_dpi: u32) -> (u32, u32) {
+    let target = if output_dpi == 0 {
+        page_dpi
+    } else {
+        output_dpi
+    };
+    if target == page_dpi {
+        return (width, height);
+    }
+    let scale = target as f64 / page_dpi as f64;
+    (
+        ((width as f64 * scale).round() as u32).max(1),
+        ((height as f64 * scale).round() as u32).max(1),
+    )
+}
+
+fn encode_rgb_to_jpeg_len(rgb: &[u8], width: u32, height: u32, quality: u8) -> usize {
+    let mut jpeg = Vec::new();
+    let encoder = jpeg_encoder::Encoder::new(&mut jpeg, quality);
+    let _ = encoder.encode(
+        rgb,
+        width as u16,
+        height as u16,
+        jpeg_encoder::ColorType::Rgb,
+    );
+    jpeg.len()
+}


### PR DESCRIPTION
## Summary
- add `examples/pdf_memory_probe.rs` for reproducible PDF export timing, per-stage bytes, and `/usr/bin/time -l` RSS probes
- record sequential and parallel `pdf_export_*` Criterion baselines in `PERF_EXPERIMENTS.md`
- record corrected sequential/parallel PDF export peak RSS and public benchmark summary

Fixes #298

## Measurements
- `pdf_export_sequential`: 955.42 ms median (`916.16..999.54 ms`)
- `pdf_export_parallel`: 154.05 ms median (`153.41..154.66 ms`)
- corrected probe `pdf_export_ms`: sequential 893.827 ms, parallel 187.183 ms
- corrected peak RSS: sequential 80,379,904 bytes (76.7 MiB), parallel 240,058,368 bytes (228.9 MiB)
- output PDF bytes: 6,651,085 in both modes

## Validation
- `cargo fmt --check`
- `cargo check --example pdf_memory_probe`
- `cargo check --example pdf_memory_probe --features parallel`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --no-default-features`
- `cargo nextest run --profile ci --workspace --exclude djvu-py --features cli`
- `cargo bench --bench render --features std -- pdf_export_sequential`
- `cargo bench --bench render --features std,parallel -- pdf_export_parallel`
- `/usr/bin/time -l cargo run --release --example pdf_memory_probe -- tests/corpus/watchmaker.djvu`
- `/usr/bin/time -l cargo run --release --features parallel --example pdf_memory_probe -- tests/corpus/watchmaker.djvu`
- `git diff --check`

## Review
- self-review completed against #298 acceptance criteria
- independent review found the first RSS probe retained stage buffers during full export; fixed by scoping/dropping those buffers before `djvu_to_pdf`
- independent re-review found no remaining issues

## Scope
Measurement-only. No PDF pipeline behavior or output bytes were changed.