### PR TITLE
ci: add Linux aarch64 smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,33 @@ jobs:
       - name: CLI smoke (djvu info)
         run: .\target\debug\djvu.exe info tests\fixtures\boy_jb2.djvu
 
+  # ── Linux aarch64 smoke ─────────────────────────────────────────────────────
+  linux-aarch64:
+    name: Linux aarch64 smoke
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: linux-aarch64
+
+      # Native Linux aarch64 runner. NEON is part of baseline aarch64, but this
+      # job is support coverage only; #308 owns ARM64 performance validation.
+      - name: Build workspace + CLI
+        run: cargo build --workspace --exclude djvu-py --features cli
+
+      - name: Test libraries
+        run: cargo test --lib --workspace --exclude djvu-py
+
+      - name: CLI smoke (djvu info)
+        run: ./target/debug/djvu info tests/fixtures/boy_jb2.djvu
+
   # ── MSRV ─────────────────────────────────────────────────────────────────────
   msrv:
     name: MSRV (1.88)

--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -45,7 +45,7 @@ so follow-up SIMD work can fill them without changing the schema.
 | Linux x86_64-v3 / AVX2 | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | `avx2` via x86-64-v3 codegen | stable from workflow | `-C target-cpu=x86-64-v3` | `.github/workflows/bench.yml` `bench-x86-64-v3` job; #189 artifact run `25299920836` | Current AVX2 validation exists for selected IW44/render benches |
 | wasm32 scalar | — | — | `wasm32` | scalar | — | — | Blocked pending #306 harness | Missing |
 | wasm32 simd128 | — | — | `wasm32` | `simd128` | — | `-C target-feature=+simd128` | Blocked pending #306 harness | Missing |
-| Linux aarch64 | — | — | `aarch64` | NEON | — | — | No trustworthy current artifact | Missing |
+| Linux aarch64 | Ubuntu GitHub-hosted arm64 runner | `ubuntu-24.04-arm` | `aarch64` | NEON baseline | stable from workflow | unset | `.github/workflows/ci.yml` `Linux aarch64 smoke` job (#305) | CI smoke coverage only; benchmark numbers still missing |
 
 ### Architecture-sensitive seed numbers
 
@@ -71,8 +71,9 @@ Notes:
   this file.
 - Linux x86_64 baseline and x86_64-v3 values come from the #189 AVX2 validation
   artifact recorded in `PERF_EXPERIMENTS.md`.
-- The wasm32 and Linux aarch64 cells are explicitly missing. #306 and #308 are
-  expected to fill them using the metadata template above.
+- The wasm32 and Linux aarch64 benchmark cells are explicitly missing. #306 and
+  #308 are expected to fill them using the metadata template above; #305 only
+  records Linux aarch64 build/test support coverage.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a native Linux aarch64 smoke job on ubuntu-24.04-arm
- build the workspace with --features cli, run workspace library tests, and smoke djvu info
- record Linux aarch64 as CI smoke support coverage in BENCHMARKS_RESULTS.md without adding benchmark numbers

Fixes #305

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- cargo build --workspace --exclude djvu-py --features cli
- cargo test --lib --workspace --exclude djvu-py
- ./target/debug/djvu info tests/fixtures/boy_jb2.djvu
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --no-default-features
- git diff --check

## Review
- self-review: native arm64 support only, no performance claim; #308 remains responsible for ARM64 performance validation

## Experiments
- not recorded in PERF_EXPERIMENTS.md; this is CI smoke coverage, not a benchmark issue