### PR TITLE
perf(jb2-enc): estimate cross-size refinement byte cost

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -1485,3 +1485,63 @@ RGB/YCbCr conversion, inside the forward wavelet / coefficient quantization /
 reconstruction-tracking path on high-detail color backgrounds. Follow-up #320
 isolates that path with coefficient-plane diagnostics before any encoder
 tuning.
+
+### #301 — JB2 cross-size refinement byte-cost estimator — **Proceed** (2026-05-17)
+
+**Approach.** Extended the existing #283 cross-size candidate-count probe with
+an approximate byte-cost model. For near cross-size candidates, the model
+compares the current record-1 fresh-symbol payload estimate against a
+hypothetical cross-size record-6 estimate that includes symbol-index/context
+overhead, width/height/refinement overhead, and a packed Hamming-payload proxy.
+No bytes are emitted and `encode_djvm_bundle_jb2` behavior is unchanged.
+
+**Platform.**
+- OS: macOS / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple Silicon host
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: Apple ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- RUSTFLAGS: unset
+
+**Command(s).**
+
+```sh
+cargo run --release --example encode_quality_djbz -- \
+  tests/corpus/watchmaker.djvu tests/corpus/pathogenic_bacteria_1896.djvu \
+  --cc-stats --cross-size-stats \
+  > /private/tmp/jb2_cost_301.jsonl \
+  2> /private/tmp/jb2_cost_301.stderr
+```
+
+**Numbers.**
+
+Bundle baseline from the same run:
+
+| File | Pages | Original Sjbz | Independent dict | Bundled shared-Djbz | Bundle / independent | Round-trip |
+|------|------:|--------------:|-----------------:|--------------------:|---------------------:|------------|
+| `watchmaker.djvu` | 12 | 122,923 | 130,036 | 122,832 | 0.9446x | pixel-exact |
+| `pathogenic_bacteria_1896.djvu` | 517 | 24,849,842 | 34,254,905 | 33,430,276 | 0.9759x | pixel-exact |
+
+Cross-size estimator:
+
+| File | Fresh CCs | Eligible | Candidates | Near @ 5% | Near pixels | Median best Hamming | Est current rec-1 | Est cross-size rec-6 | Est delta | Delta / independent |
+|------|----------:|---------:|-----------:|----------:|------------:|--------------------:|-----------------:|---------------------:|----------:|--------------------:|
+| `watchmaker.djvu` | 2,652 | 2,649 | 2,331 | 547 (20.65%) | 525,061 | 92 | 75,632 B | 5,641 B | -69,991 B | -53.82% |
+| `pathogenic_bacteria_1896.djvu` | 759,291 | 703,928 | 686,402 | 61,485 (8.73%) | 67,245,972 | 88 | 9,677,015 B | 830,556 B | -8,846,459 B | -25.83% |
+
+Semantics: a real cross-size record-6 path should be lossless if it emits the
+full refinement bitmap correctly. This probe is not an emitting encoder path;
+it uses nearest-neighbor scaled Hamming only for candidate selection and cost
+estimation. The byte model is deliberately approximate and optimistic because
+the packed Hamming proxy is not a real ZP-coded refinement bitstream.
+
+**Decision.** Proceed.
+
+**Reason.** Both required corpora show enough estimated byte headroom to justify
+a narrow emitting spike: `watchmaker` has 547 near cross-size matches and
+`pathogenic_bacteria_1896` has 61,485, with large estimated negative deltas.
+The result is not sufficient to change defaults because the estimator does not
+prove actual ZP-coded record-6 byte cost or round-trip behavior. Follow-up #322
+should implement an experiment-only cross-size rec-6 emitter, compare actual
+bytes against this estimate, and stop before tuning if output is not
+pixel-exact. The shipped default remains exact shared-Djbz rec-7 plus rec-1.

--- a/examples/encode_quality_djbz.rs
+++ b/examples/encode_quality_djbz.rs
@@ -202,6 +202,9 @@ fn process_file(
             total.near_matches += s.near_matches;
             total.near_match_pixels += s.near_match_pixels;
             total.best_hamming.extend(s.best_hamming);
+            total.estimated_rec1_bytes += s.estimated_rec1_bytes;
+            total.estimated_cross_size_rec6_bytes += s.estimated_cross_size_rec6_bytes;
+            total.estimated_byte_delta += s.estimated_byte_delta;
         }
         let median = if total.best_hamming.is_empty() {
             0
@@ -218,6 +221,16 @@ fn process_file(
             total.near_matches as f64 / total.eligible_fresh_ccs.max(1) as f64 * 100.0,
             total.near_match_pixels,
             median,
+        );
+        eprintln!(
+            "  cross-size byte estimate: current_rec1={}B hypothetical_rec6={}B delta={}B ({:.2}% of independent)",
+            total.estimated_rec1_bytes,
+            total.estimated_cross_size_rec6_bytes,
+            total.estimated_byte_delta,
+            total.estimated_byte_delta as f64 / indep_total.max(1) as f64 * 100.0,
+        );
+        eprintln!(
+            "  cross-size semantics: hypothetical rec-6 would be lossless if emitted with a full refinement bitmap; this probe does not emit bytes and uses nearest-neighbor scaled Hamming only for candidate selection/cost estimation",
         );
     }
 

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -464,6 +464,22 @@ pub struct CrossSizeRefinementStats {
     pub near_match_pixels: u64,
     /// Best normalized Hamming score observed for every near-size candidate.
     pub best_hamming: Vec<u32>,
+    /// Approximate bytes current record-1 emissions spend on near-match symbols.
+    ///
+    /// This includes direct bitmap payload bytes plus a small fixed record
+    /// overhead approximation. It intentionally excludes coordinate coding
+    /// because both record-1 and hypothetical record-6 still place a symbol.
+    pub estimated_rec1_bytes: u64,
+    /// Approximate bytes a hypothetical cross-size record-6 path would spend
+    /// for the same near-match symbols.
+    ///
+    /// Includes an estimated symbol-index/context overhead and a packed
+    /// refinement-difference payload estimate. No encoder behavior depends on
+    /// this value; it is measurement-only.
+    pub estimated_cross_size_rec6_bytes: u64,
+    /// Estimated byte delta: `cross_size_rec6 - current_rec1`.
+    /// Negative means the hypothetical path may save bytes.
+    pub estimated_byte_delta: i64,
 }
 
 /// Extract all 8-connected components of black pixels from `bitmap`.
