### PR TITLE
quality(iw44-enc): diagnose low PSNR on conquete_paix

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -1390,3 +1390,98 @@ from the streamable PDF color path. Sequential RSS falls modestly from
 `169.5 MiB` (-26%). The remaining peak is dominated by retained per-page
 encoded RGB/JPEG/PDF object bodies, so a larger memory reduction would require
 streaming PDF object emission rather than only row-streamed rendering.
+
+### #300 — IW44 low-PSNR diagnosis on `conquete_paix` — **Needs follow-up** (2026-05-17)
+
+**Approach.** Added a repeatable diagnostic example that re-encodes existing
+BG44 backgrounds from `watchmaker` and `conquete_paix` with controlled variants:
+current pre-quantization RGB-to-YCbCr model, inverse-compatible pre-quantization
+model, default IW44 encode, full-resolution chroma, 200 total slices, and
+gray-luma-only encode. This issue intentionally did not change default encoder
+behavior.
+
+**Platform.**
+- OS: macOS / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple Silicon host
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: Apple ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- RUSTFLAGS: unset
+
+**Command(s).**
+
+```sh
+cargo run --release --features std --example diagnose_iw44_quality -- \
+  tests/corpus/watchmaker.djvu tests/corpus/conquete_paix.djvu \
+  > /private/tmp/iw44_diag_300.jsonl \
+  2> /private/tmp/iw44_diag_300.stderr
+```
+
+`watchmaker` pages 0-4, 7-9, and 11 were skipped because the original BG44
+stream did not decode through the strict full-stream diagnostic path; pages 5,
+6, and 10 were enough to confirm the good-page baseline.
+
+**Numbers.**
+
+| File | Variant | Pages | Avg luma PSNR | Min luma PSNR | Avg byte ratio |
+|------|---------|------:|--------------:|--------------:|---------------:|
+| `watchmaker.djvu` | default | 3 | 46.42 dB | 44.99 dB | 0.73x |
+| `watchmaker.djvu` | full chroma | 3 | 46.37 dB | 44.99 dB | 0.73x |
+| `watchmaker.djvu` | 200 slices | 3 | 46.31 dB | 44.93 dB | 137.32x |
+| `watchmaker.djvu` | gray luma only, 200 slices | 3 | 46.41 dB | 44.95 dB | 137.31x |
+| `conquete_paix.djvu` | pre-quant current YCbCr model | 20 | 47.90 dB | 42.97 dB | n/a |
+| `conquete_paix.djvu` | pre-quant inverse-compatible model | 20 | 52.53 dB | 51.32 dB | n/a |
+| `conquete_paix.djvu` | default | 20 | 15.49 dB | 9.75 dB | 1.16x |
+| `conquete_paix.djvu` | full chroma | 20 | 16.35 dB | 9.15 dB | 1.24x |
+| `conquete_paix.djvu` | 200 slices | 20 | 15.43 dB | 10.84 dB | 55.87x |
+| `conquete_paix.djvu` | gray luma only, 200 slices | 20 | 14.57 dB | 9.21 dB | 40.40x |
+
+Per-page `watchmaker` baseline:
+
+| Page | Orig BG44 bytes | Default bytes | Default luma PSNR | Full chroma luma PSNR | 200 slices luma PSNR | Gray luma-only PSNR |
+|------|----------------:|--------------:|------------------:|----------------------:|---------------------:|--------------------:|
+| 5 | 2,028 | 1,788 | 44.994 dB | 44.988 dB | 44.934 dB | 44.950 dB |
+| 6 | 1,804 | 1,178 | 47.268 dB | 47.123 dB | 47.036 dB | 47.302 dB |
+| 10 | 1,772 | 1,161 | 46.984 dB | 46.988 dB | 46.975 dB | 46.979 dB |
+
+Per-page `conquete_paix` diagnostic:
+
+| Page | Orig BG44 bytes | Default bytes | Default luma PSNR | Full chroma luma PSNR | 200 slices luma PSNR | Gray luma-only PSNR |
+|------|----------------:|--------------:|------------------:|----------------------:|---------------------:|--------------------:|
+| 2 | 75,375 | 86,138 | 13.716 dB | 18.130 dB | 10.842 dB | 15.499 dB |
+| 3 | 36,721 | 37,994 | 9.746 dB | 16.749 dB | 14.251 dB | 19.829 dB |
+| 4 | 41,754 | 49,853 | 12.713 dB | 9.148 dB | 15.914 dB | 9.764 dB |
+| 5 | 32,415 | 39,573 | 12.125 dB | 12.345 dB | 13.436 dB | 9.961 dB |
+| 6 | 125,387 | 140,114 | 15.159 dB | 18.328 dB | 13.634 dB | 17.737 dB |
+| 7 | 90,023 | 102,677 | 14.429 dB | 9.876 dB | 11.275 dB | 18.507 dB |
+| 8 | 97,611 | 110,499 | 20.826 dB | 14.056 dB | 16.937 dB | 16.546 dB |
+| 9 | 94,750 | 107,785 | 16.934 dB | 14.794 dB | 21.151 dB | 20.543 dB |
+| 10 | 102,842 | 116,915 | 18.350 dB | 20.647 dB | 17.430 dB | 12.006 dB |
+| 11 | 91,607 | 104,672 | 11.219 dB | 19.431 dB | 11.875 dB | 17.791 dB |
+| 12 | 104,131 | 117,898 | 16.722 dB | 14.036 dB | 17.168 dB | 10.354 dB |
+| 13 | 96,424 | 109,673 | 20.043 dB | 18.464 dB | 20.039 dB | 9.210 dB |
+| 14 | 102,115 | 115,874 | 18.909 dB | 18.312 dB | 19.579 dB | 13.873 dB |
+| 15 | 91,303 | 103,789 | 11.826 dB | 13.003 dB | 11.657 dB | 16.271 dB |
+| 16 | 112,528 | 126,994 | 19.714 dB | 19.820 dB | 13.751 dB | 11.713 dB |
+| 17 | 110,328 | 124,617 | 12.350 dB | 16.952 dB | 11.208 dB | 17.077 dB |
+| 18 | 36,292 | 43,735 | 11.783 dB | 19.109 dB | 18.280 dB | 9.960 dB |
+| 19 | 26,855 | 38,856 | 20.226 dB | 21.302 dB | 14.453 dB | 11.716 dB |
+| 20 | 45,896 | 53,610 | 16.041 dB | 15.038 dB | 17.046 dB | 15.550 dB |
+| 21 | 87,548 | 99,228 | 16.901 dB | 17.430 dB | 18.767 dB | 17.463 dB |
+
+**Decision.** Needs follow-up.
+
+**Reason.** The failure is reproduced on `conquete_paix` while `watchmaker`
+remains high quality. It is not explained by BG44 byte budget: default output
+is already larger than the original on `conquete_paix` (`1.16x` average), and
+200 slices explodes output size (`55.87x`) without improving luma PSNR. It is
+not solved by chroma subsampling alone: full-resolution chroma improves some
+bad pages substantially (for example page 3: `9.746 dB` to `16.749 dB`, page
+11: `11.219 dB` to `19.431 dB`) but still leaves the corpus at only
+`16.35 dB` average and worsens other pages. The pre-quantization color-model
+probes stay much higher (`47.90 dB` current model, `52.53 dB`
+inverse-compatible model), so the catastrophic luma loss appears after
+RGB/YCbCr conversion, inside the forward wavelet / coefficient quantization /
+reconstruction-tracking path on high-detail color backgrounds. Follow-up #320
+isolates that path with coefficient-plane diagnostics before any encoder
+tuning.

