### PR TITLE
docs: reconcile stale roadmap notes

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,5 +1,10 @@
 # djvu-rs Benchmark Results
 
+> Historical benchmark log. Current benchmark claims and the cross-architecture
+> matrix live in [`BENCHMARKS_RESULTS.md`](BENCHMARKS_RESULTS.md). Compare the
+> older sections below only within their dated context; benchmark definitions,
+> corpus coverage, and output sizes have changed across the roadmap work.
+
 ## How to reproduce
 
 ```sh

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -441,16 +441,14 @@ compression to update text/annotations/metadata. With this PR the
 `librarian` consumer (#158) can finally drop its `djvused` shell-out for
 single-page DjVu files.
 
-**Open follow-ups (PR3-4 of #222 sequence).**
-1. **PR3**: bundled DJVM mutation (DIRM offset recomputation) plus
-   `DjVuDocumentMut::set_bookmarks(&[DjVuBookmark])` for NAVM at the
-   bundle root.
-2. **PR4**: byte-range patching for true byte-identical round-trip even
-   *with* edits (only changed chunks are rewritten; unchanged regions are
-   memcpy'd). Currently any mutation triggers a full `iff::emit` which
-   may differ from the original byte layout in incidental ways.
-3. **PR5**: indirect DJVM support — the issue's "per-file rewrite vs
-   re-bundle" decision still needs a concrete answer.
+**Follow-up status.**
+1. Bundled DJVM mutation and `DjVuDocumentMut::set_bookmarks(&[DjVuBookmark])`
+   have landed.
+2. Single-page byte-range patching was implemented in #302; bundled-DJVM and
+   indirect-DJVM byte-range work remain tracked separately.
+3. Indirect DJVM support is intentionally deferred after #303; the decision
+   record is `docs/indirect-djvm-mutation.md`, with implementation follow-ups
+   in #325 and #326.
 
 ### #222 PR1 — `DjVuDocumentMut::from_bytes` + chunk-replacement primitive — **Kept** (2026-04-30)
 
@@ -508,19 +506,15 @@ the high-level setter design (`set_metadata`, `set_bookmarks`,
 (`encode_navm`, `encode_annotations*`, `encode_metadata`,
 `encode_text_layer`).
 
-**Open follow-ups (PR2-4 of #222 sequence).**
-1. **PR2**: high-level setters (`set_metadata`, `set_bookmarks`,
-   `page_mut(i).set_text_layer`, `…set_annotations`) on top of
-   `replace_leaf`.
-2. **PR3**: byte-range patching for true byte-identical round-trip even
-   *with* edits (only changed chunks are rewritten; unchanged regions are
-   memcpy'd). Currently any mutation triggers a full `iff::emit` which
-   may differ from the original byte layout in incidental ways (FORM
-   length recomputation, padding).
-3. **PR4**: indirect DJVM support — the issue's "per-file rewrite vs
-   re-bundle" decision still needs a concrete answer.
-4. `librarian` consumer migration off `djvused` shell-out (#158
-   follow-up) — depends on PR2 setters.
+**Follow-up status.**
+1. High-level setters (`set_metadata`, `set_bookmarks`,
+   `page_mut(i).set_text_layer`, `…set_annotations`) have landed.
+2. Single-page byte-range patching landed in #302; bundled-DJVM byte-range
+   patching remains a separate follow-up.
+3. Indirect DJVM support was scoped by #303 and remains intentionally
+   unsupported until the external-file rewrite/re-bundle work in #325/#326.
+4. `librarian` consumer migration off `djvused` shell-out (#158 follow-up)
+   can use the setter surface, but is outside this repository.
 
 ### #229 PR1 — extract `djvu-zp` into a standalone workspace crate — **Kept** (2026-04-30)
 
@@ -645,8 +639,8 @@ Both pass on the local x86_64 host. All 405 lib tests pass; clippy
 speedup over scalar at this hot path (called once per (block × band) =
 ~1024 blocks/page × 10 bands = ~10K calls/page) is on the order of
 4–8× from replacing the scalar 16-iteration loop with three AVX2 ops + a
-narrow + horizontal OR. End-to-end `iw44_decode_*` benches will pick up
-the change at the next `bench.yml` AVX2 runner pass.
+narrow + horizontal OR. End-to-end `iw44_decode_*` benches were later sampled
+by the #189 validation run and the #307 AVX2 spike.
 
 **Reason kept.** Two more AVX2 kernels close the parity gap with NEON
 that issue #189 calls out (lines 11–14 of the issue body listed
@@ -658,12 +652,10 @@ established for the remaining kernels (`row_pass_neon_s1_row`,
 `lifting_even`, `predict_inner`, `predict_avg`).
 
 **Open follow-ups.**
-1. `row_pass_neon_s1_row` AVX2 port — significantly larger because AVX2
-   has no native `vld2q_s16` deinterleave; `### #184` below is the
-   cautionary tale of attempting strided loads in AVX2 without gather.
+1. `row_pass_neon_s1_row` AVX2 port was measured in #307 and rejected: full
+   decode improved, but the sensitive sub2/sub4 partial-decode paths regressed.
 2. Encoder-side ports (`forward_row_neon_s1_row`, `forward_col_predict_neon`).
