### PR TITLE
perf(pdf): stream RGB staging for color pages

### DIFF
--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -260,6 +260,11 @@ requested output rectangle is larger than the native page.
   **154 ms**. Memory probe peak RSS: sequential **76.7 MiB**, parallel
   **228.9 MiB**. See `PERF_EXPERIMENTS.md` entry #298 for commands and
   per-stage byte counts.
+- PDF color row streaming (#299, same fixture/platform): sequential
+  `pdf_export_sequential` median **812 ms**; parallel probe peak RSS improved
+  from **228.9 MiB** to **169.5 MiB** with unchanged PDF bytes. See
+  `PERF_EXPERIMENTS.md` entry #299 for the noisy parallel Criterion runs and
+  full command log.
 - `render_large_doc_first_page` improved from ~43 ms → 10.4 ms across v0.5.2–v0.5.3:
   - `Pixmap::new` fill changed from per-pixel push to `vec![fill; n]`
   - JB2 symbol dictionary cached via `RwLock<HashMap<usize, Arc<JB2Dict>>>`

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -1331,3 +1331,62 @@ baseline for #299 is therefore: beat ~894 ms sequential wall time and reduce
 or cap the ~76.7 MiB sequential peak RSS / ~228.9 MiB parallel peak RSS by
 streaming page render/RGB/JPEG data into PDF objects instead of retaining all
 encoded page bodies at once.
+
+### #299 — PDF color row streaming — **Kept** (2026-05-17)
+
+**Approach.** Replaced the PDF color-image path's full `Pixmap` + full RGB
+staging pair with `render_streaming` into one RGB staging buffer when render
+options are streamable. The fallback `render_pixmap(...).to_rgb()` path remains
+for anti-aliasing, scaled Lanczos, rotation, and other non-streamable options.
+Measured against the #298 baseline on the same `tests/corpus/watchmaker.djvu`
+PDF fixture (12 pages, default PDF options: 150 dpi, JPEG-80).
+
+**Platform.**
+- OS: macOS 26.3.1 / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple M1 Max, 10 cores
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: Apple ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- RUSTFLAGS: unset
+- Source artifact: local run on `codex/issue-299-pdf-streaming`
+
+**Command(s).**
+
+```sh
+cargo bench --bench render --features std -- pdf_export_sequential
+cargo bench --bench render --features std,parallel -- pdf_export_parallel
+cargo bench --bench render --features std,parallel -- pdf_export_parallel
+
+/usr/bin/time -l cargo run --release --example pdf_memory_probe -- \
+  tests/corpus/watchmaker.djvu
+/usr/bin/time -l cargo run --release --features parallel \
+  --example pdf_memory_probe -- tests/corpus/watchmaker.djvu
+```
+
+**Numbers.**
+
+| Measurement | #298 baseline | #299 row streaming |
+|-------------|--------------:|-------------------:|
+| Criterion `pdf_export_sequential` median | 955.42 ms | 811.83 ms (`810.13..813.58 ms`) |
+| Criterion `pdf_export_parallel` median | 154.05 ms | 165.57 ms rerun (`154.19..178.74 ms`) |
+| Sequential probe `pdf_export_ms` | 893.827 ms | 852.285 ms |
+| Parallel probe `pdf_export_ms` | 187.183 ms | 155.745 ms |
+| Sequential peak RSS | 80,379,904 bytes (76.7 MiB) | 77,512,704 bytes (73.9 MiB) |
+| Parallel peak RSS | 240,058,368 bytes (228.9 MiB) | 177,684,480 bytes (169.5 MiB) |
+| Output PDF bytes | 6,651,085 | 6,651,085 |
+
+The first parallel Criterion run after the change measured
+`219.65 ms` (`206.80..232.42 ms`) and reported a regression; an immediate rerun
+measured `165.57 ms` (`154.19..178.74 ms`). The single-run probe also measured
+parallel export at `155.745 ms`. Treat parallel timing as noisy on this host;
+the stable win is peak RSS.
+
+**Decision.** Kept.
+
+**Reason.** The change preserves PDF bytes and keeps the fallback path for
+non-streamable render options. It removes the extra full RGBA page allocation
+from the streamable PDF color path. Sequential RSS falls modestly from
+`76.7 MiB` to `73.9 MiB`; parallel RSS falls materially from `228.9 MiB` to
+`169.5 MiB` (-26%). The remaining peak is dominated by retained per-page
+encoded RGB/JPEG/PDF object bodies, so a larger memory reduction would require
+streaming PDF object emission rather than only row-streamed rendering.

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -255,8 +255,7 @@ fn render_page_data(page: &DjVuPage, opts: &PdfOptions) -> Result<RenderedPage, 
             height: rh,
             ..RenderOptions::default()
         };
-        let pixmap = djvu_render::render_pixmap(page, &render_opts)?;
-        let rgb = pixmap.to_rgb();
+        let rgb = render_rgb_for_pdf(page, &render_opts, rw, rh)?;
 
         let img_dict = format!(
             " /Type /XObject /Subtype /Image /Width {rw} /Height {rh}\
@@ -290,6 +289,33 @@ fn render_page_data(page: &DjVuPage, opts: &PdfOptions) -> Result<RenderedPage, 
         text_ops,
         link_annot_bodies,
     })
