### PR TITLE
docs: correct noisy render benchmark baseline

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -25,16 +25,18 @@ including recent async lazy loading and x86-64-v3 AVX2 validation results.
 
 The latest full local Criterion run is summarized in
 [`BENCHMARKS_RESULTS.md`](BENCHMARKS_RESULTS.md) (2026-05-17, macOS arm64,
-Rust 1.92.0). Selected results from that run:
+Rust 1.92.0). Render rows use the targeted rerun recorded there because the
+initial full-workspace render rows were rejected as a noisy local artifact.
+Selected current results:
 
 | Benchmark | Time |
 |-----------|-----:|
 | `render_page/dpi/72` | 246 µs |
-| `render_page/dpi/144` | 934 µs |
-| `render_page/dpi/300` | 6.96 ms |
-| `render_colorbook` | 8.78 ms |
-| `render_colorbook_cold` | 48.9 ms |
-| `render_corpus_color` | 151 ms |
+| `render_page/dpi/144` | 938 µs |
+| `render_page/dpi/300` | 3.59 ms |
+| `render_colorbook` | 7.22 ms |
+| `render_colorbook_cold` | 18.8 ms |
+| `render_corpus_color` | 71.2 ms |
 | `render_corpus_bilevel` | 75.4 ms |
 | `jb2_decode` | 132 µs |
 | `iw44_decode_first_chunk` | 592 µs |

--- a/BENCHMARKS_RESULTS.md
+++ b/BENCHMARKS_RESULTS.md
@@ -6,16 +6,18 @@ Rust: 1.92.0 stable (edition 2024)
 Profile: release (opt-level 3, lto = thin)
 Date: 2026-05-17
 
-Command: `cargo bench --workspace --features cli,tiff`
+Primary command: `cargo bench --workspace --features cli,tiff`
+Render correction command: `cargo bench --bench render -- 'render_corpus_color|render_colorbook' --output-format bencher`
+Additional render correction command: `cargo bench --bench render -- 'render_page/dpi|render_corpus_bilevel|render_native_stages' --output-format bencher`
 
 Most Criterion benchmarks use 100 samples, 3 s warm-up, and 5 s measurement;
 the bounded `render_row_scratch_ab/*` A/B group uses 10 samples and 1 s warm-up
-to keep full-run time practical. Rows below report Criterion mean point
-estimates from the post-roadmap full workspace run. Some native and cold render
-groups had wide confidence intervals in this run, so treat those rows as a
-fresh public snapshot rather than a narrow regression claim.
+to keep full-run time practical. Codec, document, and PDF rows below report
+Criterion mean point estimates from the post-roadmap full workspace run.
+Render rows use targeted reruns after the initial full-workspace render rows
+proved non-representative.
 
-Notable wide Criterion intervals from this run:
+Rejected full-workspace render artifact preserved for context:
 
 | Benchmark | Mean | 95% confidence interval |
 |-----------|-----:|------------------------:|
@@ -25,6 +27,10 @@ Notable wide Criterion intervals from this run:
 | `render_colorbook_cold` | 48.9 ms | 41.1-57.3 ms |
 | `render_corpus_color` | 151 ms | 129-175 ms |
 | `render_native_stages/render_streaming_discard/watchmaker_color` | 195 ms | 174-218 ms |
+
+Targeted reruns on the same code returned the render rows below to the expected
+range. The rejected artifact remains recorded in `PERF_EXPERIMENTS.md` and is
+not used for public render claims.
 
 ---
 
@@ -52,7 +58,7 @@ so follow-up SIMD work can fill them without changing the schema.
 
 | Target family | OS | CPU / runner | target_arch | target_feature(s) | Rust | RUSTFLAGS | Source artifact | Status |
 |---------------|----|--------------|-------------|-------------------|------|-----------|-----------------|--------|