@@ -591,6 +607,27 @@ fn scaled_hamming(cand: &Bitmap, reference: &Bitmap) -> u32 {
     diff
 }
 
+fn packed_bytes_for_pixels(pixels: u64) -> u64 {
+    pixels.div_ceil(8)
+}
+
+fn index_overhead_bytes(dict_len: usize) -> u64 {
+    let bits = usize::BITS - dict_len.max(1).leading_zeros();
+    u64::from(bits).div_ceil(8)
+}
+
+fn estimate_record1_symbol_bytes(symbol: &Bitmap) -> u64 {
+    const RECORD1_OVERHEAD_BYTES: u64 = 3; // record type + width + height, approximate.
+    symbol.data.len() as u64 + RECORD1_OVERHEAD_BYTES
+}
+
+fn estimate_cross_size_rec6_symbol_bytes(hamming: u32, dict_len: usize) -> u64 {
+    const RECORD6_OVERHEAD_BYTES: u64 = 5; // record type + wdiff/hdiff + refinement flags, approximate.
+    RECORD6_OVERHEAD_BYTES
+        + index_overhead_bytes(dict_len)
+        + packed_bytes_for_pixels(u64::from(hamming))
+}
+
 /// Estimate cross-size refinement headroom without changing encoder output.
 ///
 /// The JB2 format can encode record-6 refinements where the reference symbol
@@ -677,6 +714,11 @@ pub fn analyze_jb2_cross_size_refinement(
                 if best <= max_diff {
                     stats.near_matches += 1;
                     stats.near_match_pixels += pixels;
+                    let rec1 = estimate_record1_symbol_bytes(&cc.bitmap);
+                    let rec6 = estimate_cross_size_rec6_symbol_bytes(best, dict_entries.len());
+                    stats.estimated_rec1_bytes += rec1;
+                    stats.estimated_cross_size_rec6_bytes += rec6;
+                    stats.estimated_byte_delta += rec6 as i64 - rec1 as i64;
                 }
             }
         }
@@ -2340,6 +2382,8 @@ mod tests {
         let stats = analyze_jb2_cross_size_refinement(&page, &[shared_glyph], 1, 0.05);
         assert_eq!(stats.near_matches, 1);
         assert_eq!(stats.near_match_pixels, 42);
+        assert!(stats.estimated_rec1_bytes > 0);
+        assert!(stats.estimated_cross_size_rec6_bytes > 0);
         assert!(
             stats.candidate_ccs >= stats.near_matches,
             "near matches must be a subset of cross-size candidates"


### PR DESCRIPTION
## Summary
- extend the existing cross-size JB2 refinement probe with approximate byte-cost fields
- print current rec-1 vs hypothetical cross-size rec-6 estimates from `encode_quality_djbz --cross-size-stats`
- record required `watchmaker` and `pathogenic_bacteria_1896` measurements in `PERF_EXPERIMENTS.md`
- file follow-up #322 for an experiment-only emitting spike before any default behavior change

## Results

| File | Fresh CCs | Eligible | Candidates | Near @ 5% | Est current rec-1 | Est cross-size rec-6 | Est delta |
|------|----------:|---------:|-----------:|----------:|-----------------:|---------------------:|----------:|
| `watchmaker.djvu` | 2,652 | 2,649 | 2,331 | 547 | 75,632 B | 5,641 B | -69,991 B |
| `pathogenic_bacteria_1896.djvu` | 759,291 | 703,928 | 686,402 | 61,485 | 9,677,015 B | 830,556 B | -8,846,459 B |

Decision recorded as `Proceed`: the estimator justifies a narrow emitting spike, not a shipped encoder change.

## Scope/safety
- measurement-only; no bytes are emitted by the new estimator
- `encode_djvm_bundle_jb2` defaults remain unchanged
- estimator is documented as approximate/optimistic because it uses a packed Hamming proxy, not actual ZP-coded record-6 bytes

## Validation
- `cargo fmt --check`
- `cargo test analyze_cross_size_refinement_counts_near_size_candidates --lib --features std`
- `cargo check --example encode_quality_djbz --features std`
- `cargo run --release --example encode_quality_djbz -- tests/corpus/watchmaker.djvu tests/corpus/pathogenic_bacteria_1896.djvu --cc-stats --cross-size-stats > /private/tmp/jb2_cost_301.jsonl 2> /private/tmp/jb2_cost_301.stderr`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo build --no-default-features`
- `cargo nextest run --profile ci --workspace --exclude djvu-py --features cli`
- `git diff --check`

## Review
- Self-review completed against #301 acceptance criteria.
- Independent read-only review found no blockers.

Closes #301.