+}
+
+fn render_rgb_for_pdf(
+    page: &DjVuPage,
+    opts: &RenderOptions,
+    width: u32,
+    height: u32,
+) -> Result<Vec<u8>, PdfError> {
+    if can_stream_pdf_render(page, opts) {
+        let mut rgb = Vec::with_capacity(width as usize * height as usize * 3);
+        djvu_render::render_streaming(page, opts, |_, rgba_row| {
+            for rgba in rgba_row.chunks_exact(4) {
+                rgb.extend_from_slice(&rgba[..3]);
+            }
+        })?;
+        Ok(rgb)
+    } else {
+        Ok(djvu_render::render_pixmap(page, opts)?.to_rgb())
+    }
+}
+
+fn can_stream_pdf_render(page: &DjVuPage, opts: &RenderOptions) -> bool {
+    !opts.aa
+        && (opts.resampling == djvu_render::Resampling::Bilinear
+            || (page.width() as u32 == opts.width && page.height() as u32 == opts.height))
+        && page.rotation() == crate::info::Rotation::None
+        && opts.rotation == djvu_render::UserRotation::None
 }
 
 /// Decode and deflate the JB2 foreground mask into a PDF ImageMask XObject body.
@@ -1256,5 +1282,44 @@ mod tests {
             default_pdf.len() < flat_pdf.len(),
             "default PDF must use DCT and be smaller than FlateDecode"
         );
+    }
+
+    #[test]
+    fn pdf_rgb_streaming_matches_pixmap_rgb() {
+        let doc = load_doc("boy.djvu");
+        let page = doc.page(0).unwrap();
+        let (rw, rh) = render_dims(
+            page.width() as u32,
+            page.height() as u32,
+            page.dpi().max(1) as f32,
+            PdfOptions::default().output_dpi,
+        );
+        let opts = RenderOptions {
+            width: rw,
+            height: rh,
+            ..RenderOptions::default()
+        };
+
+        let streamed = render_rgb_for_pdf(page, &opts, rw, rh).unwrap();
+        let pixmap = djvu_render::render_pixmap(page, &opts).unwrap();
+
+        assert_eq!(streamed, pixmap.to_rgb());
+    }
+
+    #[test]
+    fn pdf_rgb_fallback_handles_non_streamable_options() {
+        let doc = load_doc("boy.djvu");
+        let page = doc.page(0).unwrap();
+        let opts = RenderOptions {
+            width: page.width() as u32,
+            height: page.height() as u32,
+            aa: true,
+            ..RenderOptions::default()
+        };
+
+        let rgb = render_rgb_for_pdf(page, &opts, opts.width, opts.height).unwrap();
+        let pixmap = djvu_render::render_pixmap(page, &opts).unwrap();
+
+        assert_eq!(rgb, pixmap.to_rgb());
     }
 }


### PR DESCRIPTION
## Summary
- route streamable PDF color-page rendering through `render_streaming` into one RGB staging buffer
- keep the existing full-pixmap fallback for AA, scaled Lanczos, rotation, and unsupported options
- add direct RGB equivalence coverage for the streaming path and fallback coverage for non-streamable options
- record #299 memory/timing results against the #298 baseline

Fixes #299

## Measurements
- sequential probe `pdf_export_ms`: #298 893.827 ms -> #299 852.285 ms
- parallel probe `pdf_export_ms`: #298 187.183 ms -> #299 155.745 ms
- sequential peak RSS: #298 80,379,904 bytes (76.7 MiB) -> #299 77,512,704 bytes (73.9 MiB)
- parallel peak RSS: #298 240,058,368 bytes (228.9 MiB) -> #299 177,684,480 bytes (169.5 MiB)
- output PDF bytes stayed unchanged at 6,651,085
- Criterion sequential median: #298 955.42 ms -> #299 811.83 ms
- Criterion parallel was noisy: first #299 run 219.65 ms, immediate rerun 165.57 ms vs #298 154.05 ms; the stable win is RSS reduction

## Validation
- `cargo fmt --check`
- `cargo test pdf_rgb_ --features cli`
- `cargo test --test pdf_conversion --features cli`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --no-default-features`
- `cargo nextest run --profile ci --workspace --exclude djvu-py --features cli`
- `cargo bench --bench render --features std -- pdf_export_sequential`
- `cargo bench --bench render --features std,parallel -- pdf_export_parallel` (twice)
- `/usr/bin/time -l cargo run --release --example pdf_memory_probe -- tests/corpus/watchmaker.djvu`
- `/usr/bin/time -l cargo run --release --features parallel --example pdf_memory_probe -- tests/corpus/watchmaker.djvu`
- `git diff --check`

## Review
- self-review completed against #299 acceptance criteria
- independent read-only review found no blockers

## Scope
No PDF object-model redesign. Fallback path remains for non-streamable render options.