--- a/examples/diagnose_iw44_quality.rs
+++ b/examples/diagnose_iw44_quality.rs
@@ -1,0 +1,300 @@
+//! IW44 quality diagnostic for issue-driven investigations.
+//!
+//! Re-encodes existing BG44 backgrounds with a small set of diagnostic variants
+//! and prints JSONL.  This example is intentionally not a benchmark harness:
+//! it is for localizing whether quality loss is from chroma sampling, luma
+//! quantization/slice budget, or another encoder stage.
+//!
+//! Usage:
+//!   cargo run --release --features=std --example diagnose_iw44_quality -- \
+//!     tests/corpus/watchmaker.djvu tests/corpus/conquete_paix.djvu
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use djvu_rs::{
+    DjVuDocument, Pixmap,
+    iw44_encode::{Iw44EncodeOptions, encode_iw44_color, encode_iw44_gray},
+    iw44_new::Iw44Image,
+};
+
+#[derive(Clone, Copy)]
+enum Variant {
+    ModelCurrent,
+    ModelInverse,
+    Default,
+    FullChroma,
+    MoreSlices,
+    GrayLumaOnly,
+}
+
+impl Variant {
+    fn name(self) -> &'static str {
+        match self {
+            Variant::ModelCurrent => "model_current_ycbcr",
+            Variant::ModelInverse => "model_inverse_ycbcr",
+            Variant::Default => "default",
+            Variant::FullChroma => "full_chroma",
+            Variant::MoreSlices => "more_slices",
+            Variant::GrayLumaOnly => "gray_luma_only",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VariantResult {
+    bytes: usize,
+    psnr_luma_db: f64,
+    psnr_rgb_db: f64,
+}
+
+fn luma(r: u8, g: u8, b: u8) -> f64 {
+    0.299 * f64::from(r) + 0.587 * f64::from(g) + 0.114 * f64::from(b)
+}
+
+fn psnr_luma(a: &Pixmap, b: &Pixmap) -> f64 {
+    assert_eq!(a.width, b.width);
+    assert_eq!(a.height, b.height);
+    let mut mse = 0.0f64;
+    let mut n = 0usize;
+    for (ra, rb) in a.data.chunks_exact(4).zip(b.data.chunks_exact(4)) {
+        let d = luma(ra[0], ra[1], ra[2]) - luma(rb[0], rb[1], rb[2]);
+        mse += d * d;
+        n += 1;
+    }
+    psnr_from_mse(mse, n)
+}
+
+fn psnr_rgb(a: &Pixmap, b: &Pixmap) -> f64 {
+    assert_eq!(a.width, b.width);
+    assert_eq!(a.height, b.height);
+    let mut mse = 0.0f64;
+    let mut n = 0usize;
+    for (ra, rb) in a.data.chunks_exact(4).zip(b.data.chunks_exact(4)) {
+        for chan in 0..3 {
+            let d = f64::from(ra[chan]) - f64::from(rb[chan]);
+            mse += d * d;
+            n += 1;
+        }
+    }
+    psnr_from_mse(mse, n)
+}
+
+fn psnr_from_mse(sum_sq: f64, n: usize) -> f64 {
+    if n == 0 {
+        return f64::NAN;
+    }
+    let mse = sum_sq / n as f64;
+    if mse == 0.0 {
+        f64::INFINITY
+    } else {
+        10.0 * (255.0 * 255.0 / mse).log10()
+    }
+}
+
+fn current_encoder_ycbcr(r: u8, g: u8, b: u8) -> (i32, i32, i32) {
+    let r = i32::from(r);
+    let g = i32::from(g);
+    let b = i32::from(b);
+    let y = (r + (g << 1) + b) / 4 - 128;
+    let cb = b - g;
+    let cr = r - g;
+    (y.clamp(-128, 127), cb.clamp(-256, 255), cr.clamp(-256, 255))
+}
+
+fn inverse_compatible_ycbcr(r: u8, g: u8, b: u8) -> (i32, i32, i32) {
+    let r = i32::from(r);
+    let g = i32::from(g);
+    let b = i32::from(b);
+    let dr = r - g;
+    let db = b - g;
+    let cb = ((-2 * dr + 8 * db) as f64 / 15.0).round() as i32;
+    let cr = ((8 * dr - db) as f64 / 15.0).round() as i32;
+    let y = (g - 128) + ((cb as f64 / 4.0) + (cr as f64 / 2.0)).round() as i32;
+    (y.clamp(-128, 127), cb.clamp(-128, 127), cr.clamp(-128, 127))
+}
+
+fn ycbcr_to_rgb(y: i32, cb: i32, cr: i32) -> (u8, u8, u8) {
+    let t2 = cr + (cr >> 1);
+    let t3 = y + 128 - (cb >> 2);
+    (
+        (y + 128 + t2).clamp(0, 255) as u8,
+        (t3 - (cr >> 1)).clamp(0, 255) as u8,
+        (t3 + (cb << 1)).clamp(0, 255) as u8,
+    )
+}
+
+fn model_roundtrip(reference: &Pixmap, model: fn(u8, u8, u8) -> (i32, i32, i32)) -> Pixmap {
+    let mut out = Pixmap::white(reference.width, reference.height);
+    for y in 0..reference.height {
+        for x in 0..reference.width {
+            let (r, g, b) = reference.get_rgb(x, y);
+            let (yy, cb, cr) = model(r, g, b);
+            let (rr, gg, bb) = ycbcr_to_rgb(yy, cb, cr);
+            out.set_rgb(x, y, rr, gg, bb);
+        }
+    }
+    out
+}
+
+fn json_float(value: f64) -> String {
+    if value.is_finite() {
+        format!("{value:.3}")
+    } else {
+        "null".to_string()
+    }
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("string serialization cannot fail")
+}
+
+fn decode_bg44_chunks(chunks: &[&[u8]]) -> Option<Pixmap> {
+    let mut img = Iw44Image::new();
+    for chunk in chunks {
+        img.decode_chunk(chunk).ok()?;
+    }
+    img.to_rgb().ok()
+}
+
+fn decode_bg44_owned(chunks: &[Vec<u8>]) -> Option<Pixmap> {
+    let mut img = Iw44Image::new();
+    for chunk in chunks {
+        img.decode_chunk(chunk).ok()?;
+    }
+    img.to_rgb().ok()
+}
+
+fn encode_variant(reference: &Pixmap, variant: Variant) -> Option<VariantResult> {
+    if matches!(variant, Variant::ModelCurrent | Variant::ModelInverse) {
+        let decoded = match variant {
+            Variant::ModelCurrent => model_roundtrip(reference, current_encoder_ycbcr),
+            Variant::ModelInverse => model_roundtrip(reference, inverse_compatible_ycbcr),
+            _ => unreachable!(),
+        };
+        return Some(VariantResult {
+            bytes: 0,
+            psnr_luma_db: psnr_luma(reference, &decoded),
+            psnr_rgb_db: psnr_rgb(reference, &decoded),
+        });
+    }
+
+    let chunks = match variant {
+        Variant::ModelCurrent | Variant::ModelInverse => unreachable!(),
+        Variant::Default => encode_iw44_color(reference, &Iw44EncodeOptions::default()),
+        Variant::FullChroma => {
+            let opts = Iw44EncodeOptions {
+                chroma_half: false,
+                ..Iw44EncodeOptions::default()
+            };
+            encode_iw44_color(reference, &opts)
+        }
+        Variant::MoreSlices => {
+            let opts = Iw44EncodeOptions {
+                total_slices: 200,
+                slices_per_chunk: 20,
+                ..Iw44EncodeOptions::default()
+            };
+            encode_iw44_color(reference, &opts)
+        }
+        Variant::GrayLumaOnly => {
+            let gray = reference.to_gray8();
+            let opts = Iw44EncodeOptions {
+                total_slices: 200,
+                slices_per_chunk: 20,
+                ..Iw44EncodeOptions::default()
+            };
+            encode_iw44_gray(&gray, &opts)
+        }
+    };
+    let bytes = chunks.iter().map(Vec::len).sum();
+    let decoded = decode_bg44_owned(&chunks)?;
+    Some(VariantResult {
+        bytes,
+        psnr_luma_db: psnr_luma(reference, &decoded),
+        psnr_rgb_db: psnr_rgb(reference, &decoded),
+    })
+}
+
+fn process_file(path: &Path) -> Result<usize, String> {
+    let data = std::fs::read(path).map_err(|err| err.to_string())?;
+    let doc = DjVuDocument::parse(&data).map_err(|err| err.to_string())?;
+    let variants = [
+        Variant::ModelCurrent,
+        Variant::ModelInverse,
+        Variant::Default,
+        Variant::FullChroma,
+        Variant::MoreSlices,
+        Variant::GrayLumaOnly,
+    ];
+
+    let mut pages = 0usize;
+    for page_idx in 0..doc.page_count() {
+        let page = doc.page(page_idx).map_err(|err| err.to_string())?;
+        let bg44_chunks = page.bg44_chunks();
+        if bg44_chunks.is_empty() {
+            continue;
+        }
+        let orig_bytes = bg44_chunks.iter().map(|chunk| chunk.len()).sum::<usize>();
+        let Some(reference) = decode_bg44_chunks(&bg44_chunks) else {
+            eprintln!(
+                "skip {} page {}: original BG44 decode failed",
+                path.display(),
+                page_idx
+            );
+            continue;
+        };
+
+        for variant in variants {
+            let Some(result) = encode_variant(&reference, variant) else {
+                eprintln!(
+                    "skip {} page {} variant {}: decode failed",
+                    path.display(),
+                    page_idx,
+                    variant.name()
+                );
+                continue;
+            };
+            println!(
+                "{{\"file\":{},\"page\":{},\"variant\":{},\
+                 \"width\":{},\"height\":{},\"orig_bg44_bytes\":{},\
+                 \"rs_bg44_bytes\":{},\"byte_ratio\":{:.3},\
+                 \"psnr_luma_db\":{},\"psnr_rgb_db\":{}}}",
+                json_string(&path.display().to_string()),
+                page_idx,
+                json_string(variant.name()),
+                reference.width,
+                reference.height,
+                orig_bytes,
+                result.bytes,
+                result.bytes as f64 / orig_bytes.max(1) as f64,
+                json_float(result.psnr_luma_db),
+                json_float(result.psnr_rgb_db)
+            );
+        }
+        pages += 1;
+    }
+    Ok(pages)
+}
+
+fn main() -> ExitCode {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() {
+        eprintln!("usage: diagnose_iw44_quality <file.djvu> [<file2.djvu> ...]");
+        return ExitCode::from(2);
+    }
+
+    let mut total = 0usize;
+    for arg in args {
+        match process_file(Path::new(&arg)) {
+            Ok(pages) => total += pages,
+            Err(err) => eprintln!("skip {arg}: {err}"),
+        }
+    }
+
+    if total == 0 {
+        eprintln!("no BG44 pages processed");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary
- add a repeatable IW44 quality diagnostic example for issue #300
- run default/full-chroma/200-slice/gray-luma/pre-quant model probes on `watchmaker` and `conquete_paix`
- record aggregate and per-page results in `PERF_EXPERIMENTS.md`
- file follow-up #320 for coefficient-plane isolation before any encoder tuning

## Diagnosis
- `watchmaker` good pages stay around 46.42 dB average luma PSNR with default encoding.
- `conquete_paix` defaults average 15.49 dB luma PSNR, despite output bytes already averaging 1.16x original BG44.
- Full chroma improves some bad pages but does not solve the corpus: 16.35 dB average, with mixed per-page behavior.
- 200 slices greatly increases bytes, 55.87x average, without improving average luma PSNR.
- Pre-quant model probes stay high, 47.90 dB current model and 52.53 dB inverse-compatible model, pointing after RGB/YCbCr conversion into forward wavelet / quantization / reconstruction tracking.

## Validation
- `cargo fmt --check`
- `cargo check --example diagnose_iw44_quality --features std`
- `cargo run --release --features std --example diagnose_iw44_quality -- tests/corpus/watchmaker.djvu tests/corpus/conquete_paix.djvu > /private/tmp/iw44_diag_300.jsonl 2> /private/tmp/iw44_diag_300.stderr`
- JSON parser check over `/private/tmp/iw44_diag_300.jsonl` (138 records)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --no-default-features`
- `cargo nextest run --profile ci --workspace --exclude djvu-py --features cli`
- `git diff --check`

## Review
- Self-review completed against #300 acceptance criteria.
- Independent read-only review found issues around per-page recording, chroma wording, and JSON escaping; all were fixed.
- Independent re-review found no remaining blockers.

Closes #300.