-| Apple ARM64 | macOS 26.3.1 (Darwin 25.3) | Apple M1 Max, 10 cores | `aarch64` | ARM64 baseline; NEON available on Apple Silicon | 1.92.0 stable | unset | Post-roadmap local full run, `cargo bench --workspace --features cli,tiff` (2026-05-17) | Current broad Apple ARM64 baseline |
+| Apple ARM64 | macOS 26.3.1 (Darwin 25.3) | Apple M1 Max, 10 cores | `aarch64` | ARM64 baseline; NEON available on Apple Silicon | 1.92.0 stable | unset | Post-roadmap full run plus targeted render rerun (2026-05-17) | Current broad Apple ARM64 baseline |
 | Linux x86_64 baseline | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | baseline x86-64 codegen | stable from workflow | unset | #189 artifact run `25299920836` from `.github/workflows/bench.yml` `bench-x86-64-v3` validation | Current selected IW44/render baseline |
 | Linux x86_64-v3 / AVX2 | Ubuntu GitHub-hosted runner | `ubuntu-latest` | `x86_64` | `avx2` via x86-64-v3 codegen | stable from workflow | `-C target-cpu=x86-64-v3` | `.github/workflows/bench.yml` `bench-x86-64-v3` job; #189 artifact run `25299920836` | Current AVX2 validation exists for selected IW44/render benches |
 | wasm32 scalar | macOS 26.3.1 host / Node.js v26.0.0 | Apple M1 Max host running Node.js wasm | `wasm32` | scalar | 1.92.0 stable | unset | `scripts/bench_wasm_simd128.sh` local run (#306) | Current small-fixture wasm baseline |
@@ -72,20 +78,19 @@ metadata format.
 | `iw44_to_rgb_colorbook/sub1_full_decode` | **5.73 ms** | 9,231,033 ns | 9,129,333 ns | missing | missing | missing |
 | `iw44_to_rgb_colorbook/sub2_partial_decode` | **1.34 ms** | 2,164,523 ns | 2,199,280 ns | missing | missing | missing |
 | `iw44_to_rgb_colorbook/sub4_partial_decode` | **347 µs** | 565,640 ns | 583,519 ns | missing | missing | missing |
-| `render_colorbook` | **8.78 ms** | 13,072,440 ns | 12,826,562 ns | missing | missing | missing |
-| `render_colorbook_cold` | **48.9 ms** | 28,127,606 ns | 27,105,326 ns | missing | missing | missing |
-| `render_colorbook_stages/mask_decode` | **12.7 ms** | 5,325,125 ns | 5,107,550 ns | missing | missing | missing |
-| `render_corpus_color` | **151 ms** | 133,813,976 ns | 133,185,634 ns | missing | missing | missing |
+| `render_colorbook` | **7.22 ms** | 13,072,440 ns | 12,826,562 ns | missing | missing | missing |
+| `render_colorbook_cold` | **18.8 ms** | 28,127,606 ns | 27,105,326 ns | missing | missing | missing |
+| `render_colorbook_stages/mask_decode` | **4.39 ms** | 5,325,125 ns | 5,107,550 ns | missing | missing | missing |
+| `render_corpus_color` | **71.2 ms** | 133,813,976 ns | 133,185,634 ns | missing | missing | missing |
 | `wasm_render_150dpi_fresh_doc` | n/a | n/a | n/a | 2.715 ms | 2.548 ms | n/a |
 | `wasm_render_150dpi_cached_page` | n/a | n/a | n/a | 2.685 ms | 2.491 ms | n/a |
 | `wasm_progressive_150dpi_chunk0` | n/a | n/a | n/a | 2.693 ms | 2.463 ms | n/a |
 
 Notes:
 
-- Apple ARM64 IW44/render values come from the 2026-05-17 post-roadmap full
-  local run on Apple M1 Max. The earlier #308 filtered run remains recorded in
-  `PERF_EXPERIMENTS.md` as targeted NEON validation, but this table now tracks
-  the broad public baseline.
+- Apple ARM64 codec values come from the 2026-05-17 post-roadmap full local
+  run on Apple M1 Max. Render values come from the targeted rerun after the
+  initial full-workspace render rows were rejected as noisy.
 - Linux x86_64 baseline and x86_64-v3 values come from the #189 AVX2 validation
   artifact recorded in `PERF_EXPERIMENTS.md`.
 - The wasm32 rows come from the Node.js harness added in #306 and are not
@@ -158,20 +163,20 @@ Corpus files: `tests/corpus/`, colorbook: `references/djvujs/library/assets/colo
 | DPI | Approx output size | Time (Criterion mean) |
 |-----|--------------------|--------------|
 | 72 dpi | ~138×184 px | **246 µs** |
-| 144 dpi | ~276×368 px | **934 µs** |
-| 300 dpi | ~576×768 px | **6.96 ms** |
-| 600 dpi | ~1152×1536 px | **42.1 ms** |
+| 144 dpi | ~276×368 px | **938 µs** |
+| 300 dpi | ~576×768 px | **3.59 ms** |
+| 600 dpi | ~1152×1536 px | **13.9 ms** |
 
 ### Full-resolution corpus render
 
 | Benchmark | File | Native size | Time (Criterion mean) | Notes |
 |-----------|------|-------------|--------------|-------|
 | `render_coarse` | boy.djvu | 192×256 | **3.41 ms** | |
-| `render_colorbook` | colorbook.djvu | 2260×3669 (400 dpi) | **8.78 ms** | 150 dpi, warm (sub=4 mask + partial BG44) |
-| `render_colorbook_stages/full_render` | colorbook.djvu | 2260×3669 (400 dpi) | **7.16 ms** | Warm full render stage |
-| `render_colorbook_stages/mask_decode` | colorbook.djvu | 2260×3669 (400 dpi) | **12.7 ms** | JB2 mask decode stage |
-| `render_colorbook_cold` | colorbook.djvu | 2260×3669 (400 dpi) | **48.9 ms** | cold (ZP + wavelet + RGB, first render) |
-| `render_corpus_color` | watchmaker.djvu | 2550×3301 | **151 ms** | native 600 dpi, full IW44 |
+| `render_colorbook` | colorbook.djvu | 2260×3669 (400 dpi) | **7.22 ms** | 150 dpi, warm (sub=4 mask + partial BG44) |
+| `render_colorbook_stages/full_render` | colorbook.djvu | 2260×3669 (400 dpi) | **7.26 ms** | Warm full render stage |
+| `render_colorbook_stages/mask_decode` | colorbook.djvu | 2260×3669 (400 dpi) | **4.39 ms** | JB2 mask decode stage |
+| `render_colorbook_cold` | colorbook.djvu | 2260×3669 (400 dpi) | **18.8 ms** | cold (ZP + wavelet + RGB, first render) |
+| `render_corpus_color` | watchmaker.djvu | 2550×3301 | **71.2 ms** | native 600 dpi, full IW44 |
 | `render_corpus_bilevel` | cable_1973_100133.djvu | 2550×3301 | **75.4 ms** | native 600 dpi, bilevel JB2 |
 | `render_scaled_0.5x/bilinear` | boy.djvu | 0.5× output | **149 µs** | Built-in bilinear downscale |
 | `render_scaled_0.5x/lanczos3` | boy.djvu | 0.5× output | **3.85 ms** | Higher quality separable Lanczos3 |
@@ -193,16 +198,16 @@ API, `render_into_reuse_buffer` composites into a caller-owned buffer, and
 
 | Benchmark | Page | Time (Criterion mean) | Notes |
 |-----------|------|--------------:|-------|
-| `render_native_stages/render_pixmap` | watchmaker color | **70.8 ms** | public `Pixmap` path, warm decode caches |
-| `render_native_stages/render_into_reuse_buffer` | watchmaker color | **70.4 ms** | caller-owned RGBA buffer |
-| `render_native_stages/render_streaming_discard` | watchmaker color | **195 ms** | row streaming, no retained output; noisy in this run |
-| `render_native_stages/mask_decode` | watchmaker color | **7.26 ms** | JB2 mask decode only |
-| `render_native_stages/bg_to_rgb_warm` | watchmaker color | **7.48 ms** | cached IW44 inverse + RGB |
+| `render_native_stages/render_pixmap` | watchmaker color | **71.5 ms** | public `Pixmap` path, warm decode caches |
+| `render_native_stages/render_into_reuse_buffer` | watchmaker color | **70.5 ms** | caller-owned RGBA buffer |
+| `render_native_stages/render_streaming_discard` | watchmaker color | **70.2 ms** | row streaming, no retained output |
+| `render_native_stages/mask_decode` | watchmaker color | **2.74 ms** | JB2 mask decode only |
+| `render_native_stages/bg_to_rgb_warm` | watchmaker color | **2.96 ms** | cached IW44 inverse + RGB |
 | `render_native_stages/render_pixmap` | cable mixed bilevel | **85.1 ms** | public `Pixmap` path, warm decode caches |
 | `render_native_stages/render_into_reuse_buffer` | cable mixed bilevel | **71.6 ms** | caller-owned RGBA buffer |
-| `render_native_stages/render_streaming_discard` | cable mixed bilevel | **70.9 ms** | row streaming, no retained output |
-| `render_native_stages/mask_decode` | cable mixed bilevel | **428 µs** | JB2 mask decode only |
-| `render_native_stages/bg_to_rgb_warm` | cable mixed bilevel | **8.86 ms** | cached IW44 inverse + RGB |
+| `render_native_stages/render_streaming_discard` | cable mixed bilevel | **71.0 ms** | row streaming, no retained output |
+| `render_native_stages/mask_decode` | cable mixed bilevel | **427 µs** | JB2 mask decode only |
+| `render_native_stages/bg_to_rgb_warm` | cable mixed bilevel | **2.91 ms** | cached IW44 inverse + RGB |
 
 The diagnostic split shows the native-resolution gap is dominated by compositor
 sampling and output materialization, not by warm JB2/IW44 decode alone.
@@ -246,12 +251,12 @@ Current local run (2026-05-17):
 | Benchmark | djvu-rs | libdjvulibre C API | ddjvu CLI | Ratio |
 |-----------|--------:|-------------------:|----------:|------:|
 | `boy.djvu` @ 72 dpi, small color IW44 | **246 µs** | **159 µs** | **30.6 ms** | djvu-rs **1.5x slower** |
-| `colorbook.djvu` @ 150 dpi, color IW44 | **8.78 ms** | **5.96 ms** | **67.3 ms** | djvu-rs **1.5x slower** |
-| `watchmaker.djvu` @ 300 dpi, native color corpus | **151 ms** | **36.44 ms** | **79.8 ms** | djvu-rs **4.2x slower** |
+| `colorbook.djvu` @ 150 dpi, color IW44 | **7.22 ms** | **5.96 ms** | **67.3 ms** | djvu-rs **1.2x slower** |
+| `watchmaker.djvu` @ 300 dpi, native color corpus | **71.2 ms** | **36.44 ms** | **79.8 ms** | djvu-rs **2.0x slower** |
 | `cable_1973_100133.djvu` @ 300 dpi, native bilevel JB2 corpus | **75.45 ms** | **35.25 ms** | **73.8 ms** | djvu-rs **2.1x slower** |
 
 For the closest cold-path djvu-rs Criterion comparison,
-`render_colorbook_cold` is **48.9 ms**. That benchmark includes document
+`render_colorbook_cold` is **18.8 ms**. That benchmark includes document
 parsing and first render work, but it is not identical to libdjvulibre's
 open+decode measurement. The libdjvulibre C API harness intentionally avoids
 upscale cases because `ddjvu_page_render` can return a zero buffer when the
@@ -261,10 +266,10 @@ requested output rectangle is larger than the native page.
 
 | Scenario | Winner | Margin |
 |----------|--------|--------|
-| Downscaled render (< native DPI), warm | **DjVuLibre** | 1.5x faster in this matrix |
-| Native-resolution corpus render | **DjVuLibre** | 2.1-4.2x faster |
+| Downscaled render (< native DPI), warm | **DjVuLibre** | 1.2-1.5x faster in this matrix |
+| Native-resolution corpus render | **DjVuLibre** | 2.0-2.1x faster |
 | `ddjvu` CLI subprocess baseline | comparable to slower than djvu-rs render-only | 30.6-79.8 ms across measured cases |
-| djvu-rs cold colorbook render | — | 48.9 ms; not directly equivalent to libdjvulibre open+decode |
+| djvu-rs cold colorbook render | — | 18.8 ms; not directly equivalent to libdjvulibre open+decode |
 | Document open / parse | **djvu-rs** | `parse_multipage_520p`: 2.29 ms |
 
 ---
@@ -272,8 +277,8 @@ requested output rectangle is larger than the native page.
 ## Notes
 
 - JB2 and IW44 pure decode are sub-millisecond to low-millisecond for typical pages.
-- Full native-resolution render (2550×3301 px): ~75–151 ms in the 2026-05-17
-  full local run; the color corpus row was noisy.
+- Full native-resolution render (2550×3301 px): ~71-75 ms in the corrected
+  2026-05-17 local render baseline.
 - Corpus benchmarks use public domain files from Internet Archive.
 - PDF export baseline for `tests/corpus/watchmaker.djvu` (12 pages, 150 dpi,
   JPEG-80, Apple M1 Max / macOS arm64, Rust 1.92, 2026-05-17):

--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -5,7 +5,58 @@ numbers, decision, reason. Referenced from issue templates ("Record result
 in `PERF_EXPERIMENTS.md` (Kept or Reverted + reason)") and from
 `.github/workflows/bench.yml`.
 
-### Post-roadmap full benchmark refresh — **Kept** (2026-05-17)
+### Post-roadmap render baseline correction — **Kept** (2026-05-17)
+
+**Approach.** Reran the render filters from #308 on the same code after the
+post-roadmap full workspace run produced implausibly slow render rows. The
+rerun confirmed that the public render baseline should use the targeted render
+artifact, not the full-run outliers from PR #335.
+
+**Platform.**
+- OS: macOS 26.3.1 / Darwin 25.3.0 (`RELEASE_ARM64_T6000`)
+- CPU: Apple M1 Max, 10 cores
+- arch: `arm64` / Rust host `aarch64-apple-darwin`
+- target features: ARM64 baseline; NEON available on Apple Silicon
+- Rust: `rustc 1.92.0 (ded5c06cf 2025-12-08)`
+- Cargo: `cargo 1.92.0 (344c4567c 2025-10-21)`
+- RUSTFLAGS: unset
+
+**Command(s).**
+
+```sh
+cargo bench --bench render -- 'render_corpus_color|render_colorbook' --output-format bencher
+cargo bench --bench render -- 'render_page/dpi|render_corpus_bilevel|render_native_stages' --output-format bencher
+```
+
+**Numbers.**
+
+| Benchmark | Corrected render baseline |
+|-----------|--------------------------:|
+| `render_page/dpi/72` | 246,839 ns |
+| `render_page/dpi/144` | 937,501 ns |
+| `render_page/dpi/300` | 3,586,208 ns |
+| `render_page/dpi/600` | 13,911,536 ns |
+| `render_colorbook` | 7,221,910 ns |
+| `render_colorbook_stages/full_render` | 7,256,342 ns |
+| `render_colorbook_stages/mask_decode` | 4,392,493 ns |
+| `render_colorbook_cold` | 18,838,014 ns |
+| `render_corpus_color` | 71,247,374 ns |
+| `render_native_stages/render_pixmap/watchmaker_color` | 71,532,521 ns |
+| `render_native_stages/render_into_reuse_buffer/watchmaker_color` | 70,452,562 ns |
+| `render_native_stages/render_streaming_discard/watchmaker_color` | 70,185,520 ns |
+| `render_native_stages/mask_decode/watchmaker_color` | 2,735,714 ns |
+| `render_native_stages/bg_to_rgb_warm/watchmaker_color` | 2,962,458 ns |
+
+**Decision.** Kept.
+
+**Reason.** No render-path code changed between the #308 targeted baseline and
+the bad #335 full-run artifact; the only intervening render source edits were
+documentation comments. The targeted rerun restored the expected range, so
+`README.md`, `BENCHMARKS_RESULTS.md`, and `BENCHMARKS.md` now use this
+corrected render baseline. The bad full-run render rows remain recorded below
+as a rejected artifact instead of being used as public claims.
+
+### Post-roadmap full benchmark refresh — **Needs follow-up** (2026-05-17)
 
 **Approach.** Reran the public full workspace Criterion command after the
 roadmap PR series was merged through #310, then reran the DjVuLibre comparison
@@ -61,13 +112,12 @@ DjVuLibre comparison on the same local fixture matrix:
 | `watchmaker.djvu` @ 300 dpi | 151 ms | 36.44 ms | 79.8 ms | djvu-rs 4.2x slower |
 | `cable_1973_100133.djvu` @ 300 dpi | 75.45 ms | 35.25 ms | 73.8 ms | djvu-rs 2.1x slower |
 
-**Decision.** Kept.
+**Decision.** Needs follow-up.
 
-**Reason.** This run is the current broad Apple ARM64 public snapshot after all
-roadmap work through #310. `README.md`, `BENCHMARKS_RESULTS.md`, and the
-current-summary block in `BENCHMARKS.md` were updated. Several native/cold
-render rows had wide Criterion intervals, so the docs record the measurements
-without making a narrow regression claim.
+**Reason.** Codec, document, and PDF rows from this run remain useful, but the
+render rows were too noisy to use as public baseline claims. They were
+superseded by the targeted render correction above, and the public docs were
+updated accordingly.
 
 ### #306 — wasm32 scalar vs simd128 benchmark harness — **Kept** (2026-05-17)
 

--- a/README.md
+++ b/README.md
@@ -466,19 +466,21 @@ text/annotation parsing — all codec primitives that work on byte slices.
 
 ## Performance
 
-Latest full Criterion run: Apple M1 Max / macOS `arm64`, Rust 1.92,
-release profile (`cargo bench --workspace --features cli,tiff`, 2026-05-17).
+Latest post-roadmap Criterion refresh: Apple M1 Max / macOS `arm64`, Rust 1.92.
+The codec/document/PDF rows come from `cargo bench --workspace --features
+cli,tiff`; render rows below use targeted `cargo bench --bench render` reruns
+after the full workspace run produced noisy render outliers.
 
 | Benchmark | Time |
 |-----------|-----:|
 | `render_page/dpi/72` | **246 µs** |
-| `render_page/dpi/144` | **934 µs** |
-| `render_page/dpi/300` | **6.96 ms** |
-| `render_colorbook` (150 dpi, warm) | **8.78 ms** |
-| `render_colorbook_cold` | **48.9 ms** |
-| `render_corpus_color` (native 600 dpi) | **151 ms** |
+| `render_page/dpi/144` | **938 µs** |
+| `render_page/dpi/300` | **3.59 ms** |
+| `render_colorbook` (150 dpi, warm) | **7.22 ms** |
+| `render_colorbook_cold` | **18.8 ms** |
+| `render_corpus_color` (native 600 dpi) | **71.2 ms** |
 | `render_corpus_bilevel` (native 600 dpi) | **75.4 ms** |
-| `render_native_stages/render_streaming_discard` (color) | **195 ms** |
+| `render_native_stages/render_streaming_discard` (color) | **70.2 ms** |
 | `jb2_decode` | **132 µs** |
 | `iw44_decode_first_chunk` | **592 µs** |
 | `iw44_decode_corpus_color` | **655 µs** |
@@ -486,9 +488,9 @@ release profile (`cargo bench --workspace --features cli,tiff`, 2026-05-17).
 | `render_large_doc_first_page` | **10.6 ms** |
 | `pdf_export_sequential` (12 pages, JPEG-80) | **821 ms** |
 
-This post-roadmap refresh supersedes the 2026-05-16 broad local summary. Some
-native and cold render groups were noisy in this full workspace run; use the
-confidence intervals in `BENCHMARKS_RESULTS.md` for detailed comparisons.
+The initial full-workspace render rows from this refresh were rejected as a
+noisy local artifact and preserved only in `PERF_EXPERIMENTS.md`; the public
+render baseline uses the targeted rerun recorded in `BENCHMARKS_RESULTS.md`.
 
 ### Comparison with DjVuLibre
 
@@ -501,8 +503,8 @@ Current local matrix (2026-05-17):
 | Scenario | djvu-rs | DjVuLibre | Ratio |
 |----------|--------:|----------:|------:|
 | Small color IW44, 72 dpi | **246 µs** | **159 µs** | DjVuLibre **1.5x faster** |
-| Large color IW44, 150 dpi | **8.78 ms** | **5.96 ms** | DjVuLibre **1.5x faster** |
-| Native color corpus, 300 dpi | **151 ms** | **36.44 ms** | DjVuLibre **4.2x faster** |
+| Large color IW44, 150 dpi | **7.22 ms** | **5.96 ms** | DjVuLibre **1.2x faster** |
+| Native color corpus, 300 dpi | **71.2 ms** | **36.44 ms** | DjVuLibre **2.0x faster** |
 | Native bilevel JB2 corpus, 300 dpi | **75.45 ms** | **35.25 ms** | DjVuLibre **2.1x faster** |
 
 The same workflow also records `ddjvu` CLI timings for these files


### PR DESCRIPTION
## Summary
- mark the post-roadmap full-run render rows as a rejected/noisy artifact instead of public baseline claims
- replace README/BENCHMARKS render summary rows with targeted render rerun values on the same code
- record the correction and exact targeted commands in PERF_EXPERIMENTS.md

## Root cause
PR #335 accepted a full-workspace local Criterion artifact even though several render rows had implausible outliers. A targeted rerun of the same render filters on the same code returned the expected range, and no render-path behavioral code changed between the prior targeted baseline and the bad artifact.

## Validation
- cargo bench --bench render -- 'render_corpus_color|render_colorbook' --output-format bencher
- cargo bench --bench render -- 'render_page/dpi|render_corpus_bilevel|render_native_stages' --output-format bencher
- git diff --check
- cargo fmt --check