-3. Bench numbers from the next `bench.yml` AVX2 runner pass should be
-   recorded here once available.
+3. ARM64 NEON validation was refreshed in #308.
 
 ### #225 Phase 2 — public `render_streaming` API — **Kept** (2026-04-30)
 
@@ -743,13 +735,15 @@ primitive without changing the public API. Three new module-private functions:
   `render_into`, `render_region`, `render_coarse`, and `render_progressive`.
 
 - `pub(crate) render_rows<F>` — decode/setup entry point (mirrors
-  `render_pixmap`'s decode logic) that calls `composite_rows`. This is the
-  Phase 2 hook: future `render_streaming` will delegate here instead of
+  `render_pixmap`'s decode logic) that calls `composite_rows`. This became the
+  shared row source for the public `render_streaming` API instead of
   allocating a full Pixmap.
 
-`render_pixmap` is now a thin adapter: it pre-allocates `Pixmap::white(w, h)`,
-calls `render_rows` with a sink that copies each row into `pm.data`, then
-applies the existing aa/Lanczos/rotation post-processing steps.
+At the time, `render_pixmap` was a thin adapter: it pre-allocated
+`Pixmap::white(w, h)`, called `render_rows` with a sink that copied each row
+into `pm.data`, then applied the existing aa/Lanczos/rotation post-processing
+steps. Current strict renders use the direct full-pixmap path, while permissive
+renders still share row-based recovery with `render_streaming`.
 
 Two new unit tests — `render_rows_byte_identical_to_render_into_color` and
 `render_rows_byte_identical_to_render_into_bilevel` — verify that
@@ -778,8 +772,7 @@ with zero public API change, bit-exact output verified by tests, all 550 tests
 pass, clippy and fmt clean. The `render_rows` hook is in place for Phase 2.
 
 **Open follow-ups.**
-1. Phase 2 (future PR): expose `pub fn render_streaming` with a user-visible
-   row callback, enabling true zero-full-pixmap rendering for WASM / embedded.
+1. Phase 2 shipped `pub fn render_streaming` with a user-visible row callback.
 2. `render_region`, `render_coarse`, `render_progressive` could similarly be
    refactored to use `composite_rows` for API symmetry, but are not hot paths.
 

--- a/src/djvu_mut.rs
+++ b/src/djvu_mut.rs
@@ -1,15 +1,16 @@
 //! In-place DjVu document mutation — byte-preserving rewrite of the IFF tree.
 //!
-//! PR1 of [#222](https://github.com/matyushkin/djvu-rs/issues/222). This is the
-//! foundation layer: parse a document into an editable tree, walk to a leaf
+//! Originated in [#222](https://github.com/matyushkin/djvu-rs/issues/222).
+//! This module parses a document into an editable tree, can walk to a leaf
 //! chunk by path, replace its data, and serialise back. When no mutations have
-//! happened, [`DjVuDocumentMut::into_bytes`] returns the original bytes
-//! verbatim (byte-identical round-trip).
+//! happened, [`into_bytes`](crate::djvu_mut::DjVuDocumentMut::into_bytes)
+//! returns the original bytes verbatim (byte-identical round-trip). High-level
+//! setters are available for page text, annotations, metadata, and bundled-DJVM
+//! bookmarks.
 //!
-//! Future PRs in the [#222](https://github.com/matyushkin/djvu-rs/issues/222)
-//! sequence add high-level setters (`set_metadata`, `set_bookmarks`,
-//! `page_mut(i).set_text_layer`, `…set_annotations`) plus indirect-DJVM
-//! support, which all build on the chunk-replacement primitive defined here.
+//! Indirect `FORM:DJVM` mutation remains unsupported because it requires a
+//! concrete external-file rewrite or re-bundle policy; see
+//! [`docs/indirect-djvm-mutation.md`](../docs/indirect-djvm-mutation.md).
 //!
 //! ## Example
 //!
@@ -102,9 +103,9 @@ pub enum MutError {
     /// The operation requires DIRM offset recomputation, which is not
     /// implemented for indirect (non-bundled) `FORM:DJVM` documents — those
     /// reference page bytes in external files via a resolver, so editing them
-    /// in place would also need the external files rewritten. Tracked as a
-    /// follow-up PR (PR5) in the
-    /// [#222](https://github.com/matyushkin/djvu-rs/issues/222) sequence.
+    /// in place would also need the external files rewritten. The current
+    /// decision record is
+    /// [`docs/indirect-djvm-mutation.md`](../docs/indirect-djvm-mutation.md).
     #[error("mutation of indirect DJVM documents is not supported")]
     IndirectDjvmUnsupported,
 

--- a/src/djvu_render.rs
+++ b/src/djvu_render.rs
@@ -1259,7 +1259,7 @@ struct CompositeContext<'a> {
 /// Look up the palette color for a foreground pixel at (px, py).
 ///
 /// Uses the blit map to find the per-glyph blit index, then maps it through
-/// the FGbz index table to get the final color. Falls back to palette[0] when
+/// the FGbz index table to get the final color. Falls back to `palette[0]` when
 /// no index table is present, and to black when lookup fails.
 #[inline]
 fn lookup_palette_color(
@@ -1794,9 +1794,9 @@ fn composite_rows_area_avg_one(
 ///
 /// `rgba_row` contains `opts.width * 4` bytes (RGBA, alpha = 255).
 ///
-/// This is the internal streaming primitive for Phase 1.  Public callers should
-/// use [`render_pixmap`] (allocates a complete `Pixmap`) or, in a future Phase
-/// 2 PR, a public `render_streaming` API.
+/// This is the internal streaming primitive used by [`render_streaming`] and by
+/// permissive [`render_pixmap`] fallback. Public callers that need full-pixmap
+/// post-processing should use [`render_pixmap`].
 ///
 /// # Errors
 ///
@@ -2012,10 +2012,9 @@ pub fn render_into(
 
 /// Render a `DjVuPage` to a new [`Pixmap`] using the given options.
 ///
-/// Internally delegates to [`render_rows`], which composites each output row
-/// into a per-row scratch buffer and copies it into the pre-allocated `Pixmap`.
-/// This thin adapter keeps the public API unchanged while the per-row path
-/// prepares Phase 2 streaming support (issue #225).
+/// Strict renders composite directly into the full pixmap. Permissive renders
+/// reuse the row path so decode-error recovery remains shared with
+/// [`render_streaming`].
 pub fn render_pixmap(page: &DjVuPage, opts: &RenderOptions) -> Result<Pixmap, RenderError> {
     let w = opts.width;
     let h = opts.height;

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -741,7 +741,7 @@ pub fn analyze_jb2_cross_size_refinement(
 /// instead of the original CC. Visual loss is bounded by the threshold.
 ///
 /// Used by [`Jb2EncodeOptions::lossy_threshold`] (#224 Phase 4); independent
-/// of [`find_refinement_ref`] which gates record-6 (lossless refinement).
+/// of `find_refinement_ref`, which gated record-6 (lossless refinement).
 fn find_lossy_copy_ref(
     cand: &Bitmap,
     dict_entries: &[Bitmap],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,8 +275,8 @@ pub mod navm_encode;
 
 /// Smmr chunk codec — ITU-T G4 (MMR) bilevel image compression.
 ///
-/// Provides [`smmr::decode_smmr`] (chunk → [`Bitmap`]) and
-/// [`smmr::encode_smmr`] ([`Bitmap`] → chunk). Useful as an alternative
+/// Provides [`decode_smmr`](crate::smmr::decode_smmr) (chunk → [`Bitmap`]) and
+/// [`encode_smmr`](crate::smmr::encode_smmr) ([`Bitmap`] → chunk). Useful as an alternative
 /// to JB2 for fax-style scans without recurring glyph structure.
 pub mod smmr;
 

--- a/src/smmr.rs
+++ b/src/smmr.rs
@@ -10,8 +10,8 @@
 //!
 //! ## API
 //!
-//! * [`decode_smmr`] — chunk payload → [`Bitmap`]
-//! * [`encode_smmr`] — [`Bitmap`] → chunk payload (horizontal-mode only;
+//! * [`decode_smmr`](crate::smmr::decode_smmr) — chunk payload → [`Bitmap`]
+//! * [`encode_smmr`](crate::smmr::encode_smmr) — [`Bitmap`] → chunk payload (horizontal-mode only;
 //!   correct but not size-optimal — see fn docs for trade-offs vs JB2)
 
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
## Summary
- mark BENCHMARKS.md as historical and point current benchmark claims to BENCHMARKS_RESULTS.md
- update mutation/render docs that still described shipped work as future
- refresh stale PERF_EXPERIMENTS.md follow-up notes and repair broken rustdoc links

Closes #309.

## Validation
- cargo fmt --check
- git diff --check
- cargo build --no-default-features
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --profile ci --workspace --exclude djvu-py --features cli
- RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --document-private-items -p djvu-rs --features cli