### PR TITLE
ci: add Windows MSVC CLI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,28 @@ jobs:
           cargo nextest run --profile ci --workspace --exclude djvu-py --features cli
           --filter-expr 'not (binary(pdf_conversion) or test(iw44_new_decode_big))'
 
+  # ── Windows smoke ───────────────────────────────────────────────────────────
+  windows-msvc:
+    name: Windows MSVC smoke
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable (MSVC)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-msvc
+
+      - name: Build CLI
+        run: cargo build --features cli
+
+      - name: CLI smoke (djvu info)
+        run: .\target\debug\djvu.exe info tests\fixtures\boy_jb2.djvu
+
   # ── MSRV ─────────────────────────────────────────────────────────────────────
   msrv:
     name: MSRV (1.88)


### PR DESCRIPTION
## Summary
- add a windows-latest MSVC stable Rust smoke job to CI
- build with --features cli
- run the built djvu.exe against tests/fixtures/boy_jb2.djvu with djvu info

Fixes #304

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- cargo run --features cli --bin djvu -- info tests/fixtures/boy_jb2.djvu
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --no-default-features
- git diff --check

## Review
- self-review: scope is CI-only, smoke-level, no optional Windows OCR/perf setup

## Experiments
- not run; this is CI coverage, not a measurement issue