### PR TITLE
docs: refresh post-roadmap benchmark results

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -24,22 +24,22 @@ kept/reverted decisions are recorded in [`PERF_EXPERIMENTS.md`](PERF_EXPERIMENTS
 including recent async lazy loading and x86-64-v3 AVX2 validation results.
 
 The latest full local Criterion run is summarized in
-[`BENCHMARKS_RESULTS.md`](BENCHMARKS_RESULTS.md) (2026-05-16, macOS arm64,
+[`BENCHMARKS_RESULTS.md`](BENCHMARKS_RESULTS.md) (2026-05-17, macOS arm64,
 Rust 1.92.0). Selected results from that run:
 
 | Benchmark | Time |
 |-----------|-----:|
-| `render_page/dpi/72` | 238 µs |
-| `render_page/dpi/144` | 904 µs |
-| `render_page/dpi/300` | 3.44 ms |
-| `render_colorbook` | 6.90 ms |
-| `render_colorbook_cold` | 17.3 ms |
-| `render_corpus_color` | 68.7 ms |
-| `render_corpus_bilevel` | 69.7 ms |
-| `jb2_decode` | 128 µs |
-| `iw44_decode_first_chunk` | 571 µs |
-| `iw44_decode_corpus_color` | 637 µs |
-| `parse_multipage_520p` | 2.19 ms |
+| `render_page/dpi/72` | 246 µs |
+| `render_page/dpi/144` | 934 µs |
+| `render_page/dpi/300` | 6.96 ms |
+| `render_colorbook` | 8.78 ms |
+| `render_colorbook_cold` | 48.9 ms |
+| `render_corpus_color` | 151 ms |
+| `render_corpus_bilevel` | 75.4 ms |
+| `jb2_decode` | 132 µs |
+| `iw44_decode_first_chunk` | 592 µs |
+| `iw44_decode_corpus_color` | 655 µs |
+| `parse_multipage_520p` | 2.29 ms |
 | `render_large_doc_first_page` | 10.6 ms |
 
 ## Contributing results

--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -4,15 +4,27 @@ Platform: Apple Silicon (`arm64`)
 OS: macOS 26.3.1 (Darwin 25.3)
 Rust: 1.92.0 stable (edition 2024)
 Profile: release (opt-level 3, lto = thin)
-Date: 2026-05-16
+Date: 2026-05-17
 
 Command: `cargo bench --workspace --features cli,tiff`
 
-All Criterion benchmarks use 100 samples, 3 s warm-up, 5 s measurement.
-Criterion's local baseline comparison reported improvements for most codec,
-document, and native-render benches; `pdf_export_sequential` was unchanged;
-small thumbnail paths (`render_page/dpi/72` and `render_scaled_0.5x/bilinear`)
-were ~10–12% slower.
+Most Criterion benchmarks use 100 samples, 3 s warm-up, and 5 s measurement;
+the bounded `render_row_scratch_ab/*` A/B group uses 10 samples and 1 s warm-up
+to keep full-run time practical. Rows below report Criterion mean point
+estimates from the post-roadmap full workspace run. Some native and cold render
+groups had wide confidence intervals in this run, so treat those rows as a
+fresh public snapshot rather than a narrow regression claim.
+
+Notable wide Criterion intervals from this run:
+
+| Benchmark | Mean | 95% confidence interval |
+|-----------|-----:|------------------------:|
+| `render_page/dpi/300` | 6.96 ms | 6.01-8.00 ms |
+| `render_page/dpi/600` | 42.1 ms | 36.2-48.4 ms |
+| `render_colorbook` | 8.78 ms | 7.99-9.73 ms |
+| `render_colorbook_cold` | 48.9 ms | 41.1-57.3 ms |
+| `render_corpus_color` | 151 ms | 129-175 ms |
+| `render_native_stages/render_streaming_discard/watchmaker_color` | 195 ms | 174-218 ms |
 
 ---
 
@@ -40,7 +52,7 @@ so follow-up SIMD work can fill them without changing the schema.
 
 | Target family | OS | CPU / runner | target_arch | target_feature(s) | Rust | RUSTFLAGS | Source artifact | Status |
 |---------------|----|--------------|-------------|-------------------|------|-----------|-----------------|--------|
-| Apple ARM64 | macOS 26.3.1 (Darwin 25.3) | Apple M1 Max, 10 cores | `aarch64` | ARM64 baseline; NEON available on Apple Silicon | 1.92.0 stable | unset | #308 local filtered IW44/render run | Current IW44/NEON validation baseline |
+| Apple ARM64 | macOS 26.3.1 (Darwin 25.3) | Apple M1 Max, 10 cores | `aarch64` | ARM64 baseline; NEON available on Apple Silicon | 1.92.0 stable | unset | Post-roadmap local full run, `cargo bench --workspace --features cli,tiff` (2026-05-17) | Current broad Apple ARM64 baseline |
 | Linux x86_64 baseline | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | baseline x86-64 codegen | stable from workflow | unset | #189 artifact run `25299920836` from `.github/workflows/bench.yml` `bench-x86-64-v3` validation | Current selected IW44/render baseline |
 | Linux x86_64-v3 / AVX2 | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | `avx2` via x86-64-v3 codegen | stable from workflow | `-C target-cpu=x86-64-v3` | `.github/workflows/bench.yml` `bench-x86-64-v3` job; #189 artifact run `25299920836` | Current AVX2 validation exists for selected IW44/render benches |
 | wasm32 scalar | macOS 26.3.1 host / Node.js v26.0.0 | Apple M1 Max host running Node.js wasm | `wasm32` | scalar | 1.92.0 stable | unset | `scripts/bench_wasm_simd128.sh` local run (#306) | Current small-fixture wasm baseline |
@@ -55,24 +67,25 @@ metadata format.
 
 | Benchmark | Apple ARM64 local | Linux x86_64 baseline | Linux x86_64-v3 / AVX2 | wasm32 scalar | wasm32 simd128 | Linux aarch64 |
 |-----------|------------------:|----------------------:|-----------------------:|--------------:|----------------:|--------------:|
-| `iw44_decode_corpus_color` | **637 µs** | 1,385,461 ns | 1,123,865 ns | missing | missing | missing |
-| `iw44_decode_first_chunk` | **557 µs** | 765,703 ns | 728,565 ns | missing | missing | missing |
-| `iw44_to_rgb_colorbook/sub1_full_decode` | **5.47 ms** | 9,231,033 ns | 9,129,333 ns | missing | missing | missing |
-| `iw44_to_rgb_colorbook/sub2_partial_decode` | **1.30 ms** | 2,164,523 ns | 2,199,280 ns | missing | missing | missing |
-| `iw44_to_rgb_colorbook/sub4_partial_decode` | **337 µs** | 565,640 ns | 583,519 ns | missing | missing | missing |
-| `render_colorbook` | **6.92 ms** | 13,072,440 ns | 12,826,562 ns | missing | missing | missing |
-| `render_colorbook_cold` | **17.4 ms** | 28,127,606 ns | 27,105,326 ns | missing | missing | missing |
-| `render_colorbook_stages/mask_decode` | **4.17 ms** | 5,325,125 ns | 5,107,550 ns | missing | missing | missing |
-| `render_corpus_color` | **68.7 ms** | 133,813,976 ns | 133,185,634 ns | missing | missing | missing |
+| `iw44_decode_corpus_color` | **655 µs** | 1,385,461 ns | 1,123,865 ns | missing | missing | missing |
+| `iw44_decode_first_chunk` | **592 µs** | 765,703 ns | 728,565 ns | missing | missing | missing |
+| `iw44_to_rgb_colorbook/sub1_full_decode` | **5.73 ms** | 9,231,033 ns | 9,129,333 ns | missing | missing | missing |
+| `iw44_to_rgb_colorbook/sub2_partial_decode` | **1.34 ms** | 2,164,523 ns | 2,199,280 ns | missing | missing | missing |
+| `iw44_to_rgb_colorbook/sub4_partial_decode` | **347 µs** | 565,640 ns | 583,519 ns | missing | missing | missing |
+| `render_colorbook` | **8.78 ms** | 13,072,440 ns | 12,826,562 ns | missing | missing | missing |
+| `render_colorbook_cold` | **48.9 ms** | 28,127,606 ns | 27,105,326 ns | missing | missing | missing |
+| `render_colorbook_stages/mask_decode` | **12.7 ms** | 5,325,125 ns | 5,107,550 ns | missing | missing | missing |
+| `render_corpus_color` | **151 ms** | 133,813,976 ns | 133,185,634 ns | missing | missing | missing |
 | `wasm_render_150dpi_fresh_doc` | n/a | n/a | n/a | 2.715 ms | 2.548 ms | n/a |
 | `wasm_render_150dpi_cached_page` | n/a | n/a | n/a | 2.685 ms | 2.491 ms | n/a |
 | `wasm_progressive_150dpi_chunk0` | n/a | n/a | n/a | 2.693 ms | 2.463 ms | n/a |
 
 Notes:
 
-- Apple ARM64 IW44/render values come from the #308 local filtered Criterion
-  run on Apple M1 Max. Older broad local benchmark rows below remain useful for
-  non-IW44 context, but the architecture matrix uses the fresher #308 filters.
+- Apple ARM64 IW44/render values come from the 2026-05-17 post-roadmap full
+  local run on Apple M1 Max. The earlier #308 filtered run remains recorded in
+  `PERF_EXPERIMENTS.md` as targeted NEON validation, but this table now tracks
+  the broad public baseline.
 - Linux x86_64 baseline and x86_64-v3 values come from the #189 AVX2 validation
   artifact recorded in `PERF_EXPERIMENTS.md`.
 - The wasm32 rows come from the Node.js harness added in #306 and are not
@@ -87,20 +100,20 @@ Notes:
 
 Test files: `references/djvujs/library/assets/` and `tests/corpus/`
 
-| Benchmark | File | Payload | Time (median) | Notes |
+| Benchmark | File | Payload | Time (Criterion mean) | Notes |
 |-----------|------|---------|--------------|-------|
-| `bzz_decode` | navm_fgbz.djvu NAVM | 89 bytes | **68.6 ns** | ZP + MTF + BWT; tiny NAVM chunk |
-| `jb2_decode` | boy_jb2.djvu Sjbz | — | **128 µs** | Bilevel JB2 decode, small page |
-| `iw44_decode_first_chunk` | boy.djvu BG44 | — | **571 µs** | Single IW44 wavelet chunk |
-| `jb2_decode_corpus_bilevel` | cable_1973_100133.djvu Sjbz | — | **417 µs** | Larger bilevel scan |
-| `iw44_decode_corpus_color` | watchmaker.djvu first BG44 | — | **637 µs** | Color IW44 chunk |
-| `jb2_decode_large_600dpi` | pathogenic_bacteria_1896.djvu page mask | 11,438 bytes | **2.13 µs** | Large-page JB2 mask fast path |
-| `iw44_to_rgb_colorbook/sub1_full_decode` | colorbook.djvu | — | **5.39 ms** | Full decode + RGB |
-| `iw44_to_rgb_colorbook/sub2_partial_decode` | colorbook.djvu | — | **1.29 ms** | Partial decode at sub=2 |
-| `iw44_to_rgb_colorbook/sub4_partial_decode` | colorbook.djvu | — | **337 µs** | Partial decode at sub=4 |
-| `iw44_encode_color` | synthetic color page | — | **1.75 ms** | IW44 color encode |
-| `iw44_encode_large_1024x1024` | synthetic 1024×1024 page | — | **16.2 ms** | IW44 large encode |
-| `jb2_encode` | synthetic bilevel page | — | **168 µs** | JB2 encode |
+| `bzz_decode` | navm_fgbz.djvu NAVM | 89 bytes | **70.4 ns** | ZP + MTF + BWT; tiny NAVM chunk |
+| `jb2_decode` | boy_jb2.djvu Sjbz | — | **132 µs** | Bilevel JB2 decode, small page |
+| `iw44_decode_first_chunk` | boy.djvu BG44 | — | **592 µs** | Single IW44 wavelet chunk |
+| `jb2_decode_corpus_bilevel` | cable_1973_100133.djvu Sjbz | — | **427 µs** | Larger bilevel scan |
+| `iw44_decode_corpus_color` | watchmaker.djvu first BG44 | — | **655 µs** | Color IW44 chunk |
+| `jb2_decode_large_600dpi` | pathogenic_bacteria_1896.djvu page mask | 11,438 bytes | **2.18 µs** | Large-page JB2 mask fast path |
+| `iw44_to_rgb_colorbook/sub1_full_decode` | colorbook.djvu | — | **5.73 ms** | Full decode + RGB |
+| `iw44_to_rgb_colorbook/sub2_partial_decode` | colorbook.djvu | — | **1.34 ms** | Partial decode at sub=2 |
+| `iw44_to_rgb_colorbook/sub4_partial_decode` | colorbook.djvu | — | **347 µs** | Partial decode at sub=4 |
+| `iw44_encode_color` | synthetic color page | — | **1.83 ms** | IW44 color encode |
+| `iw44_encode_large_1024x1024` | synthetic 1024×1024 page | — | **17.4 ms** | IW44 large encode |
+| `jb2_encode` | synthetic bilevel page | — | **174 µs** | JB2 encode |
 
 Note: `bzz_decode` measures the 89-byte NAVM payload in navm_fgbz.djvu. BZZ performance
 scales with payload size (BWT requires a full-block sort); large payloads (e.g. 6 KB DIRM
@@ -142,34 +155,34 @@ Corpus files: `tests/corpus/`, colorbook: `references/djvujs/library/assets/colo
 
 ### DPI scaling — boy.djvu (IW44 color page, 192×256 native)
 
-| DPI | Approx output size | Time (median) |
+| DPI | Approx output size | Time (Criterion mean) |
 |-----|--------------------|--------------|
-| 72 dpi | ~138×184 px | **238 µs** |
-| 144 dpi | ~276×368 px | **904 µs** |
-| 300 dpi | ~576×768 px | **3.44 ms** |
-| 600 dpi | ~1152×1536 px | **13.4 ms** |
+| 72 dpi | ~138×184 px | **246 µs** |
+| 144 dpi | ~276×368 px | **934 µs** |
+| 300 dpi | ~576×768 px | **6.96 ms** |
+| 600 dpi | ~1152×1536 px | **42.1 ms** |
 
 ### Full-resolution corpus render
 
-| Benchmark | File | Native size | Time (median) | Notes |
+| Benchmark | File | Native size | Time (Criterion mean) | Notes |
 |-----------|------|-------------|--------------|-------|
-| `render_coarse` | boy.djvu | 192×256 | **1.09 ms** | |
-| `render_colorbook` | colorbook.djvu | 2260×3669 (400 dpi) | **6.90 ms** | 150 dpi, warm (sub=4 mask + partial BG44) |
-| `render_colorbook_stages/full_render` | colorbook.djvu | 2260×3669 (400 dpi) | **6.90 ms** | Warm full render stage |
-| `render_colorbook_stages/mask_decode` | colorbook.djvu | 2260×3669 (400 dpi) | **4.13 ms** | JB2 mask decode stage |
-| `render_colorbook_cold` | colorbook.djvu | 2260×3669 (400 dpi) | **17.3 ms** | cold (ZP + wavelet + RGB, first render) |
-| `render_corpus_color` | watchmaker.djvu | 2550×3301 | **68.7 ms** | native 600 dpi, full IW44 |
-| `render_corpus_bilevel` | cable_1973_100133.djvu | 2550×3301 | **69.7 ms** | native 600 dpi, bilevel JB2 |
-| `render_scaled_0.5x/bilinear` | boy.djvu | 0.5× output | **144 µs** | Built-in bilinear downscale |
-| `render_scaled_0.5x/lanczos3` | boy.djvu | 0.5× output | **3.75 ms** | Higher quality separable Lanczos3 |
-| `pdf_export_sequential` | watchmaker.djvu | — | **848 ms** | 12 pages, `output_dpi=150`, DCTDecode JPEG-80 |
+| `render_coarse` | boy.djvu | 192×256 | **3.41 ms** | |
+| `render_colorbook` | colorbook.djvu | 2260×3669 (400 dpi) | **8.78 ms** | 150 dpi, warm (sub=4 mask + partial BG44) |
+| `render_colorbook_stages/full_render` | colorbook.djvu | 2260×3669 (400 dpi) | **7.16 ms** | Warm full render stage |
+| `render_colorbook_stages/mask_decode` | colorbook.djvu | 2260×3669 (400 dpi) | **12.7 ms** | JB2 mask decode stage |
+| `render_colorbook_cold` | colorbook.djvu | 2260×3669 (400 dpi) | **48.9 ms** | cold (ZP + wavelet + RGB, first render) |
+| `render_corpus_color` | watchmaker.djvu | 2550×3301 | **151 ms** | native 600 dpi, full IW44 |
+| `render_corpus_bilevel` | cable_1973_100133.djvu | 2550×3301 | **75.4 ms** | native 600 dpi, bilevel JB2 |
+| `render_scaled_0.5x/bilinear` | boy.djvu | 0.5× output | **149 µs** | Built-in bilinear downscale |
+| `render_scaled_0.5x/lanczos3` | boy.djvu | 0.5× output | **3.85 ms** | Higher quality separable Lanczos3 |
+| `pdf_export_sequential` | watchmaker.djvu | — | **821 ms** | 12 pages, `output_dpi=150`, DCTDecode JPEG-80 |
 | `pdf_export_parallel` | watchmaker.djvu | — | — | Not measured in this run |
 
 Note: The `render_colorbook` benchmark renders at 150 dpi (848×1376 output). For sub=4
 renders djvu-rs applies a cascade of optimizations: (1) partial BG44 decode (first chunk
 only), (2) cached 1/4-res max-pool mask pyramid (single bit lookup per pixel), (3)
-bit-shift instead of UDIV for bg/mask coordinate transforms.  Cold render includes full
-ZP arithmetic decode for the first BG44 chunk (~20 ms) + wavelet + composite.
+bit-shift instead of UDIV for bg/mask coordinate transforms.  Cold render includes
+document setup, ZP arithmetic decode for the first BG44 chunk, wavelet, and composite.
 
 ### Native render stage breakdown (#281)
 
@@ -178,18 +191,18 @@ These benches are diagnostic: `render_pixmap` is the public allocation-returning
 API, `render_into_reuse_buffer` composites into a caller-owned buffer, and
 `render_streaming_discard` measures row generation without retaining output.
 
-| Benchmark | Page | Time (median) | Notes |
+| Benchmark | Page | Time (Criterion mean) | Notes |
 |-----------|------|--------------:|-------|
-| `render_native_stages/render_pixmap` | watchmaker color | **68.7 ms** | public `Pixmap` path, warm decode caches |
-| `render_native_stages/render_into_reuse_buffer` | watchmaker color | **68.3 ms** | caller-owned RGBA buffer |
-| `render_native_stages/render_streaming_discard` | watchmaker color | **65.1 ms** | row streaming, no retained output |
-| `render_native_stages/mask_decode` | watchmaker color | **2.61 ms** | JB2 mask decode only |
-| `render_native_stages/bg_to_rgb_warm` | watchmaker color | **2.77 ms** | cached IW44 inverse + RGB |
-| `render_native_stages/render_pixmap` | cable mixed bilevel | **69.8 ms** | public `Pixmap` path, warm decode caches |
-| `render_native_stages/render_into_reuse_buffer` | cable mixed bilevel | **69.4 ms** | caller-owned RGBA buffer |
-| `render_native_stages/render_streaming_discard` | cable mixed bilevel | **66.0 ms** | row streaming, no retained output |
-| `render_native_stages/mask_decode` | cable mixed bilevel | **408 µs** | JB2 mask decode only |
-| `render_native_stages/bg_to_rgb_warm` | cable mixed bilevel | **2.81 ms** | cached IW44 inverse + RGB |
+| `render_native_stages/render_pixmap` | watchmaker color | **70.8 ms** | public `Pixmap` path, warm decode caches |
+| `render_native_stages/render_into_reuse_buffer` | watchmaker color | **70.4 ms** | caller-owned RGBA buffer |
+| `render_native_stages/render_streaming_discard` | watchmaker color | **195 ms** | row streaming, no retained output; noisy in this run |
+| `render_native_stages/mask_decode` | watchmaker color | **7.26 ms** | JB2 mask decode only |
+| `render_native_stages/bg_to_rgb_warm` | watchmaker color | **7.48 ms** | cached IW44 inverse + RGB |
+| `render_native_stages/render_pixmap` | cable mixed bilevel | **85.1 ms** | public `Pixmap` path, warm decode caches |
+| `render_native_stages/render_into_reuse_buffer` | cable mixed bilevel | **71.6 ms** | caller-owned RGBA buffer |
+| `render_native_stages/render_streaming_discard` | cable mixed bilevel | **70.9 ms** | row streaming, no retained output |
+| `render_native_stages/mask_decode` | cable mixed bilevel | **428 µs** | JB2 mask decode only |
+| `render_native_stages/bg_to_rgb_warm` | cable mixed bilevel | **8.86 ms** | cached IW44 inverse + RGB |
 
 The diagnostic split shows the native-resolution gap is dominated by compositor
 sampling and output materialization, not by warm JB2/IW44 decode alone.
@@ -201,15 +214,15 @@ sampling and output materialization, not by warm JB2/IW44 decode alone.
 Test file: `tests/corpus/pathogenic_bacteria_1896.djvu` (520 pages, 25 MB, bilevel JB2 at 600 dpi)
 Text layer: `tests/corpus/watchmaker.djvu` (TXTz present)
 
-| Benchmark | Time (median) | Notes |
+| Benchmark | Time (Criterion mean) | Notes |
 |-----------|--------------|-------|
-| `parse_multipage_520p` | **2.19 ms** | Parse DJVM directory + all page descriptors, 520 pages |
-| `iterate_pages_520p` | **1.49 µs** | Read width/height/dpi for all 520 pages (no render) |
+| `parse_multipage_520p` | **2.29 ms** | Parse DJVM directory + all page descriptors, 520 pages |
+| `iterate_pages_520p` | **1.52 µs** | Read width/height/dpi for all 520 pages (no render) |
 | `render_large_doc_first_page` | **10.6 ms** | Render page 1 of 520 at native 600 dpi |
-| `render_large_doc_mid_page` | **10.5 ms** | Render page 260 of 520 — dense text, large JB2 |
-| `decode_mask_large_600dpi` | **2.41 ms** | Decode JB2 mask only, page 1 |
-| `decode_mask_mid_600dpi` | **15.2 ms** | Decode JB2 mask only, page 260 |
-| `text_extraction_single_page` | **171 µs** | TXTz parse + plain text output, watchmaker.djvu |
+| `render_large_doc_mid_page` | **10.6 ms** | Render page 260 of 520 — dense text, large JB2 |
+| `decode_mask_large_600dpi` | **2.53 ms** | Decode JB2 mask only, page 1 |
+| `decode_mask_mid_600dpi` | **16.0 ms** | Decode JB2 mask only, page 260 |
+| `text_extraction_single_page` | **168 µs** | TXTz parse + plain text output, watchmaker.djvu |
 
 ---
 
@@ -220,7 +233,7 @@ The benchmark workflow keeps this comparison active:
 machine as Criterion and formats the result with `scripts/djvulibre_compare.py`.
 The benchmark dashboard workflow also publishes a DjVuLibre overlay.
 
-Current local run (2026-05-16):
+Current local run (2026-05-17):
 
 - `boy.djvu`: small color IW44 downscale
 - `colorbook.djvu`: large color IW44 downscale
@@ -232,13 +245,13 @@ Current local run (2026-05-16):
 
 | Benchmark | djvu-rs | libdjvulibre C API | ddjvu CLI | Ratio |
 |-----------|--------:|-------------------:|----------:|------:|
-| `boy.djvu` @ 72 dpi, small color IW44 | **238 µs** | **179 µs** | **27.6 ms** | djvu-rs **1.3x slower** |
-| `colorbook.djvu` @ 150 dpi, color IW44 | **6.90 ms** | **5.87 ms** | **62.3 ms** | djvu-rs **1.2x slower** |
-| `watchmaker.djvu` @ 300 dpi, native color corpus | **68.71 ms** | **35.13 ms** | **74.1 ms** | djvu-rs **2.0x slower** |
-| `cable_1973_100133.djvu` @ 300 dpi, native bilevel JB2 corpus | **69.73 ms** | **33.89 ms** | **69.7 ms** | djvu-rs **2.1x slower** |
+| `boy.djvu` @ 72 dpi, small color IW44 | **246 µs** | **159 µs** | **30.6 ms** | djvu-rs **1.5x slower** |
+| `colorbook.djvu` @ 150 dpi, color IW44 | **8.78 ms** | **5.96 ms** | **67.3 ms** | djvu-rs **1.5x slower** |
+| `watchmaker.djvu` @ 300 dpi, native color corpus | **151 ms** | **36.44 ms** | **79.8 ms** | djvu-rs **4.2x slower** |
+| `cable_1973_100133.djvu` @ 300 dpi, native bilevel JB2 corpus | **75.45 ms** | **35.25 ms** | **73.8 ms** | djvu-rs **2.1x slower** |
 
 For the closest cold-path djvu-rs Criterion comparison,
-`render_colorbook_cold` is **17.3 ms**. That benchmark includes document
+`render_colorbook_cold` is **48.9 ms**. That benchmark includes document
 parsing and first render work, but it is not identical to libdjvulibre's
 open+decode measurement. The libdjvulibre C API harness intentionally avoids
 upscale cases because `ddjvu_page_render` can return a zero buffer when the
@@ -248,27 +261,28 @@ requested output rectangle is larger than the native page.
 
 | Scenario | Winner | Margin |
 |----------|--------|--------|
-| Downscaled render (< native DPI), warm | **DjVuLibre** | 1.2-1.3x faster in this matrix |
-| Native-resolution corpus render | **DjVuLibre** | 2.0-2.1x faster |
-| `ddjvu` CLI subprocess baseline | comparable to slower than djvu-rs render-only | 27.6-74.1 ms across measured cases |
-| djvu-rs cold colorbook render | — | 17.3 ms; not directly equivalent to libdjvulibre open+decode |
-| Document open / parse | **djvu-rs** | `parse_multipage_520p`: 2.19 ms |
+| Downscaled render (< native DPI), warm | **DjVuLibre** | 1.5x faster in this matrix |
+| Native-resolution corpus render | **DjVuLibre** | 2.1-4.2x faster |
+| `ddjvu` CLI subprocess baseline | comparable to slower than djvu-rs render-only | 30.6-79.8 ms across measured cases |
+| djvu-rs cold colorbook render | — | 48.9 ms; not directly equivalent to libdjvulibre open+decode |
+| Document open / parse | **djvu-rs** | `parse_multipage_520p`: 2.29 ms |
 
 ---
 
 ## Notes
 
 - JB2 and IW44 pure decode are sub-millisecond to low-millisecond for typical pages.
-- Full native-resolution render (2550×3301 px): ~67–70 ms.
+- Full native-resolution render (2550×3301 px): ~75–151 ms in the 2026-05-17
+  full local run; the color corpus row was noisy.
 - Corpus benchmarks use public domain files from Internet Archive.
 - PDF export baseline for `tests/corpus/watchmaker.djvu` (12 pages, 150 dpi,
   JPEG-80, Apple M1 Max / macOS arm64, Rust 1.92, 2026-05-17):
-  `pdf_export_sequential` median **955 ms**, `pdf_export_parallel` median
+  `pdf_export_sequential` mean **955 ms**, `pdf_export_parallel` mean
   **154 ms**. Memory probe peak RSS: sequential **76.7 MiB**, parallel
   **228.9 MiB**. See `PERF_EXPERIMENTS.md` entry #298 for commands and
   per-stage byte counts.
 - PDF color row streaming (#299, same fixture/platform): sequential
-  `pdf_export_sequential` median **812 ms**; parallel probe peak RSS improved
+  `pdf_export_sequential` mean **812 ms**; parallel probe peak RSS improved
   from **228.9 MiB** to **169.5 MiB** with unchanged PDF bytes. See
   `PERF_EXPERIMENTS.md` entry #299 for the noisy parallel Criterion runs and
   full command log.

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -5,6 +5,70 @@ numbers, decision, reason. Referenced from issue templates ("Record result
 in `PERF_EXPERIMENTS.md` (Kept or Reverted + reason)") and from
 `.github/workflows/bench.yml`.
 
+### Post-roadmap full benchmark refresh — **Kept** (2026-05-17)
+
+**Approach.** Reran the public full workspace Criterion command after the
+roadmap PR series was merged through #310, then reran the DjVuLibre comparison
+harness against the same local Criterion artifact. No code was changed; this
+refresh updates public benchmark documentation from the new measurements.
+
+**Platform.**
+- OS: macOS 26.3.1 / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple M1 Max, 10 cores
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- Cargo: `cargo 1.92.0 (344c4567c 2025-10-21)`
+- RUSTFLAGS: unset
+
+**Command(s).**
+
+```sh
+cargo bench --workspace --features cli,tiff
+bash scripts/bench_djvulibre.sh /private/tmp/djvu-rs-post-roadmap-djvulibre
+python3 scripts/djvulibre_compare.py \
+  --criterion target/criterion \
+  --djvulibre-bench /private/tmp/djvu-rs-post-roadmap-djvulibre/djvulibre_bench.txt \
+  --ddjvu-timing /private/tmp/djvu-rs-post-roadmap-djvulibre/ddjvu_timing.txt
+```
+
+**Numbers.**
+
+| Benchmark | Criterion mean |
+|-----------|---------------:|
+| `render_page/dpi/72` | 246 us |
+| `render_page/dpi/144` | 934 us |
+| `render_page/dpi/300` | 6.96 ms |
+| `render_page/dpi/600` | 42.1 ms |
+| `render_colorbook` | 8.78 ms |
+| `render_colorbook_cold` | 48.9 ms |
+| `render_corpus_color` | 151 ms |
+| `render_corpus_bilevel` | 75.4 ms |
+| `render_native_stages/render_streaming_discard/watchmaker_color` | 195 ms |
+| `jb2_decode` | 132 us |
+| `iw44_decode_first_chunk` | 592 us |
+| `iw44_decode_corpus_color` | 655 us |
+| `parse_multipage_520p` | 2.29 ms |
+| `render_large_doc_first_page` | 10.6 ms |
+| `pdf_export_sequential` | 821 ms |
+
+DjVuLibre comparison on the same local fixture matrix:
+
+| Scenario | djvu-rs | libdjvulibre C API | ddjvu CLI | Ratio |
+|----------|--------:|-------------------:|----------:|------:|
+| `boy.djvu` @ 72 dpi | 246 us | 159 us | 30.6 ms | djvu-rs 1.5x slower |
+| `colorbook.djvu` @ 150 dpi | 8.78 ms | 5.96 ms | 67.3 ms | djvu-rs 1.5x slower |
+| `watchmaker.djvu` @ 300 dpi | 151 ms | 36.44 ms | 79.8 ms | djvu-rs 4.2x slower |
+| `cable_1973_100133.djvu` @ 300 dpi | 75.45 ms | 35.25 ms | 73.8 ms | djvu-rs 2.1x slower |
+
+**Decision.** Kept.
+
+**Reason.** This run is the current broad Apple ARM64 public snapshot after all
+roadmap work through #310. `README.md`, `BENCHMARKS_RESULTS.md`, and the
+current-summary block in `BENCHMARKS.md` were updated. Several native/cold
+render rows had wide Criterion intervals, so the docs record the measurements
+without making a narrow regression claim.
+
 ### #306 — wasm32 scalar vs simd128 benchmark harness — **Kept** (2026-05-17)
 
 **Approach.** Added a reproducible Node.js harness for the existing

--- a/README.md
+++ b/README.md
@@ -467,29 +467,28 @@ text/annotation parsing — all codec primitives that work on byte slices.
 ## Performance
 
 Latest full Criterion run: Apple M1 Max / macOS `arm64`, Rust 1.92,
-release profile (`cargo bench --workspace --features cli,tiff`, 2026-05-16).
+release profile (`cargo bench --workspace --features cli,tiff`, 2026-05-17).
 
 | Benchmark | Time |
 |-----------|-----:|
-| `render_page/dpi/72` | **238 µs** |
-| `render_page/dpi/144` | **904 µs** |
-| `render_page/dpi/300` | **3.44 ms** |
-| `render_colorbook` (150 dpi, warm) | **6.90 ms** |
-| `render_colorbook_cold` | **17.3 ms** |
-| `render_corpus_color` (native 600 dpi) | **68.7 ms** |
-| `render_corpus_bilevel` (native 600 dpi) | **69.7 ms** |
-| `render_native_stages/render_streaming_discard` (color) | **65.1 ms** |
-| `jb2_decode` | **128 µs** |
-| `iw44_decode_first_chunk` | **571 µs** |
-| `iw44_decode_corpus_color` | **637 µs** |
-| `parse_multipage_520p` | **2.19 ms** |
+| `render_page/dpi/72` | **246 µs** |
+| `render_page/dpi/144` | **934 µs** |
+| `render_page/dpi/300` | **6.96 ms** |
+| `render_colorbook` (150 dpi, warm) | **8.78 ms** |
+| `render_colorbook_cold` | **48.9 ms** |
+| `render_corpus_color` (native 600 dpi) | **151 ms** |
+| `render_corpus_bilevel` (native 600 dpi) | **75.4 ms** |
+| `render_native_stages/render_streaming_discard` (color) | **195 ms** |
+| `jb2_decode` | **132 µs** |
+| `iw44_decode_first_chunk` | **592 µs** |
+| `iw44_decode_corpus_color` | **655 µs** |
+| `parse_multipage_520p` | **2.29 ms** |
 | `render_large_doc_first_page` | **10.6 ms** |
-| `pdf_export_sequential` (12 pages, JPEG-80) | **848 ms** |
+| `pdf_export_sequential` (12 pages, JPEG-80) | **821 ms** |
 
-Criterion compared this run against the previous local baseline: native render,
-codec, and document benches mostly improved; `pdf_export_sequential` was
-unchanged; small thumbnail paths (`render_page/dpi/72` and 0.5× bilinear) were
-reported ~10–12% slower and are noted as a caveat.
+This post-roadmap refresh supersedes the 2026-05-16 broad local summary. Some
+native and cold render groups were noisy in this full workspace run; use the
+confidence intervals in `BENCHMARKS_RESULTS.md` for detailed comparisons.
 
 ### Comparison with DjVuLibre
 
@@ -497,17 +496,17 @@ The benchmark workflow still runs a DjVuLibre comparison via
 [`scripts/bench_djvulibre.sh`](scripts/bench_djvulibre.sh) and formats it with
 [`scripts/djvulibre_compare.py`](scripts/djvulibre_compare.py).
 
-Current local matrix (2026-05-16):
+Current local matrix (2026-05-17):
 
 | Scenario | djvu-rs | DjVuLibre | Ratio |
 |----------|--------:|----------:|------:|
-| Small color IW44, 72 dpi | **238 µs** | **179 µs** | DjVuLibre **1.3x faster** |
-| Large color IW44, 150 dpi | **6.90 ms** | **5.87 ms** | DjVuLibre **1.2x faster** |
-| Native color corpus, 300 dpi | **68.71 ms** | **35.13 ms** | DjVuLibre **2.0x faster** |
-| Native bilevel JB2 corpus, 300 dpi | **69.73 ms** | **33.89 ms** | DjVuLibre **2.1x faster** |
+| Small color IW44, 72 dpi | **246 µs** | **159 µs** | DjVuLibre **1.5x faster** |
+| Large color IW44, 150 dpi | **8.78 ms** | **5.96 ms** | DjVuLibre **1.5x faster** |
+| Native color corpus, 300 dpi | **151 ms** | **36.44 ms** | DjVuLibre **4.2x faster** |
+| Native bilevel JB2 corpus, 300 dpi | **75.45 ms** | **35.25 ms** | DjVuLibre **2.1x faster** |
 
 The same workflow also records `ddjvu` CLI timings for these files
-(27.6-74.1 ms locally), including process startup and PPM output.
+(30.6-79.8 ms locally), including process startup and PPM output.
 
 See [BENCHMARKS_RESULTS.md](BENCHMARKS_RESULTS.md) for the full Criterion
 run, methodology, and the full DjVuLibre comparison. Historical multi-platform


### PR DESCRIPTION
## Summary
- reran the post-roadmap full Criterion benchmark on Apple M1 Max / macOS arm64
- reran the DjVuLibre comparison harness against the same Criterion artifact
- updated README, BENCHMARKS_RESULTS, BENCHMARKS summary, and PERF_EXPERIMENTS with the refreshed public numbers

## Validation
- cargo bench --workspace --features cli,tiff
- bash scripts/bench_djvulibre.sh /private/tmp/djvu-rs-post-roadmap-djvulibre
- python3 scripts/djvulibre_compare.py --criterion target/criterion --djvulibre-bench /private/tmp/djvu-rs-post-roadmap-djvulibre/djvulibre_bench.txt --ddjvu-timing /private/tmp/djvu-rs-post-roadmap-djvulibre/ddjvu_timing.txt
- git diff --check
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings

## Notes
- Several native/cold render rows had wide Criterion intervals, so the docs record the snapshot without making a narrow regression claim.
