### PR TITLE
chore: align binding package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,11 @@ ctx.putImageData(img, 0, 0);
 
 See [`examples/wasm/`](examples/wasm/) for a complete drag-and-drop demo.
 
+The generated npm package follows the Rust crate version; there is no separate
+WASM release train. The local `pkg/` directory is ignored wasm-pack output, so
+regenerate it from the checked-in `Cargo.toml` before publishing instead of
+editing generated `pkg/package.json` by hand.
+
 ### WASM scalar vs simd128 benchmark
 
 The local Node.js harness builds two `wasm-pack --target nodejs` bundles and

--- a/djvu-py/README.md
+++ b/djvu-py/README.md
@@ -8,10 +8,16 @@ Python bindings for [djvu-rs](https://github.com/matyushkin/djvu-rs), a pure-Rus
 pip install djvu-rs
 ```
 
+## Version policy
+
+The Python package follows the Rust crate version. For example, Python package
+`djvu-rs==0.18.0` is built from the `djvu-rs` Rust workspace at version
+`0.18.0`. There is no separate Python release train.
+
 ## Usage
 
 ```python
-import djvu_rs_python as djvu
+import djvu_rs as djvu
 
 doc = djvu.Document.open('scan.djvu')
 print(f'{doc.page_count()} pages')

--- a/djvu-py/pyproject.toml
+++ b/djvu-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "djvu-rs"
-version = "0.1.0"
+version = "0.18.0"
 description = "Python bindings for djvu-rs — pure-Rust DjVu decoder"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- align djvu-py pyproject version with the Rust crate version
- fix the Python README import example to use the actual PyO3 module name
- document that Python and generated WASM/npm bindings follow the Rust crate version, with pkg/ treated as generated wasm-pack output

Closes #310.

## Validation
- python3 metadata consistency check for Cargo.toml, djvu-py/pyproject.toml, PyO3 module name, and docs
- cargo fmt --check
- git diff --check
- cargo build --no-default-features
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --profile ci --workspace --exclude djvu-py --features cli