### PR TITLE
perf(wasm): add simd128 benchmark harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,13 @@ jobs:
           RUSTFLAGS: -C target-feature=+simd128
         run: cargo check --target wasm32-unknown-unknown --features wasm
 
+      # Timing is intentionally not run in CI; Node/runner variance is too high.
+      # Keep the reproducible local scalar-vs-simd128 harness syntax-checked.
+      - name: wasm simd128 benchmark harness syntax check
+        run: |
+          bash -n scripts/bench_wasm_simd128.sh
+          node --check scripts/bench_wasm_simd128.mjs
+
       # Consumer-side no_std smoke (#227). The wasm32 build above proves the
       # lib *itself* is no_std-clean; this sub-crate proves the four codec
       # entry points (iff::parse_form, bzz_new::bzz_decode, jb2::decode_dict,

--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -43,8 +43,8 @@ so follow-up SIMD work can fill them without changing the schema.
 | Apple ARM64 | macOS 26.3.1 (Darwin 25.3) | Apple M1 Max, 10 cores | `aarch64` | ARM64 baseline; NEON available on Apple Silicon | 1.92.0 stable | unset | Current local `cargo bench --workspace --features cli,tiff` summary below | Current broad baseline |
 | Linux x86_64 baseline | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | baseline x86-64 codegen | stable from workflow | unset | #189 artifact run `25299920836` from `.github/workflows/bench.yml` `bench-x86-64-v3` validation | Current selected IW44/render baseline |
 | Linux x86_64-v3 / AVX2 | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | `avx2` via x86-64-v3 codegen | stable from workflow | `-C target-cpu=x86-64-v3` | `.github/workflows/bench.yml` `bench-x86-64-v3` job; #189 artifact run `25299920836` | Current AVX2 validation exists for selected IW44/render benches |
-| wasm32 scalar | — | — | `wasm32` | scalar | — | — | Blocked pending #306 harness | Missing |
-| wasm32 simd128 | — | — | `wasm32` | `simd128` | — | `-C target-feature=+simd128` | Blocked pending #306 harness | Missing |
+| wasm32 scalar | macOS 26.3.1 host / Node.js v26.0.0 | Apple M1 Max host running Node.js wasm | `wasm32` | scalar | 1.92.0 stable | unset | `scripts/bench_wasm_simd128.sh` local run (#306) | Current small-fixture wasm baseline |
+| wasm32 simd128 | macOS 26.3.1 host / Node.js v26.0.0 | Apple M1 Max host running Node.js wasm | `wasm32` | `simd128` | 1.92.0 stable | `-C target-feature=+simd128` | `scripts/bench_wasm_simd128.sh` local run (#306) | Current small-fixture wasm simd128 baseline |
 | Linux aarch64 | Ubuntu GitHub-hosted arm64 runner | `ubuntu-24.04-arm` | `aarch64` | NEON baseline | stable from workflow | unset | `.github/workflows/ci.yml` `Linux aarch64 smoke` job (#305) | CI smoke coverage only; benchmark numbers still missing |
 
 ### Architecture-sensitive seed numbers
@@ -64,6 +64,9 @@ metadata format.
 | `render_colorbook_cold` | **17.3 ms** | 28,127,606 ns | 27,105,326 ns | missing | missing | missing |
 | `render_colorbook_stages/mask_decode` | **4.13 ms** | 5,325,125 ns | 5,107,550 ns | missing | missing | missing |
 | `render_corpus_color` | **68.7 ms** | 133,813,976 ns | 133,185,634 ns | missing | missing | missing |
+| `wasm_render_150dpi_fresh_doc` | n/a | n/a | n/a | 2.715 ms | 2.548 ms | n/a |
+| `wasm_render_150dpi_cached_page` | n/a | n/a | n/a | 2.685 ms | 2.491 ms | n/a |
+| `wasm_progressive_150dpi_chunk0` | n/a | n/a | n/a | 2.693 ms | 2.463 ms | n/a |
 
 Notes:
 
@@ -71,9 +74,10 @@ Notes:
   this file.
 - Linux x86_64 baseline and x86_64-v3 values come from the #189 AVX2 validation
   artifact recorded in `PERF_EXPERIMENTS.md`.
-- The wasm32 and Linux aarch64 benchmark cells are explicitly missing. #306 and
-  #308 are expected to fill them using the metadata template above; #305 only
-  records Linux aarch64 build/test support coverage.
+- The wasm32 rows come from the Node.js harness added in #306 and are not
+  directly comparable to native Criterion rows. Linux aarch64 benchmark cells
+  are still missing; #308 is expected to fill them using the metadata template
+  above. #305 only records Linux aarch64 build/test support coverage.
 
 ---
 

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -5,6 +5,64 @@ numbers, decision, reason. Referenced from issue templates ("Record result
 in `PERF_EXPERIMENTS.md` (Kept or Reverted + reason)") and from
 `.github/workflows/bench.yml`.
 
+### #306 — wasm32 scalar vs simd128 benchmark harness — **Kept** (2026-05-17)
+
+**Approach.** Added a reproducible Node.js harness for the existing
+`wasm-bindgen` API. The wrapper builds two `wasm-pack --target nodejs` bundles:
+one scalar wasm32 bundle and one simd128 bundle built with
+`RUSTFLAGS="-C target-feature=+simd128"`. The benchmark then imports both
+bundles in Node.js and times parse, full render, cached render, and first
+progressive render on `tests/fixtures/boy.djvu` at 150 dpi.
+
+**Platform.**
+- OS: macOS 26.3.1 (Darwin 25.3)
+- CPU: Apple M1 Max, 10 cores
+- host arch: `arm64`
+- wasm target_arch: `wasm32`
+- target_feature(s): scalar vs `simd128`
+- Rust: 1.92.0 stable (`aarch64-apple-darwin`)
+- wasm-pack: 0.13.1
+- Node.js: v26.0.0
+- RUSTFLAGS: unset for scalar; `-C target-feature=+simd128` for simd128
+
+**Command(s).**
+
+```sh
+ITERATIONS=30 WARMUP=8 DPI=150 ./scripts/bench_wasm_simd128.sh
+
+node scripts/bench_wasm_simd128.mjs \
+  --scalar target/wasm-bench/scalar \
+  --simd target/wasm-bench/simd128 \
+  --fixture tests/fixtures/boy.djvu \
+  --iterations 30 \
+  --warmup 8 \
+  --dpi 150 \
+  --json
+```
+
+**Numbers.** Median milliseconds, 30 measured iterations after 8 warmups.
+Negative delta means the simd128 bundle is faster.
+
+| Benchmark | scalar median ms | simd128 median ms | delta |
+|-----------|-----------------:|------------------:|------:|
+| `parse_document` | 0.003 | 0.002 | -30.4% |
+| `render_150dpi_fresh_doc` | 2.715 | 2.548 | -6.1% |
+| `render_150dpi_cached_page` | 2.685 | 2.491 | -7.2% |
+| `progressive_150dpi_chunk0` | 2.693 | 2.463 | -8.5% |
+
+Checksums matched between scalar and simd128 for all render benchmarks
+(`-663404102` for full render/cached render; `-663404261` for progressive
+chunk 0), and the harness now fails if per-iteration checksums are unstable or
+if scalar and simd128 checksums differ.
+
+**Decision.** Kept.
+
+**Reason.** The harness gives future wasm SIMD work a reproducible local
+baseline and already confirms a modest render-path win on the existing
+simd128 IW44 code. CI syntax-checks the harness and still build-checks both
+plain wasm32 and `+simd128`; it does not run timing comparisons because hosted
+runner variance would make the numbers unsuitable as a regression gate.
+
 ### #295 — JB2 encoder corpus round-trip and size baseline — **Needs follow-up** (2026-05-17)
 
 **Approach.** Refreshed the existing JB2 quality harnesses without changing

--- a/README.md
+++ b/README.md
@@ -425,6 +425,21 @@ ctx.putImageData(img, 0, 0);
 
 See [`examples/wasm/`](examples/wasm/) for a complete drag-and-drop demo.
 
+### WASM scalar vs simd128 benchmark
+
+The local Node.js harness builds two `wasm-pack --target nodejs` bundles and
+compares scalar wasm32 against `RUSTFLAGS="-C target-feature=+simd128"`:
+
+```sh
+ITERATIONS=50 WARMUP=10 DPI=150 ./scripts/bench_wasm_simd128.sh
+```
+
+The script uses `tests/fixtures/boy.djvu` by default and reports parse,
+full-render, cached-render, and first progressive-render timings. CI
+syntax-checks the harness and build-checks both wasm targets, but does not run
+timing comparisons because hosted runner variance is too high for stable
+regression gates.
+
 ## Feature flags
 
 | Flag | Default | Description |

--- a/scripts/bench_wasm_simd128.mjs
+++ b/scripts/bench_wasm_simd128.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+
+const require = createRequire(import.meta.url);
+
+function usage() {
+  console.error(`Usage:
+  node scripts/bench_wasm_simd128.mjs \\
+    --scalar target/wasm-bench/scalar \\
+    --simd target/wasm-bench/simd128 \\
+    [--fixture tests/fixtures/boy.djvu] \\
+    [--iterations 50] [--warmup 10] [--dpi 150] [--json]
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    fixture: "tests/fixtures/boy.djvu",
+    iterations: 50,
+    warmup: 10,
+    dpi: 150,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      args.json = true;
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next === undefined) {
+      throw new Error(`missing value for ${arg}`);
+    }
+    i += 1;
+    switch (arg) {
+      case "--scalar":
+        args.scalar = next;
+        break;
+      case "--simd":
+        args.simd = next;
+        break;
+      case "--fixture":
+        args.fixture = next;
+        break;
+      case "--iterations":
+        args.iterations = Number.parseInt(next, 10);
+        break;
+      case "--warmup":
+        args.warmup = Number.parseInt(next, 10);
+        break;
+      case "--dpi":
+        args.dpi = Number.parseInt(next, 10);
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!args.scalar || !args.simd) {
+    throw new Error("--scalar and --simd are required");
+  }
+  for (const key of ["iterations", "warmup", "dpi"]) {
+    if (!Number.isInteger(args[key]) || args[key] <= 0) {
+      throw new Error(`--${key} must be a positive integer`);
+    }
+  }
+  return args;
+}
+
+function loadPkg(dir) {
+  return require(resolve(dir, "djvu_rs.js"));
+}
+
+function percentile(sorted, p) {
+  const idx = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p));
+  return sorted[idx];
+}
+
+function summarize(samples) {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const sum = samples.reduce((acc, v) => acc + v, 0);
+  return {
+    min_ms: sorted[0],
+    median_ms: percentile(sorted, 0.5),
+    p90_ms: percentile(sorted, 0.9),
+    mean_ms: sum / samples.length,
+  };
+}
+
+function timeIt(fn) {
+  const t0 = performance.now();
+  const checksum = fn();
+  return { ms: performance.now() - t0, checksum };
+}
+
+function benchPackage(label, pkg, bytes, args) {
+  const { WasmDocument } = pkg;
+
+  const benches = [
+    {
+      name: "parse_document",
+      fn: () => WasmDocument.from_bytes(bytes).page_count(),
+    },
+    {
+      name: `render_${args.dpi}dpi_fresh_doc`,
+      fn: () => {
+        const doc = WasmDocument.from_bytes(bytes);
+        const page = doc.page(0);
+        const pixels = page.render(args.dpi);
+        return pixelChecksum(pixels) ^ page.width_at(args.dpi) ^ page.height_at(args.dpi);
+      },
+    },
+    {
+      name: `render_${args.dpi}dpi_cached_page`,
+      setup: () => {
+        const doc = WasmDocument.from_bytes(bytes);
+        return doc.page(0);
+      },
+      fn: (page) => {
+        const pixels = page.render(args.dpi);
+        return pixelChecksum(pixels) ^ page.width_at(args.dpi) ^ page.height_at(args.dpi);
+      },
+    },
+    {
+      name: `progressive_${args.dpi}dpi_chunk0`,
+      setup: () => {
+        const doc = WasmDocument.from_bytes(bytes);
+        return doc.page(0);
+      },
+      fn: (page) => {
+        const pixels = page.render_progressive(args.dpi, 0);
+        return pixelChecksum(pixels) ^ page.bg44_chunk_count();
+      },
+    },
+  ];
+
+  const results = [];
+  for (const bench of benches) {
+    const state = bench.setup ? bench.setup() : undefined;
+    for (let i = 0; i < args.warmup; i += 1) {
+      bench.fn(state);
+    }
+    const samples = [];
+    let expectedChecksum;
+    for (let i = 0; i < args.iterations; i += 1) {
+      const { ms, checksum } = timeIt(() => bench.fn(state));
+      if (expectedChecksum === undefined) {
+        expectedChecksum = checksum;
+      } else if (checksum !== expectedChecksum) {
+        throw new Error(
+          `${label}/${bench.name} produced unstable checksum: ${checksum} != ${expectedChecksum}`,
+        );
+      }
+      samples.push(ms);
+    }
+    results.push({
+      package: label,
+      benchmark: bench.name,
+      iterations: args.iterations,
+      checksum: expectedChecksum,
+      ...summarize(samples),
+    });
+  }
+  return results;
+}
+
+function pixelChecksum(pixels) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < pixels.length; i += 1) {
+    hash ^= pixels[i];
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  hash ^= pixels.length;
+  return hash >>> 0;
+}
+
+function pctDelta(scalar, simd) {
+  return ((simd - scalar) / scalar) * 100;
+}
+
+function printMarkdown(results) {
+  const byBench = new Map();
+  for (const row of results) {
+    if (!byBench.has(row.benchmark)) {
+      byBench.set(row.benchmark, {});
+    }
+    byBench.get(row.benchmark)[row.package] = row;
+  }
+  console.log("| Benchmark | scalar median ms | simd128 median ms | delta |");
+  console.log("|-----------|-----------------:|------------------:|------:|");
+  for (const [name, rows] of byBench) {
+    const scalar = rows.scalar?.median_ms;
+    const simd = rows.simd128?.median_ms;
+    const delta = scalar === undefined || simd === undefined ? NaN : pctDelta(scalar, simd);
+    console.log(
+      `| \`${name}\` | ${scalar.toFixed(3)} | ${simd.toFixed(3)} | ${delta.toFixed(1)}% |`,
+    );
+  }
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  const bytes = readFileSync(args.fixture);
+  const scalar = loadPkg(args.scalar);
+  const simd = loadPkg(args.simd);
+  const results = [
+    ...benchPackage("scalar", scalar, bytes, args),
+    ...benchPackage("simd128", simd, bytes, args),
+  ];
+  assertMatchingChecksums(results);
+  if (args.json) {
+    console.log(JSON.stringify({ args, node: process.version, results }, null, 2));
+  } else {
+    printMarkdown(results);
+  }
+} catch (err) {
+  usage();
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(2);
+}
+
+function assertMatchingChecksums(results) {
+  const byBench = new Map();
+  for (const row of results) {
+    if (!byBench.has(row.benchmark)) {
+      byBench.set(row.benchmark, {});
+    }
+    byBench.get(row.benchmark)[row.package] = row.checksum;
+  }
+  for (const [name, rows] of byBench) {
+    if (rows.scalar !== rows.simd128) {
+      throw new Error(
+        `${name} checksum mismatch between scalar (${rows.scalar}) and simd128 (${rows.simd128})`,
+      );
+    }
+  }
+}

--- a/scripts/bench_wasm_simd128.sh
+++ b/scripts/bench_wasm_simd128.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${OUT:-$ROOT/target/wasm-bench}"
+FIXTURE="${FIXTURE:-$ROOT/tests/fixtures/boy.djvu}"
+ITERATIONS="${ITERATIONS:-50}"
+WARMUP="${WARMUP:-10}"
+DPI="${DPI:-150}"
+
+mkdir -p "$OUT"
+
+echo "==> Building scalar wasm bundle"
+RUSTFLAGS="" wasm-pack build "$ROOT" \
+  --target nodejs \
+  --out-dir "$OUT/scalar" \
+  --no-opt \
+  -- \
+  --features wasm
+
+echo "==> Building simd128 wasm bundle"
+RUSTFLAGS="-C target-feature=+simd128" wasm-pack build "$ROOT" \
+  --target nodejs \
+  --out-dir "$OUT/simd128" \
+  --no-opt \
+  -- \
+  --features wasm
+
+echo "==> Running scalar vs simd128 benchmark"
+node "$ROOT/scripts/bench_wasm_simd128.mjs" \
+  --scalar "$OUT/scalar" \
+  --simd "$OUT/simd128" \
+  --fixture "$FIXTURE" \
+  --iterations "$ITERATIONS" \
+  --warmup "$WARMUP" \
+  --dpi "$DPI"


### PR DESCRIPTION
## Summary
- add a reproducible Node.js wasm scalar vs simd128 benchmark harness
- build deterministic scalar and simd128 wasm-pack nodejs bundles
- enforce per-iteration and scalar-vs-simd128 output checksums
- syntax-check the harness in CI and document local usage
- record the first scalar vs simd128 numbers in PERF_EXPERIMENTS.md and update the public benchmark matrix

Fixes #306

## Results
Median ms, tests/fixtures/boy.djvu at 150 dpi, 30 iterations after 8 warmups:

| Benchmark | scalar | simd128 | delta |
|---|---:|---:|---:|
| parse_document | 0.003 | 0.002 | -30.4% |
| render_150dpi_fresh_doc | 2.715 | 2.548 | -6.1% |
| render_150dpi_cached_page | 2.685 | 2.491 | -7.2% |
| progressive_150dpi_chunk0 | 2.693 | 2.463 | -8.5% |

## Validation
- ITERATIONS=30 WARMUP=8 DPI=150 ./scripts/bench_wasm_simd128.sh
- node scripts/bench_wasm_simd128.mjs --scalar target/wasm-bench/scalar --simd target/wasm-bench/simd128 --fixture tests/fixtures/boy.djvu --iterations 30 --warmup 8 --dpi 150 --json
- bash -n scripts/bench_wasm_simd128.sh
- node --check scripts/bench_wasm_simd128.mjs
- cargo check --target wasm32-unknown-unknown --features wasm
- RUSTFLAGS='-C target-feature=+simd128' cargo check --target wasm32-unknown-unknown --features wasm
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo build --no-default-features
- git diff --check

## Review
- independent reviewer found two reproducibility issues; both fixed
- re-review: no findings

## Experiments
- recorded in PERF_EXPERIMENTS.md (#306)
- BENCHMARKS_RESULTS.md updated for wasm scalar/simd128 rows