### PR TITLE
Implement issues #320, #322, #325, #326

### DIFF
--- a/PERF_EXPERIMENTS.md
+++ b/PERF_EXPERIMENTS.md
@@ -5,6 +5,105 @@ numbers, decision, reason. Referenced from issue templates ("Record result
 in `PERF_EXPERIMENTS.md` (Kept or Reverted + reason)") and from
 `.github/workflows/bench.yml`.
 
+### Cross-size JB2 record-6 refinement emitter (#322) — **Reverted / kept disabled** (2026-06-15)
+
+**Issue.** #322: build an *experiment-only* cross-size record-6 refinement
+emitter behind a probe flag (`max_dim_delta = 2`, `max_hamming_fraction =
+0.05`), decode + pixel-compare on `watchmaker` and `pathogenic_bacteria_1896`,
+and record the real byte deltas + round-trip status. Keep
+`encode_djvm_bundle_jb2` (and the other shipped encoders) unchanged.
+
+**Approach.** Added `CrossSizeRec6Probe` to `Jb2EncodeOptions` (default `None`).
+When enabled, a fresh connected component with no exact dictionary hit searches
+dictionary entries whose bbox differs by ≤ `max_dim_delta` per axis, scores them
+with nearest-neighbor-resampled Hamming distance, and — if within the budget —
+emits a **lossless** record-6 matched refinement (`wdiff`/`hdiff` + 11-bit
+refinement bitmap against the chosen reference) instead of a record-1 new
+symbol. This required finishing the dormant `encode_bitmap_ref` helper: it was
+written in image (top-down) space, but the decoder's `decode_bitmap_ref` walks
+packed Jbm rows **bottom-up**, and the `>> 1` centre-alignment floor is not
+symmetric under that flip — so a non-solid refinement bitmap desynchronised the
+ZP stream (`UnknownRecordType` on decode). Rewriting the encoder to mirror the
+decoder's Jbm-row traversal exactly made it round-trip.
+
+**Numbers** (re-encoding existing page masks; baseline = shipped rec-1/7 only):
+
+| corpus | pages | pages changed | baseline | probe | delta | round-trip |
+|--------|-------|---------------|----------|-------|-------|------------|
+| watchmaker (all) | 12 | 12 | 130 036 B | 135 720 B | **+5 684 B (+4.37%)** | lossless |
+| pathogenic_bacteria_1896 (first 40) | 38 | 36 | 1 539 929 B | 1 543 596 B | **+3 667 B (+0.24%)** | lossless |
+
+**Decision.** Reverted as a shipping path; the probe stays `None` by default, so
+all shipped encoders (`encode_jb2_dict`, `encode_jb2_dict_with_shared`,
+`encode_djvm_bundle_jb2`) are byte-identical to before (asserted by
+`cross_size_rec6_probe_off_is_byte_identical`). Kept behind the flag with two
+round-trip regression tests and an `--ignored` corpus measurement driver
+(`cross_size_rec6_probe_corpus_measurement`).
+
+**Reason.** Cross-size refinement *loses* bytes on both corpora. A cross-size
+reference must be nearest-neighbor resampled before it can drive the refinement
+context; the geometric misalignment makes the 11-bit context mispredict, so the
+refinement bitmap costs nearly as much as a fresh direct symbol — and then adds
+the record-6 index + `wdiff`/`hdiff` overhead on top. It is also strictly worse
+than record-1 for *future* repeats, because record-6 is blit-only and never
+extends the dictionary, so a later exact copy of the same glyph can no longer
+hit rec-7. The earlier analysis-only scaffold's estimated deltas pointed the
+same way; this confirms it with real bytes. Net: not worth pursuing at these
+thresholds.
+
+### IW44 forward-transform reconstruction-loss localization (#320) — **Kept (diagnostic only)** (2026-06-15)
+
+**Issue.** #320: localize IW44 BG44 reconstruction loss on the photographic
+`conquete_paix` pages 3 & 11, among four candidate stages — forward wavelet
+transform, quantization threshold schedule, coefficient state transitions, and
+reconstruction tracking. Keep default encoder behavior unchanged.
+
+**Approach.** Added in-crate diagnostics (`src/iw44_encode.rs`, module
+`loss_diagnostics`):
+1. A full-precision i32 reference forward transform compared coefficient-wise
+   against the production i16 transform on the real page-3/11 luma planes, plus
+   a max-intermediate-magnitude probe for i16 headroom.
+2. Per-band reconstruction residual `Σ|blocks − recon|` vs band energy
+   `Σ|blocks|`, driving the real encoder slice loop, mapping each IW44 band to
+   its contiguous zigzag-coefficient range.
+
+**Numbers.**
+- *Forward transform:* production i16 transform equals the i32 reference
+  **exactly** (0 / 3.2 M coefficients diverge on p3, 0 / 3.3 M on p11). Largest
+  intermediate magnitude 6 845 (p3) / 11 378 (p11) ≪ `i16::MAX` (32 767) — no
+  overflow. The transform is lossless on these pages.
+- *Per-band residual after the default 100 slices (rel = resid/energy):*
+
+  | band | p3 rel | p11 rel |
+  |------|--------|---------|
+  | 0 (coarsest) | 23.0% | 17.6% |
+  | 3 | 59.4% | 25.5% |
+  | 6 | 99.8% | 65.7% |
+  | 9 (finest) | 100.0% | 99.9% |
+
+  Residual grows monotonically with frequency; band 9 `recon` is all-zero
+  (p3) or within 0.1% of it (p11) — never activated within budget.
+- *Pixel-domain floor (gray round-trip, 96×96 broadband):* avg abs error
+  plateaus at 8.72 from 200 slices onward (identical at 255) — not a
+  transform-pair mismatch but the refinement-schedule floor (`s>>1`, `s>>2`,
+  `s>>3` round to 0 at small steps, so refinement deltas vanish before `recon`
+  reaches `blocks`).
+
+**Decision.** Kept as diagnostics; **no encoder change**. Two regression tests
+(`forward_transform_is_lossless`, `loss_concentrates_in_high_frequency_bands`)
+plus an `--ignored` table dump (`print_band_table`).
+
+**Reason.** The loss is the progressive **quantization / slice budget**, not the
+forward transform, state transitions, or reconstruction tracking: the forward
+transform is bit-exact and overflow-free, and the coarse bands reconstruct
+correctly (which they could not if state/tracking were broken). The finest
+bands are simply starved — their small coefficients never cross the activation
+threshold within 100 slices. An earlier i32 reference falsely reported a
+forward-transform "divergence"; the bug was in the *reference* (it ran the
+column pass over every column instead of the `s·ℤ` multiresolution sublattice),
+not in production. Acting on quality would mean a different slice/quant schedule
+or budget, which is out of scope for this diagnostic-only issue.
+
 ### Post-roadmap render baseline correction — **Kept** (2026-05-17)
 
 **Approach.** Reran the render filters from #308 on the same code after the

--- a/docs/indirect-djvm-mutation.md
+++ b/docs/indirect-djvm-mutation.md
@@ -103,23 +103,71 @@ plan, destination policy, and atomic replacement behavior.
 
 ## Follow-Up Scope
 
-1. Add an indirect-to-bundled mutation constructor.
+1. Add an indirect-to-bundled mutation constructor. **(Implemented — #325.)**
    - Input: root DJVM bytes plus a resolver for DIRM component names.
    - Output: `DjVuDocumentMut` backed by a bundled DJVM tree.
    - Preserve current `IndirectDjvmUnsupported` behavior for plain
      `from_bytes`.
    - Cover resolver errors, missing components, and successful page metadata or
      text-layer mutation.
+   - Shipped as
+     [`DjVuDocumentMut::from_indirect_resolved`](../src/djvu_mut.rs). It resolves
+     every `DIRM` component, validates each is a `FORM:DJVU`/`DJVI`/`THUM`,
+     reuses the original BZZ directory metadata while flipping the bundled bit
+     and recomputing the offset table, and returns a side-effect-free bundled
+     byte stream from `try_into_bytes`.
 
 2. Add an explicit external-file rewrite API only after the rebundling path is
-   shipped.
+   shipped. **(Implemented — #326.)**
    - Expose a write plan before commit.
    - Require a destination directory or per-component writer.
    - Stage temporary files and document atomicity guarantees.
    - Reject unsafe or duplicate DIRM names.
+   - Shipped as
+     [`IndirectRewritePlan`](../src/djvu_mut.rs); see
+     [External-File Rewrite Path](#external-file-rewrite-path-326) below.
+
+## External-File Rewrite Path (#326)
+
+`IndirectRewritePlan` implements the second strategy: it keeps the document
+indirect and writes edits back to per-component files, rather than collapsing
+everything into one bundled stream.
+
+How it differs from the rebundled-output path:
+
+| | `DjVuDocumentMut::from_indirect_resolved` | `IndirectRewritePlan` |
+|---|---|---|
+| Output | one bundled `FORM:DJVM` byte stream | a directory of component files + index |
+| Side effects | none (`try_into_bytes` returns bytes) | files written by `commit_to_dir` |
+| Caller policy | none | destination dir, file names, atomicity |
+| Document shape | becomes bundled | stays indirect |
+
+Commit protocol:
+
+- Edits are staged in memory (`edit_page`, `set_bookmarks`); nothing is written
+  during setters.
+- `plan(root_name)` previews every file a commit will write and flags which
+  changed.
+- `commit_to_dir(dir, root_name)` validates all names first (so an invalid
+  request leaves the destination untouched), then writes each component and the
+  root index by staging a sibling temp file and atomically renaming it into
+  place. The root index is written last.
+
+Name safety: component ids and the root name must be safe *flat* relative names
+— no path separators, `.`/`..`, drive/stream colon, or NUL — so a rewrite can
+never escape the destination directory. Duplicate names (including a root name
+colliding with a component) are rejected.
+
+Atomicity: each individual file is replaced atomically on platforms with
+same-directory atomic rename. The multi-file commit as a whole is **not**
+transactional — a crash mid-commit can leave a mix of old and new component
+files. Because indirect components are independent, self-describing page files,
+each remains individually valid; callers needing all-or-nothing semantics should
+commit to a fresh directory and swap it in.
 
 ## Current Unsupported Behavior
 
-Until the first follow-up lands, mutation of indirect DJVM documents is not
-supported. Callers should either edit the individual page files directly or
-create a bundled DJVM first.
+In-place mutation through the plain `DjVuDocumentMut::from_bytes` entry point
+remains unsupported for indirect DJVM documents (`page_mut` returns
+`IndirectDjvmUnsupported`). Use `from_indirect_resolved` for a bundled result,
+or `IndirectRewritePlan` to rewrite the external component files.

--- a/src/djvu_document.rs
+++ b/src/djvu_document.rs
@@ -1324,6 +1324,41 @@ struct DirmEntry {
     id: String,
 }
 
+/// One resolved DIRM component descriptor exposed to the mutation layer.
+///
+/// `id` is the directory entry id passed to a resolver to fetch the component
+/// bytes; `is_page` is `true` for `Page` components and `false` for shared
+/// (`DJVI`) or thumbnail components.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub(crate) struct DirmComponentInfo {
+    /// Resolver key / component id (the first DIRM string field).
+    pub id: String,
+    /// Whether this component is a page (`ComponentType::Page`).
+    pub is_page: bool,
+}
+
+/// Parse a DIRM chunk's component directory for the mutation layer.
+///
+/// Returns `(components, is_bundled)` in DIRM declaration order. This is a thin
+/// wrapper over [`parse_dirm`] that drops the bundled offset table (callers that
+/// rebundle recompute offsets) and exposes only the fields needed to resolve and
+/// re-assemble components.
+#[cfg(feature = "std")]
+pub(crate) fn parse_dirm_components(
+    data: &[u8],
+) -> Result<(Vec<DirmComponentInfo>, bool), DocError> {
+    let (entries, is_bundled, _offsets) = parse_dirm(data)?;
+    let components = entries
+        .into_iter()
+        .map(|e| DirmComponentInfo {
+            id: e.id,
+            is_page: e.comp_type == ComponentType::Page,
+        })
+        .collect();
+    Ok((components, is_bundled))
+}
+
 /// Parse the DIRM chunk (directory of files in FORM:DJVM).
 ///
 /// Returns `(entries, is_bundled, offsets)`. `offsets` is non-empty only for

--- a/src/djvu_mut.rs
+++ b/src/djvu_mut.rs
@@ -8,9 +8,16 @@
 //! setters are available for page text, annotations, metadata, and bundled-DJVM
 //! bookmarks.
 //!
-//! Indirect `FORM:DJVM` mutation remains unsupported because it requires a
-//! concrete external-file rewrite or re-bundle policy; see
-//! [`docs/indirect-djvm-mutation.md`](../docs/indirect-djvm-mutation.md).
+//! Indirect `FORM:DJVM` mutation via the plain
+//! [`from_bytes`](crate::djvu_mut::DjVuDocumentMut::from_bytes) entry point
+//! remains unsupported ([`page_mut`](crate::djvu_mut::DjVuDocumentMut::page_mut)
+//! returns [`MutError::IndirectDjvmUnsupported`]). To edit an indirect document,
+//! use [`from_indirect_resolved`](crate::djvu_mut::DjVuDocumentMut::from_indirect_resolved),
+//! which resolves the external components and rebundles them into an owned
+//! bundled `FORM:DJVM` tree; see
+//! [`docs/indirect-djvm-mutation.md`](../docs/indirect-djvm-mutation.md). The
+//! explicit external-file rewrite path is provided separately by
+//! [`IndirectRewritePlan`](crate::djvu_mut::IndirectRewritePlan).
 //!
 //! ## Example
 //!
@@ -130,6 +137,61 @@ pub enum MutError {
     /// NAVM bookmarks live in `FORM:DJVM` bundles only.
     #[error("set_bookmarks requires a FORM:DJVM bundle (this document is FORM:DJVU)")]
     BookmarksRequireDjvm,
+
+    /// [`DjVuDocumentMut::from_indirect_resolved`] was called on a document
+    /// that is not an indirect `FORM:DJVM` (it is single-page `FORM:DJVU` or an
+    /// already-bundled `FORM:DJVM`). Use [`DjVuDocumentMut::from_bytes`] for
+    /// those — only indirect bundles need resolver-backed rebundling.
+    #[error("from_indirect_resolved requires an indirect FORM:DJVM document")]
+    NotIndirectDjvm,
+
+    /// A DIRM component could not be obtained from the caller-provided resolver
+    /// (the resolver returned an error or no bytes for this component name).
+    #[error("resolver did not supply DIRM component {name:?}")]
+    ComponentResolve {
+        /// The DIRM component id passed to the resolver.
+        name: String,
+    },
+
+    /// A resolved DIRM component did not parse as a `FORM:DJVU`/`FORM:DJVI`/
+    /// `FORM:THUM` chunk, so it cannot be embedded in a bundled output.
+    #[error("DIRM component {name:?} is malformed: {reason}")]
+    ComponentMalformed {
+        /// The DIRM component id that failed to parse.
+        name: String,
+        /// Why the component bytes were rejected.
+        reason: &'static str,
+    },
+
+    /// A DIRM component name (or the root index name) is not a safe relative
+    /// file name and was rejected by the external-file rewrite path. Absolute
+    /// paths, names with path separators, drive letters, `.`/`..`, and embedded
+    /// NUL bytes are all rejected so a rewrite can never escape the destination
+    /// directory.
+    #[error("unsafe component file name {name:?}: {reason}")]
+    UnsafeComponentName {
+        /// The offending name.
+        name: String,
+        /// Why it was rejected.
+        reason: &'static str,
+    },
+
+    /// Two DIRM entries resolve to the same component file name, which would
+    /// make an external-file rewrite ambiguous (one file would shadow another).
+    #[error("duplicate DIRM component file name {name:?}")]
+    DuplicateComponentName {
+        /// The duplicated name.
+        name: String,
+    },
+
+    /// A filesystem error occurred while committing an external-file rewrite.
+    #[error("rewrite I/O error for {name:?}: {message}")]
+    RewriteIo {
+        /// The file the error is associated with.
+        name: String,
+        /// The underlying error message.
+        message: String,
+    },
 }
 
 /// A DjVu document opened for in-place mutation.
@@ -160,6 +222,127 @@ impl DjVuDocumentMut {
         Ok(Self {
             file,
             original_bytes: data.to_vec(),
+            dirty: false,
+        })
+    }
+
+    /// Resolve an indirect `FORM:DJVM` document into an owned **bundled**
+    /// mutation tree, fetching every external component through `resolver`.
+    ///
+    /// An indirect DJVM stores only a `DIRM` directory in `root_bytes`; the
+    /// page (and shared-dictionary / thumbnail) component bytes live in
+    /// separate files. [`Self::from_bytes`] keeps indirect documents
+    /// unsupported because in-place editing would also need those external
+    /// files rewritten. This constructor instead implements the *rebundling*
+    /// strategy from [`docs/indirect-djvm-mutation.md`](../docs/indirect-djvm-mutation.md):
+    /// it resolves each `DIRM` component (in declaration order), embeds them
+    /// into a single bundled `FORM:DJVM`, and returns a [`DjVuDocumentMut`]
+    /// whose [`Self::try_into_bytes`] yields one self-contained bundled byte
+    /// stream that no longer needs a resolver.
+    ///
+    /// The resolver is called once per `DIRM` entry with that entry's id (the
+    /// same key [`crate::djvu_document::DjVuDocument::parse_with_resolver`]
+    /// uses) and must return the raw bytes of that component file. Returning an
+    /// error for any component aborts the whole construction.
+    ///
+    /// After construction the returned handle behaves like any bundled
+    /// `FORM:DJVM`: [`Self::page_mut`], [`Self::set_bookmarks`], and
+    /// [`Self::try_into_bytes`] all work, with `DIRM` offsets recomputed on
+    /// serialisation.
+    ///
+    /// # Errors
+    ///
+    /// - [`MutError::NotIndirectDjvm`] if `root_bytes` is not an indirect
+    ///   `FORM:DJVM` (single-page `FORM:DJVU` or an already-bundled bundle).
+    /// - [`MutError::ComponentResolve`] if the resolver fails for a component.
+    /// - [`MutError::ComponentMalformed`] if a resolved component does not parse
+    ///   as a `FORM:DJVU`/`DJVI`/`THUM`.
+    /// - [`MutError::DirmMalformed`] if the `DIRM` chunk cannot be read.
+    /// - [`MutError::InfoParse`] if `root_bytes` is not a parseable IFF FORM.
+    pub fn from_indirect_resolved<R, E>(root_bytes: &[u8], resolver: R) -> Result<Self, MutError>
+    where
+        R: Fn(&str) -> Result<Vec<u8>, E>,
+    {
+        let form = iff::parse_form(root_bytes)?;
+        if &form.form_type != b"DJVM" {
+            return Err(MutError::NotIndirectDjvm);
+        }
+        let dirm = form
+            .chunks
+            .iter()
+            .find(|c| &c.id == b"DIRM")
+            .ok_or(MutError::DirmMalformed("indirect DJVM has no DIRM chunk"))?;
+
+        let (components, is_bundled) = crate::djvu_document::parse_dirm_components(dirm.data)
+            .map_err(|_| MutError::DirmMalformed("DIRM directory could not be parsed"))?;
+        if is_bundled {
+            // Already bundled — no external files to resolve; from_bytes works.
+            return Err(MutError::NotIndirectDjvm);
+        }
+        if components.is_empty() {
+            return Err(MutError::DirmMalformed("indirect DIRM lists no components"));
+        }
+        if !components.iter().any(|c| c.is_page) {
+            return Err(MutError::DirmMalformed(
+                "indirect DIRM lists no page component",
+            ));
+        }
+
+        // Resolve every component (page + shared + thumbnail) in DIRM order and
+        // parse each into its owned FORM subtree.
+        let mut component_forms: Vec<Chunk> = Vec::with_capacity(components.len());
+        for comp in &components {
+            let bytes = resolver(&comp.id).map_err(|_| MutError::ComponentResolve {
+                name: comp.id.clone(),
+            })?;
+            let parsed = iff::parse(&bytes).map_err(|_| MutError::ComponentMalformed {
+                name: comp.id.clone(),
+                reason: "not a parseable IFF document",
+            })?;
+            match &parsed.root {
+                Chunk::Form { secondary_id, .. }
+                    if secondary_id == b"DJVU"
+                        || secondary_id == b"DJVI"
+                        || secondary_id == b"THUM" => {}
+                _ => {
+                    return Err(MutError::ComponentMalformed {
+                        name: comp.id.clone(),
+                        reason: "root is not a FORM:DJVU/DJVI/THUM",
+                    });
+                }
+            }
+            component_forms.push(parsed.root);
+        }
+
+        // Convert the indirect DIRM into a bundled one: flip the bundled bit,
+        // splice in a zeroed offset table (recomputed below), and keep the
+        // BZZ-compressed metadata tail verbatim so component ids / names /
+        // flags survive the round-trip.
+        let bundled_dirm = bundled_dirm_from_indirect(dirm.data, component_forms.len())?;
+
+        // Assemble the bundled FORM:DJVM tree: DIRM first, then components in
+        // DIRM order. `length` is recomputed by `iff::emit`.
+        let mut children: Vec<Chunk> = Vec::with_capacity(1 + component_forms.len());
+        children.push(Chunk::Leaf {
+            id: *b"DIRM",
+            data: bundled_dirm,
+        });
+        children.extend(component_forms);
+        let mut file = DjvuFile {
+            root: Chunk::Form {
+                secondary_id: *b"DJVM",
+                length: 0,
+                children,
+            },
+        };
+
+        // Fill the DIRM offset table for the about-to-be-emitted layout, then
+        // freeze the bundled bytes as this document's canonical (unedited) form.
+        recompute_dirm_offsets(&mut file.root)?;
+        let bundled_bytes = iff::emit(&file);
+        Ok(Self {
+            file,
+            original_bytes: bundled_bytes,
             dirty: false,
         })
     }
@@ -432,6 +615,31 @@ impl DjVuDocumentMut {
         self.dirty = true;
         Ok(())
     }
+}
+
+/// Convert an indirect `DIRM` payload into the bundled form expected by a
+/// rebundled `FORM:DJVM`.
+///
+/// Indirect and bundled DIRM share the same `[flags][nfiles:u16][BZZ meta]`
+/// framing; bundled documents additionally carry a `4 × nfiles` offset table
+/// between `nfiles` and the BZZ metadata. This sets the bundled flag bit, splices
+/// a zeroed offset table (filled later by [`recompute_dirm_offsets`]), and keeps
+/// the original BZZ metadata tail verbatim — preserving component ids, names,
+/// titles, and per-component flags.
+fn bundled_dirm_from_indirect(indirect: &[u8], nfiles: usize) -> Result<Vec<u8>, MutError> {
+    if indirect.len() < 3 {
+        return Err(MutError::DirmMalformed("indirect DIRM payload < 3 bytes"));
+    }
+    let table_len = 4usize
+        .checked_mul(nfiles)
+        .ok_or(MutError::DirmMalformed("DIRM offset table size overflow"))?;
+    let mut out = Vec::with_capacity(3 + table_len + (indirect.len() - 3));
+    out.push(indirect[0] | 0x80); // set the bundled bit
+    out.push(indirect[1]);
+    out.push(indirect[2]);
+    out.extend(core::iter::repeat_n(0u8, table_len)); // offsets recomputed later
+    out.extend_from_slice(&indirect[3..]); // BZZ metadata tail, unchanged
+    Ok(out)
 }
 
 /// Whether `chunk` is a bundled (rather than indirect) `FORM:DJVM`.
@@ -762,6 +970,383 @@ impl PageMut<'_> {
     fn replace_or_insert_text(&mut self, data: Vec<u8>) {
         self.replace_or_insert(b"TXTa", b"TXTz", data);
     }
+}
+
+// ---- #326: explicit external-file rewrite plan for indirect DJVM -----------
+
+/// One entry in an [`IndirectRewritePlan`] preview, describing a file the plan
+/// will touch on commit.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RewriteItem {
+    /// The file name (relative to the destination directory). For the root
+    /// index this is the name passed to [`IndirectRewritePlan::commit_to_dir`].
+    pub name: String,
+    /// Whether this is the root DJVM index file (`true`) or a page/shared
+    /// component (`false`).
+    pub is_root: bool,
+    /// Whether this file's bytes differ from the resolved original — i.e.
+    /// whether an edit changed it. Unchanged files are still (re)written on
+    /// commit so the destination directory holds a complete component set.
+    pub changed: bool,
+}
+
+/// One resolved component staged inside an [`IndirectRewritePlan`].
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+struct PlannedComponent {
+    /// DIRM component id, used both as the resolver key and the external file
+    /// name. Validated to be a safe relative file name at construction.
+    name: String,
+    /// Whether this component is a page (vs. shared dictionary / thumbnail).
+    is_page: bool,
+    /// The bytes originally returned by the resolver.
+    original: Vec<u8>,
+    /// Edited bytes, if a page edit changed this component.
+    edited: Option<Vec<u8>>,
+}
+
+/// A staged, side-effect-free plan to rewrite an **indirect** `FORM:DJVM`
+/// document across its external component files.
+///
+/// This is the explicit multi-file counterpart to
+/// [`DjVuDocumentMut::from_indirect_resolved`]. Where `from_indirect_resolved`
+/// collapses an indirect document into a single self-contained **bundled**
+/// byte stream (no destination policy needed), `IndirectRewritePlan` keeps the
+/// document **indirect**: each page stays in its own external file, and edits
+/// are written back to per-component files in a destination directory.
+///
+/// The two paths differ deliberately:
+///
+/// | | `from_indirect_resolved` | `IndirectRewritePlan` |
+/// |---|---|---|
+/// | Output | one bundled DJVM byte stream | a directory of component files + index |
+/// | Side effects | none (`try_into_bytes` returns bytes) | files written on `commit_to_dir` |
+/// | Caller policy | none | destination dir, file names, atomicity |
+/// | Document shape | becomes bundled | stays indirect |
+///
+/// # Mutation model
+///
+/// Edits never touch the filesystem. They are staged in memory via
+/// [`Self::edit_page`] / [`Self::set_bookmarks`] and only written when
+/// [`Self::commit_to_dir`] is called. Call [`Self::plan`] at any time to
+/// preview exactly which files a commit will write and which have changed.
+///
+/// # Name safety
+///
+/// Every DIRM component id (and the root index name supplied at commit) must be
+/// a safe *flat* relative file name: no path separators, no `.`/`..`, no
+/// drive-letter `:`/absolute path, no embedded NUL. Names that could escape the
+/// destination directory are rejected with [`MutError::UnsafeComponentName`];
+/// two entries mapping to one file name are rejected with
+/// [`MutError::DuplicateComponentName`]. Both checks run at construction, so an
+/// invalid directory can never reach the write phase. Nested component
+/// sub-directories are intentionally not supported by this path.
+///
+/// # Atomicity
+///
+/// Each file is written by staging a sibling temporary file in the destination
+/// directory and atomically renaming it over the target, so a reader never sees
+/// a half-written component file (on platforms where same-directory rename is
+/// atomic — POSIX and modern Windows `ReplaceFile`/`rename`). The root index is
+/// written **last**.
+///
+/// What is **not** guaranteed: the multi-file commit is not transactional. A
+/// crash partway through can leave some component files updated and others not.
+/// Because indirect components are independent, self-describing page files
+/// (the index lists names, not byte offsets), every individual file remains a
+/// valid DjVu page either way — but the document set as a whole may be a mix of
+/// old and new pages until the commit finishes. Callers needing cross-file
+/// atomicity should commit to a fresh directory and swap it in themselves.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct IndirectRewritePlan {
+    /// The current (possibly edited) root index bytes.
+    root_bytes: Vec<u8>,
+    /// Whether the root index has been edited since construction.
+    root_changed: bool,
+    components: Vec<PlannedComponent>,
+}
+
+#[cfg(feature = "std")]
+impl IndirectRewritePlan {
+    /// Resolve an indirect `FORM:DJVM` document into a rewrite plan, fetching
+    /// every external component through `resolver`.
+    ///
+    /// The resolver is called once per `DIRM` entry with that entry's id (the
+    /// same key [`DjVuDocumentMut::from_indirect_resolved`] uses), which is also
+    /// the external file name the component will be written back to.
+    ///
+    /// # Errors
+    ///
+    /// - [`MutError::NotIndirectDjvm`] if `root_bytes` is not an indirect
+    ///   `FORM:DJVM`.
+    /// - [`MutError::UnsafeComponentName`] / [`MutError::DuplicateComponentName`]
+    ///   if a DIRM component id is not a safe, unique flat file name.
+    /// - [`MutError::ComponentResolve`] if the resolver fails for a component.
+    /// - [`MutError::ComponentMalformed`] if a resolved component does not parse
+    ///   as a `FORM:DJVU`/`DJVI`/`THUM`.
+    /// - [`MutError::DirmMalformed`] / [`MutError::InfoParse`] if the index or its
+    ///   `DIRM` chunk cannot be read.
+    pub fn from_indirect_resolved<R, E>(root_bytes: &[u8], resolver: R) -> Result<Self, MutError>
+    where
+        R: Fn(&str) -> Result<Vec<u8>, E>,
+    {
+        let form = iff::parse_form(root_bytes)?;
+        if &form.form_type != b"DJVM" {
+            return Err(MutError::NotIndirectDjvm);
+        }
+        let dirm = form
+            .chunks
+            .iter()
+            .find(|c| &c.id == b"DIRM")
+            .ok_or(MutError::DirmMalformed("indirect DJVM has no DIRM chunk"))?;
+        let (infos, is_bundled) = crate::djvu_document::parse_dirm_components(dirm.data)
+            .map_err(|_| MutError::DirmMalformed("DIRM directory could not be parsed"))?;
+        if is_bundled {
+            return Err(MutError::NotIndirectDjvm);
+        }
+        if infos.is_empty() {
+            return Err(MutError::DirmMalformed("indirect DIRM lists no components"));
+        }
+
+        // Validate every component file name up front: safe + unique. This runs
+        // before any resolution or write, so an invalid directory is rejected
+        // without side effects.
+        let mut seen = std::collections::HashSet::new();
+        for info in &infos {
+            validate_safe_component_name(&info.id)?;
+            if !seen.insert(info.id.clone()) {
+                return Err(MutError::DuplicateComponentName {
+                    name: info.id.clone(),
+                });
+            }
+        }
+
+        let mut components = Vec::with_capacity(infos.len());
+        for info in &infos {
+            let bytes = resolver(&info.id).map_err(|_| MutError::ComponentResolve {
+                name: info.id.clone(),
+            })?;
+            // Validate the bytes parse as a component FORM so later commits never
+            // write a file we already know is malformed.
+            let parsed = iff::parse(&bytes).map_err(|_| MutError::ComponentMalformed {
+                name: info.id.clone(),
+                reason: "not a parseable IFF document",
+            })?;
+            match &parsed.root {
+                Chunk::Form { secondary_id, .. }
+                    if secondary_id == b"DJVU"
+                        || secondary_id == b"DJVI"
+                        || secondary_id == b"THUM" => {}
+                _ => {
+                    return Err(MutError::ComponentMalformed {
+                        name: info.id.clone(),
+                        reason: "root is not a FORM:DJVU/DJVI/THUM",
+                    });
+                }
+            }
+            components.push(PlannedComponent {
+                name: info.id.clone(),
+                is_page: info.is_page,
+                original: bytes,
+                edited: None,
+            });
+        }
+
+        Ok(Self {
+            root_bytes: root_bytes.to_vec(),
+            root_changed: false,
+            components,
+        })
+    }
+
+    /// Number of page components in the document (shared dictionaries and
+    /// thumbnails are not counted).
+    pub fn page_count(&self) -> usize {
+        self.components.iter().filter(|c| c.is_page).count()
+    }
+
+    /// Total number of components (pages + shared dictionaries + thumbnails).
+    pub fn component_count(&self) -> usize {
+        self.components.len()
+    }
+
+    /// Edit the `index`-th page component in memory.
+    ///
+    /// The closure receives a [`DjVuDocumentMut`] opened on that page's current
+    /// (possibly already-edited) bytes — a single-page `FORM:DJVU`, so
+    /// `doc.page_mut(0)` exposes the usual `set_text_layer` / `set_metadata` /
+    /// `set_annotations` setters. Nothing is written to disk; the resulting
+    /// bytes are staged for the next [`Self::commit_to_dir`].
+    ///
+    /// # Errors
+    ///
+    /// - [`MutError::PageOutOfRange`] if `index >= self.page_count()`.
+    /// - Any [`MutError`] returned by the closure or by re-serialising the page.
+    pub fn edit_page<F>(&mut self, index: usize, edit: F) -> Result<(), MutError>
+    where
+        F: FnOnce(&mut DjVuDocumentMut) -> Result<(), MutError>,
+    {
+        let count = self.page_count();
+        let comp = self
+            .components
+            .iter_mut()
+            .filter(|c| c.is_page)
+            .nth(index)
+            .ok_or(MutError::PageOutOfRange { index, count })?;
+        let current: &[u8] = comp.edited.as_deref().unwrap_or(&comp.original);
+        let mut doc = DjVuDocumentMut::from_bytes(current)?;
+        edit(&mut doc)?;
+        if doc.is_dirty() {
+            comp.edited = Some(doc.try_into_bytes()?);
+        }
+        Ok(())
+    }
+
+    /// Replace, insert, or remove the document's `NAVM` bookmarks in the root
+    /// index file. The edit is staged in memory and written on commit; only the
+    /// root index file changes (bookmarks live in the index, not page files).
+    pub fn set_bookmarks(&mut self, bookmarks: &[DjVuBookmark]) -> Result<(), MutError> {
+        let mut root = DjVuDocumentMut::from_bytes(&self.root_bytes)?;
+        root.set_bookmarks(bookmarks)?;
+        if root.is_dirty() {
+            self.root_bytes = root.try_into_bytes()?;
+            self.root_changed = true;
+        }
+        Ok(())
+    }
+
+    /// Preview the files a [`Self::commit_to_dir`] will write, in commit order
+    /// (every component, then the root index). `changed` flags which files
+    /// differ from their resolved originals.
+    ///
+    /// `root_name` is the file name the root index will be written under; it is
+    /// reported as the final, `is_root` item but is **not** validated here (that
+    /// happens at commit).
+    pub fn plan(&self, root_name: &str) -> Vec<RewriteItem> {
+        let mut items: Vec<RewriteItem> = self
+            .components
+            .iter()
+            .map(|c| RewriteItem {
+                name: c.name.clone(),
+                is_root: false,
+                changed: c.edited.is_some(),
+            })
+            .collect();
+        items.push(RewriteItem {
+            name: root_name.to_string(),
+            is_root: true,
+            changed: self.root_changed,
+        });
+        items
+    }
+
+    /// Commit the plan: write the full indirect document set (every component
+    /// plus the root index) into `dir`, staging each file as a sibling temporary
+    /// file and atomically renaming it into place. The root index is written
+    /// last.
+    ///
+    /// All name validation happens before the first byte is written, so a
+    /// validation failure (e.g. an unsafe `root_name`) leaves `dir` untouched.
+    /// Returns the absolute paths written, in the same order as [`Self::plan`].
+    ///
+    /// See the type-level docs for the atomicity guarantees and their limits.
+    pub fn commit_to_dir(
+        &self,
+        dir: impl AsRef<std::path::Path>,
+        root_name: &str,
+    ) -> Result<Vec<std::path::PathBuf>, MutError> {
+        let dir = dir.as_ref();
+
+        // ---- Validate everything before writing anything --------------------
+        validate_safe_component_name(root_name)?;
+        // Component names were validated at construction, but the root name must
+        // also not collide with a component file.
+        if self.components.iter().any(|c| c.name == root_name) {
+            return Err(MutError::DuplicateComponentName {
+                name: root_name.to_string(),
+            });
+        }
+
+        std::fs::create_dir_all(dir).map_err(|e| MutError::RewriteIo {
+            name: dir.display().to_string(),
+            message: e.to_string(),
+        })?;
+
+        // ---- Write component files, then the root index ---------------------
+        let mut written = Vec::with_capacity(self.components.len() + 1);
+        for comp in &self.components {
+            let bytes = comp.edited.as_deref().unwrap_or(&comp.original);
+            written.push(stage_and_rename(dir, &comp.name, bytes)?);
+        }
+        written.push(stage_and_rename(dir, root_name, &self.root_bytes)?);
+        Ok(written)
+    }
+}
+
+/// Reject any component / index name that is not a safe flat relative file name.
+///
+/// Permitted names are non-empty, contain no path separator (`/` or `\\`), no
+/// drive/ADS colon, no NUL, and are not `.` or `..`. This guarantees a write can
+/// never escape the destination directory.
+#[cfg(feature = "std")]
+fn validate_safe_component_name(name: &str) -> Result<(), MutError> {
+    let reject = |reason: &'static str| {
+        Err(MutError::UnsafeComponentName {
+            name: name.to_string(),
+            reason,
+        })
+    };
+    if name.is_empty() {
+        return reject("name is empty");
+    }
+    if name.contains('\0') {
+        return reject("name contains a NUL byte");
+    }
+    if name.contains('/') || name.contains('\\') {
+        return reject("name contains a path separator");
+    }
+    if name.contains(':') {
+        return reject("name contains a drive-letter / stream colon");
+    }
+    if name == "." || name == ".." {
+        return reject("name is a relative directory reference");
+    }
+    Ok(())
+}
+
+/// Write `bytes` to `dir/name` by staging a sibling temp file and atomically
+/// renaming it over the target. Returns the final path.
+#[cfg(feature = "std")]
+fn stage_and_rename(
+    dir: &std::path::Path,
+    name: &str,
+    bytes: &[u8],
+) -> Result<std::path::PathBuf, MutError> {
+    use std::io::Write;
+
+    let final_path = dir.join(name);
+    // A stable, collision-resistant-enough temp name in the same directory so
+    // the rename stays on one filesystem (and is therefore atomic).
+    let tmp_path = dir.join(format!(".{name}.djvu-rs.tmp"));
+
+    let io_err = |path: &std::path::Path, e: std::io::Error| MutError::RewriteIo {
+        name: path.display().to_string(),
+        message: e.to_string(),
+    };
+
+    {
+        let mut f = std::fs::File::create(&tmp_path).map_err(|e| io_err(&tmp_path, e))?;
+        f.write_all(bytes).map_err(|e| io_err(&tmp_path, e))?;
+        f.sync_all().map_err(|e| io_err(&tmp_path, e))?;
+    }
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        // Best-effort cleanup of the temp file on rename failure.
+        let _ = std::fs::remove_file(&tmp_path);
+        io_err(&final_path, e)
+    })?;
+    Ok(final_path)
 }
 
 #[cfg(test)]
@@ -1490,6 +2075,397 @@ mod tests {
                 "FORM at top-level child #{i} must be byte-identical after edit"
             );
         }
+    }
+
+    // ---- #325: resolver-backed indirect DJVM rebundling -------------------
+
+    /// Build an indirect FORM:DJVM index over `page_names` and a resolver that
+    /// serves each named fixture from `tests/fixtures`.
+    fn indirect_over_fixtures(
+        page_names: &[&str],
+    ) -> (
+        Vec<u8>,
+        impl Fn(&str) -> Result<Vec<u8>, std::io::Error> + use<>,
+    ) {
+        let index = crate::djvm::create_indirect(page_names).expect("create_indirect");
+        // Snapshot the fixture bytes keyed by name so the resolver is owned.
+        let map: std::collections::HashMap<String, Vec<u8>> = page_names
+            .iter()
+            .map(|n| (n.to_string(), read_corpus(n)))
+            .collect();
+        let resolver = move |name: &str| -> Result<Vec<u8>, std::io::Error> {
+            map.get(name).cloned().ok_or_else(|| {
+                std::io::Error::new(std::io::ErrorKind::NotFound, "no such component")
+            })
+        };
+        (index, resolver)
+    }
+
+    #[test]
+    fn from_indirect_resolved_rebundles_single_page() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu"]);
+        let doc = DjVuDocumentMut::from_indirect_resolved(&index, resolver).unwrap();
+        assert_eq!(doc.root_form_type(), Some(b"DJVM"));
+        assert_eq!(doc.page_count(), 1);
+        assert!(!doc.is_dirty());
+
+        // Output must parse as a bundled DJVM without any resolver.
+        let bundled = doc.try_into_bytes().unwrap();
+        let reparsed =
+            crate::djvu_document::DjVuDocument::parse(&bundled).expect("bundled output parses");
+        assert_eq!(reparsed.page_count(), 1);
+        // The single page's pixel dimensions come from the resolved chicken.djvu.
+        assert_eq!(reparsed.page(0).unwrap().width(), 181);
+        assert_eq!(reparsed.page(0).unwrap().height(), 240);
+
+        // DIRM offsets must point at the actual component FORM positions.
+        let (declared, actual) = dirm_offsets_and_actual(&bundled);
+        assert_eq!(declared, actual);
+    }
+
+    #[test]
+    fn from_indirect_resolved_multi_page_preserves_order() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu", "irish.djvu"]);
+        let doc = DjVuDocumentMut::from_indirect_resolved(&index, resolver).unwrap();
+        assert_eq!(doc.page_count(), 2);
+        let bundled = doc.try_into_bytes().unwrap();
+
+        let reparsed = crate::djvu_document::DjVuDocument::parse(&bundled).expect("parses");
+        assert_eq!(reparsed.page_count(), 2);
+        // Page 0 == chicken (181x240), page 1 == irish (different size).
+        assert_eq!(reparsed.page(0).unwrap().width(), 181);
+        let irish_doc = crate::djvu_document::DjVuDocument::parse(&read_corpus("irish.djvu"))
+            .expect("irish parses standalone");
+        assert_eq!(
+            reparsed.page(1).unwrap().dimensions(),
+            irish_doc.page(0).unwrap().dimensions()
+        );
+
+        let (declared, actual) = dirm_offsets_and_actual(&bundled);
+        assert_eq!(declared, actual);
+    }
+
+    #[test]
+    fn from_indirect_resolved_then_metadata_edit_roundtrips() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu", "irish.djvu"]);
+        let mut doc = DjVuDocumentMut::from_indirect_resolved(&index, resolver).unwrap();
+
+        let meta = DjVuMetadata {
+            title: Some("rebundled indirect".into()),
+            author: Some("djvu-rs #325".into()),
+            ..Default::default()
+        };
+        doc.page_mut(1).unwrap().set_metadata(&meta);
+        assert!(doc.is_dirty());
+        let edited = doc.into_bytes();
+
+        // Offsets stay consistent after the page-1 metadata grows.
+        let (declared, actual) = dirm_offsets_and_actual(&edited);
+        assert_eq!(declared, actual);
+
+        // Metadata round-trips through the high-level parser on the edited page.
+        let reparsed = DjVuDocumentMut::from_bytes(&edited).unwrap();
+        let mut djvu_seen = 0usize;
+        let mut found = None;
+        for child in reparsed.file.root.children() {
+            if let Chunk::Form {
+                secondary_id,
+                children,
+                ..
+            } = child
+                && secondary_id == b"DJVU"
+            {
+                if djvu_seen == 1 {
+                    found = children
+                        .iter()
+                        .find(|c| matches!(c, Chunk::Leaf { id, .. } if id == b"METz"))
+                        .map(|c| c.data().to_vec());
+                    break;
+                }
+                djvu_seen += 1;
+            }
+        }
+        let metz = found.expect("page 1 should have METz after edit");
+        let parsed = crate::metadata::parse_metadata_bzz(&metz).unwrap();
+        assert_eq!(parsed.title.as_deref(), Some("rebundled indirect"));
+    }
+
+    #[test]
+    fn from_indirect_resolved_then_text_layer_edit() {
+        use crate::text::{Rect, TextLayer, TextZone, TextZoneKind};
+
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu"]);
+        let mut doc = DjVuDocumentMut::from_indirect_resolved(&index, resolver).unwrap();
+        let layer = TextLayer {
+            text: "rebundled text".into(),
+            zones: vec![TextZone {
+                kind: TextZoneKind::Page,
+                rect: Rect {
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 50,
+                },
+                text: "rebundled text".into(),
+                children: vec![],
+            }],
+        };
+        doc.page_mut(0).unwrap().set_text_layer(&layer).unwrap();
+        let edited = doc.into_bytes();
+
+        let reparsed = crate::djvu_document::DjVuDocument::parse(&edited).expect("parses");
+        let text = reparsed.page(0).unwrap().text_layer().unwrap();
+        assert!(text.is_some(), "edited page should expose a text layer");
+        assert_eq!(text.unwrap().text, "rebundled text");
+    }
+
+    #[test]
+    fn from_indirect_resolved_missing_component_errors() {
+        // Resolver that never produces bytes ⇒ ComponentResolve.
+        let index = crate::djvm::create_indirect(&["missing.djvu"]).expect("create_indirect");
+        let err = DjVuDocumentMut::from_indirect_resolved(&index, |_name: &str| {
+            Err::<Vec<u8>, _>(std::io::Error::new(std::io::ErrorKind::NotFound, "nope"))
+        })
+        .unwrap_err();
+        match err {
+            MutError::ComponentResolve { name } => assert_eq!(name, "missing.djvu"),
+            other => panic!("expected ComponentResolve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_indirect_resolved_malformed_component_errors() {
+        let index = crate::djvm::create_indirect(&["garbage.djvu"]).expect("create_indirect");
+        let err = DjVuDocumentMut::from_indirect_resolved(&index, |_name: &str| {
+            Ok::<Vec<u8>, std::io::Error>(b"not an iff document".to_vec())
+        })
+        .unwrap_err();
+        assert!(
+            matches!(err, MutError::ComponentMalformed { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn from_indirect_resolved_rejects_bundled_input() {
+        // A genuinely bundled DJVM is not indirect ⇒ NotIndirectDjvm.
+        let bundled = read_corpus("DjVu3Spec_bundled.djvu");
+        let err = DjVuDocumentMut::from_indirect_resolved(&bundled, |_n: &str| {
+            Ok::<Vec<u8>, std::io::Error>(Vec::new())
+        })
+        .unwrap_err();
+        assert!(matches!(err, MutError::NotIndirectDjvm), "{err:?}");
+    }
+
+    #[test]
+    fn from_indirect_resolved_rejects_single_page_djvu() {
+        let chicken = read_corpus("chicken.djvu");
+        let err = DjVuDocumentMut::from_indirect_resolved(&chicken, |_n: &str| {
+            Ok::<Vec<u8>, std::io::Error>(Vec::new())
+        })
+        .unwrap_err();
+        assert!(matches!(err, MutError::NotIndirectDjvm), "{err:?}");
+    }
+
+    #[test]
+    fn from_bytes_on_indirect_still_unsupported_for_page_mut() {
+        // The plain entry point keeps the documented unsupported behavior.
+        let index = crate::djvm::create_indirect(&["chicken.djvu"]).expect("create_indirect");
+        let mut doc = DjVuDocumentMut::from_bytes(&index).unwrap();
+        let err = doc.page_mut(0).err().unwrap();
+        assert!(matches!(err, MutError::IndirectDjvmUnsupported), "{err:?}");
+    }
+
+    // ---- #326: explicit external-file rewrite plan ------------------------
+
+    /// A fresh, empty temp directory unique to `tag` (cleared if it exists).
+    fn fresh_temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("djvu_rs_rewrite_{tag}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn rewrite_plan_commits_full_set_to_dir() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu", "irish.djvu"]);
+        let mut plan = IndirectRewritePlan::from_indirect_resolved(&index, resolver).unwrap();
+        assert_eq!(plan.page_count(), 2);
+
+        // Edit page 0's metadata in memory only.
+        plan.edit_page(0, |doc| {
+            let meta = DjVuMetadata {
+                title: Some("rewrite path".into()),
+                ..Default::default()
+            };
+            doc.page_mut(0)?.set_metadata(&meta);
+            Ok(())
+        })
+        .unwrap();
+
+        // The preview marks page 0 changed, page 1 and root unchanged.
+        let preview = plan.plan("index.djvu");
+        assert_eq!(preview.len(), 3);
+        assert_eq!(preview[0].name, "chicken.djvu");
+        assert!(preview[0].changed, "edited page must show changed");
+        assert_eq!(preview[1].name, "irish.djvu");
+        assert!(!preview[1].changed, "untouched page must be unchanged");
+        assert!(preview[2].is_root);
+        assert!(!preview[2].changed, "root unchanged for a page-only edit");
+
+        let dir = fresh_temp_dir("commit_full_set");
+        let written = plan.commit_to_dir(&dir, "index.djvu").unwrap();
+        assert_eq!(written.len(), 3);
+        for p in &written {
+            assert!(p.exists(), "committed file {p:?} must exist");
+        }
+        // No stray temp files left behind.
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files must be renamed away");
+
+        // The rewritten directory parses as an indirect document and the edit
+        // landed on page 0.
+        let index_bytes = std::fs::read(dir.join("index.djvu")).unwrap();
+        let doc = crate::djvu_document::DjVuDocument::parse_from_dir(&index_bytes, &dir).unwrap();
+        assert_eq!(doc.page_count(), 2);
+        let meta_page0 = doc.page(0).unwrap();
+        // metadata is read at the document level; confirm the edited component
+        // round-trips through the single-page parser.
+        let edited_comp = std::fs::read(dir.join("chicken.djvu")).unwrap();
+        let reparsed = DjVuDocumentMut::from_bytes(&edited_comp).unwrap();
+        let has_metz = reparsed
+            .file
+            .root
+            .children()
+            .iter()
+            .any(|c| matches!(c, Chunk::Leaf { id, .. } if id == b"METz"));
+        assert!(has_metz, "edited component file must contain METz");
+        // The unedited component is byte-identical to the source fixture.
+        let irish_src = read_corpus("irish.djvu");
+        let irish_out = std::fs::read(dir.join("irish.djvu")).unwrap();
+        assert_eq!(irish_out, irish_src, "unedited component copied verbatim");
+        let _ = meta_page0;
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rewrite_plan_rejects_duplicate_dirm_names() {
+        // Two DIRM entries with the same id ⇒ DuplicateComponentName.
+        let index = crate::djvm::create_indirect(&["dup.djvu", "dup.djvu"]).expect("create");
+        let err = IndirectRewritePlan::from_indirect_resolved(&index, |_n: &str| {
+            Ok::<Vec<u8>, std::io::Error>(read_corpus("chicken.djvu"))
+        })
+        .unwrap_err();
+        match err {
+            MutError::DuplicateComponentName { name } => assert_eq!(name, "dup.djvu"),
+            other => panic!("expected DuplicateComponentName, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rewrite_plan_rejects_unsafe_dirm_names() {
+        for bad in [
+            "../evil.djvu",
+            "/abs.djvu",
+            "sub/page.djvu",
+            "..",
+            "a:b.djvu",
+        ] {
+            let index = crate::djvm::create_indirect(&[bad]).expect("create");
+            let err = IndirectRewritePlan::from_indirect_resolved(&index, |_n: &str| {
+                Ok::<Vec<u8>, std::io::Error>(read_corpus("chicken.djvu"))
+            })
+            .unwrap_err();
+            assert!(
+                matches!(err, MutError::UnsafeComponentName { .. }),
+                "name {bad:?} should be rejected, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_plan_unsafe_root_name_leaves_dir_unchanged() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu"]);
+        let plan = IndirectRewritePlan::from_indirect_resolved(&index, resolver).unwrap();
+
+        let dir = fresh_temp_dir("unsafe_root");
+        // Drop a sentinel file that must survive a failed commit.
+        std::fs::write(dir.join("sentinel"), b"keep me").unwrap();
+
+        let err = plan.commit_to_dir(&dir, "../escape.djvu").unwrap_err();
+        assert!(
+            matches!(err, MutError::UnsafeComponentName { .. }),
+            "{err:?}"
+        );
+
+        // Nothing was written: only the sentinel remains.
+        let entries: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries, vec!["sentinel".to_string()]);
+        assert_eq!(std::fs::read(dir.join("sentinel")).unwrap(), b"keep me");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rewrite_plan_root_name_collision_rejected() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu"]);
+        let plan = IndirectRewritePlan::from_indirect_resolved(&index, resolver).unwrap();
+        let dir = fresh_temp_dir("root_collision");
+        // Root name equals a component name — would shadow the page file.
+        let err = plan.commit_to_dir(&dir, "chicken.djvu").unwrap_err();
+        assert!(
+            matches!(err, MutError::DuplicateComponentName { .. }),
+            "{err:?}"
+        );
+        // Validation failed before writing: directory is still empty.
+        assert_eq!(std::fs::read_dir(&dir).unwrap().count(), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rewrite_plan_set_bookmarks_marks_root_changed() {
+        let (index, resolver) = indirect_over_fixtures(&["chicken.djvu"]);
+        let mut plan = IndirectRewritePlan::from_indirect_resolved(&index, resolver).unwrap();
+        plan.set_bookmarks(&[DjVuBookmark {
+            title: "Top".into(),
+            url: "#1".into(),
+            children: vec![],
+        }])
+        .unwrap();
+
+        let preview = plan.plan("index.djvu");
+        let root = preview.iter().find(|i| i.is_root).unwrap();
+        assert!(root.changed, "root index must be marked changed");
+
+        // Commit and confirm the index file carries NAVM bookmarks.
+        let dir = fresh_temp_dir("bookmarks");
+        plan.commit_to_dir(&dir, "index.djvu").unwrap();
+        let index_bytes = std::fs::read(dir.join("index.djvu")).unwrap();
+        let form = crate::iff::parse_form(&index_bytes).unwrap();
+        assert!(
+            form.chunks.iter().any(|c| &c.id == b"NAVM"),
+            "committed index must contain NAVM"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rewrite_plan_rejects_bundled_input() {
+        let bundled = read_corpus("DjVu3Spec_bundled.djvu");
+        let err = IndirectRewritePlan::from_indirect_resolved(&bundled, |_n: &str| {
+            Ok::<Vec<u8>, std::io::Error>(Vec::new())
+        })
+        .unwrap_err();
+        assert!(matches!(err, MutError::NotIndirectDjvm), "{err:?}");
     }
 
     /// Walk top-level children of the outer FORM and return their absolute

--- a/src/iw44_encode.rs
+++ b/src/iw44_encode.rs
@@ -1499,6 +1499,447 @@ fn encode_chunks(
 // ---- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
+mod loss_diagnostics {
+    //! IW44 reconstruction-loss diagnostics for issue #320.
+    //!
+    //! Goal: localize where a continuous-tone page's BG44 detail is lost during
+    //! re-encode, among four candidate stages — forward wavelet transform,
+    //! quantization threshold schedule, coefficient state transitions, and
+    //! reconstruction tracking.
+    //!
+    //! Findings (asserted by the tests below, measured on `conquete_paix`
+    //! pages 3 & 11):
+    //!
+    //!  * **Forward transform is not the cause.** The production i16 forward
+    //!    transform reproduces a full-precision i32 reference *exactly* (zero
+    //!    diverging coefficients) and never overflows i16 — the largest
+    //!    intermediate magnitude on these pages is ~11 k, far under 32 767.
+    //!    See `forward_transform_is_lossless`.
+    //!
+    //!  * **The loss is the progressive quantization / slice budget.** Per-band
+    //!    reconstruction residual (true `blocks` vs the decoder-mirrored
+    //!    `recon`) grows monotonically with band frequency: the coarse bands
+    //!    reconstruct well while the finest band is never activated within the
+    //!    default 100-slice budget (its `recon` stays all-zero). Because the
+    //!    low-frequency bands *do* reconstruct, the coefficient state
+    //!    transitions and reconstruction tracking are working — the diverging
+    //!    stage is the quantization threshold schedule. See
+    //!    `loss_concentrates_in_high_frequency_bands`.
+    //!
+    //! Note on the issue's "vs watchmaker" framing: `watchmaker.djvu` carries no
+    //! IW44 background at all (it is a bilevel JB2 document), so the meaningful
+    //! within-corpus control is the band-frequency gradient on the photographic
+    //! `conquete_paix` pages rather than a second IW44 document.
+    //!
+    //! These are diagnostics only; they do not change encoder behavior.
+
+    use super::*;
+    use crate::DjVuDocument;
+    use crate::iw44_new::Iw44Image;
+    use crate::pixmap::Pixmap;
+
+    const CONQUETE: &str = "tests/corpus/conquete_paix.djvu";
+
+    // ---- Full-precision i32 reference forward transform ----------------------
+    //
+    // Identical lifting/predict arithmetic to the production transform but in
+    // i32 with no per-step truncation, so any difference vs production isolates
+    // i16 rounding/overflow in the forward stage. (An earlier version of this
+    // reference had a bug — it ran the column pass over every column instead of
+    // the s·ℤ sublattice — which manufactured a spurious "divergence"; the
+    // sublattice stepping below matches production's `forward_col_pass`.)
+
+    fn ref_lift(cur: i32, p1: i32, n1: i32, p3: i32, n3: i32) -> i32 {
+        let a = p1 + n1;
+        let c = p3 + n3;
+        cur + (((a << 3) + a - c + 16) >> 5)
+    }
+    fn ref_pred_inner(cur: i32, p1: i32, n1: i32, p3: i32, n3: i32) -> i32 {
+        let a = p1 + n1;
+        cur - (((a << 3) + a - (p3 + n3) + 8) >> 4)
+    }
+    fn ref_pred_avg(cur: i32, p: i32, n: i32) -> i32 {
+        cur - ((p + n + 1) >> 1)
+    }
+
+    fn ref_row_pass(data: &mut [i32], width: usize, height: usize, stride: usize, s: usize) {
+        let sd = s.trailing_zeros() as usize;
+        let kmax = (width - 1) >> sd;
+        let border = kmax.saturating_sub(3);
+        for row in (0..height).step_by(s) {
+            let off = row * stride;
+            if kmax >= 1 {
+                let p = data[off];
+                let idx1 = off + (1 << sd);
+                if kmax >= 2 {
+                    let n = data[off + (2 << sd)];
+                    data[idx1] = ref_pred_avg(data[idx1], p, n);
+                } else {
+                    data[idx1] -= p;
+                }
+                let mut k = 3usize;
+                while k <= border {
+                    let p1 = data[off + ((k - 1) << sd)];
+                    let n1 = data[off + ((k + 1) << sd)];
+                    let p3 = data[off + ((k - 3) << sd)];
+                    let n3 = if k + 3 <= kmax {
+                        data[off + ((k + 3) << sd)]
+                    } else {
+                        0
+                    };
+                    data[off + (k << sd)] = ref_pred_inner(data[off + (k << sd)], p1, n1, p3, n3);
+                    k += 2;
+                }
+                while k <= kmax {
+                    let p = data[off + ((k - 1) << sd)];
+                    if k < kmax {
+                        let n = data[off + ((k + 1) << sd)];
+                        data[off + (k << sd)] = ref_pred_avg(data[off + (k << sd)], p, n);
+                    } else {
+                        data[off + (k << sd)] -= p;
+                    }
+                    k += 2;
+                }
+            }
+            let mut prev3 = 0i32;
+            let mut prev1 = 0i32;
+            let mut next1 = if kmax >= 1 { data[off + (1 << sd)] } else { 0 };
+            let mut k = 0usize;
+            while k <= kmax {
+                let n3 = if k + 3 <= kmax {
+                    data[off + ((k + 3) << sd)]
+                } else {
+                    0
+                };
+                let idx = off + (k << sd);
+                data[idx] = ref_lift(data[idx], prev1, next1, prev3, n3);
+                prev3 = prev1;
+                prev1 = next1;
+                next1 = n3;
+                k += 2;
+            }
+        }
+    }
+
+    fn ref_col_pass(data: &mut [i32], width: usize, height: usize, stride: usize, s: usize) {
+        let sd = s.trailing_zeros() as usize;
+        let kmax = (height - 1) >> sd;
+        let border = kmax.saturating_sub(3);
+        // Multiresolution: only the s·ℤ column sublattice (previous LL subband).
+        if kmax >= 1 {
+            let k1_off = (1 << sd) * stride;
+            if kmax >= 2 {
+                let kp1_off = (2 << sd) * stride;
+                for col in (0..width).step_by(s) {
+                    let p = data[col];
+                    let n = data[kp1_off + col];
+                    data[k1_off + col] = ref_pred_avg(data[k1_off + col], p, n);
+                }
+            } else {
+                for col in (0..width).step_by(s) {
+                    let p = data[col];
+                    data[k1_off + col] -= p;
+                }
+            }
+            let mut k = 3usize;
+            while k <= border {
+                let km3 = ((k - 3) << sd) * stride;
+                let km1 = ((k - 1) << sd) * stride;
+                let k0 = (k << sd) * stride;
+                let kp1 = ((k + 1) << sd) * stride;
+                let kp3 = ((k + 3) << sd) * stride;
+                for col in (0..width).step_by(s) {
+                    data[k0 + col] = ref_pred_inner(
+                        data[k0 + col],
+                        data[km1 + col],
+                        data[kp1 + col],
+                        data[km3 + col],
+                        data[kp3 + col],
+                    );
+                }
+                k += 2;
+            }
+            while k <= kmax {
+                let km1 = ((k - 1) << sd) * stride;
+                let k0 = (k << sd) * stride;
+                if k < kmax {
+                    let kp1 = ((k + 1) << sd) * stride;
+                    for col in (0..width).step_by(s) {
+                        data[k0 + col] =
+                            ref_pred_avg(data[k0 + col], data[km1 + col], data[kp1 + col]);
+                    }
+                } else {
+                    for col in (0..width).step_by(s) {
+                        data[k0 + col] -= data[km1 + col];
+                    }
+                }
+                k += 2;
+            }
+        }
+        let num_cols = width.div_ceil(s);
+        let mut prev3 = vec![0i32; num_cols];
+        let mut prev1 = vec![0i32; num_cols];
+        let mut next1: Vec<i32> = if kmax >= 1 {
+            let off = (1 << sd) * stride;
+            (0..width).step_by(s).map(|c| data[off + c]).collect()
+        } else {
+            vec![0i32; num_cols]
+        };
+        let mut k = 0usize;
+        while k <= kmax {
+            let k0 = (k << sd) * stride;
+            let has_n3 = k + 3 <= kmax;
+            let n3_off = if has_n3 { ((k + 3) << sd) * stride } else { 0 };
+            for (ci, col) in (0..width).step_by(s).enumerate() {
+                let n3 = if has_n3 { data[n3_off + col] } else { 0 };
+                let idx = k0 + col;
+                data[idx] = ref_lift(data[idx], prev1[ci], next1[ci], prev3[ci], n3);
+                prev3[ci] = prev1[ci];
+                prev1[ci] = next1[ci];
+                next1[ci] = n3;
+            }
+            k += 2;
+        }
+    }
+
+    /// Full-precision i32 forward transform; returns the largest magnitude that
+    /// appears at any pass boundary (so callers can check i16 headroom).
+    fn ref_transform(data: &mut [i32], width: usize, height: usize, stride: usize) -> i32 {
+        let mut max_intermediate = 0i32;
+        let mut s = 1usize;
+        while s <= 16 {
+            ref_row_pass(data, width, height, stride, s);
+            for v in data.iter() {
+                max_intermediate = max_intermediate.max(v.abs());
+            }
+            ref_col_pass(data, width, height, stride, s);
+            for v in data.iter() {
+                max_intermediate = max_intermediate.max(v.abs());
+            }
+            s <<= 1;
+        }
+        max_intermediate
+    }
+
+    // ---- Luma plane / band helpers -------------------------------------------
+
+    /// Build the luma (Y) plane exactly like `encode_iw44_color`'s Y path.
+    fn build_y_plane(px: &Pixmap) -> (Vec<i16>, usize, usize, usize) {
+        let w = px.width as usize;
+        let h = px.height as usize;
+        let stride = w.div_ceil(32) * 32;
+        let plane_h = h.div_ceil(32) * 32;
+        let mut y_plane = vec![0i16; stride * plane_h];
+        for row in 0..h {
+            let wavelet_row = h - 1 - row;
+            for col in 0..w {
+                let (r, g, b) = px.get_rgb(col as u32, row as u32);
+                let (y, _cb, _cr) = rgb_to_ycbcr(r, g, b);
+                y_plane[wavelet_row * stride + col] = (y as i32 * 64) as i16;
+            }
+        }
+        (y_plane, w, h, stride)
+    }
+
+    fn page_background(path: &str, page_idx: usize) -> Option<Pixmap> {
+        let data = std::fs::read(path).ok()?;
+        let doc = DjVuDocument::parse(&data).ok()?;
+        let page = doc.page(page_idx).ok()?;
+        let chunks = page.bg44_chunks();
+        if chunks.is_empty() {
+            return None;
+        }
+        let mut img = Iw44Image::new();
+        for c in chunks {
+            img.decode_chunk(c).ok()?;
+        }
+        img.to_rgb().ok()
+    }
+
+    /// Contiguous zigzag-coefficient index range covered by IW44 band `band`
+    /// (band 0 → the first 16 coeffs; bands 1-9 → `BAND_BUCKETS[band]` × 16).
+    fn band_idx_range(band: usize) -> (usize, usize) {
+        if band == 0 {
+            (0, 16)
+        } else {
+            let (from, to) = BAND_BUCKETS[band];
+            (from * 16, (to + 1) * 16)
+        }
+    }
+
+    /// Forward-transform + gather a luma PlaneEncoder, like `encode_iw44_color`.
+    fn y_plane_encoder(px: &Pixmap) -> PlaneEncoder {
+        let (mut y_plane, w, h, stride) = build_y_plane(px);
+        forward_wavelet_transform(&mut y_plane, w, h, stride);
+        let mut enc = PlaneEncoder::new(w, h);
+        enc.gather(&y_plane, stride);
+        enc
+    }
+
+    /// Per-band (energy = Σ|blocks|, residual = Σ|blocks − recon|).
+    fn band_stats(enc: &PlaneEncoder) -> [(i64, i64); 10] {
+        let mut out = [(0i64, 0i64); 10];
+        for (band, slot) in out.iter_mut().enumerate() {
+            let (lo, hi) = band_idx_range(band);
+            let mut energy = 0i64;
+            let mut resid = 0i64;
+            for blk in 0..enc.blocks.len() {
+                for idx in lo..hi {
+                    let t = enc.blocks[blk][idx] as i64;
+                    let r = enc.recon[blk][idx] as i64;
+                    energy += t.abs();
+                    resid += (t - r).abs();
+                }
+            }
+            *slot = (energy, resid);
+        }
+        out
+    }
+
+    /// Relative per-band reconstruction residual in [0, 1].
+    fn band_rel(stats: &[(i64, i64); 10]) -> [f64; 10] {
+        let mut rel = [0.0f64; 10];
+        for (i, &(energy, resid)) in stats.iter().enumerate() {
+            rel[i] = if energy > 0 {
+                resid as f64 / energy as f64
+            } else {
+                0.0
+            };
+        }
+        rel
+    }
+
+    fn encode_all_slices(enc: &mut PlaneEncoder, total: usize) {
+        let mut zp = ZpEncoder::new();
+        for _ in 0..total {
+            enc.encode_slice(&mut zp);
+        }
+        let _ = zp.finish();
+    }
+
+    // ---- Tests ---------------------------------------------------------------
+
+    /// The forward wavelet transform is lossless for real luma backgrounds: it
+    /// matches a full-precision i32 reference exactly and never overflows i16.
+    /// This rules the forward transform out as a source of reconstruction loss.
+    #[test]
+    fn forward_transform_is_lossless() {
+        for page in [3usize, 11] {
+            let Some(px) = page_background(CONQUETE, page) else {
+                panic!("conquete_paix page {page} background must decode");
+            };
+            let (mut i16_plane, w, h, stride) = build_y_plane(&px);
+            let mut i32_plane: Vec<i32> = i16_plane.iter().map(|&v| v as i32).collect();
+
+            forward_wavelet_transform(&mut i16_plane, w, h, stride);
+            let max_intermediate = ref_transform(&mut i32_plane, w, h, stride);
+
+            let mut diverged = 0usize;
+            for r in 0..h {
+                for c in 0..w {
+                    let idx = r * stride + c;
+                    if i16_plane[idx] as i32 != i32_plane[idx] {
+                        diverged += 1;
+                    }
+                }
+            }
+            assert_eq!(
+                diverged, 0,
+                "page {page}: i16 forward transform must equal the full-precision \
+                 reference (diverged coefficients indicate a transform/SIMD bug)"
+            );
+            assert!(
+                max_intermediate <= i16::MAX as i32,
+                "page {page}: forward transform overflowed i16 \
+                 (max intermediate magnitude {max_intermediate} > 32767)"
+            );
+        }
+    }
+
+    /// The reconstruction loss concentrates in the high-frequency bands: with
+    /// the default 100-slice budget the coarse bands reconstruct well while the
+    /// finest band is never activated (its `recon` stays all-zero). The
+    /// monotone-with-frequency residual isolates the loss to the quantization
+    /// threshold schedule — coefficient state transitions and reconstruction
+    /// tracking work, since the coarse bands *do* reconstruct.
+    #[test]
+    fn loss_concentrates_in_high_frequency_bands() {
+        for page in [3usize, 11] {
+            let Some(px) = page_background(CONQUETE, page) else {
+                panic!("conquete_paix page {page} background must decode");
+            };
+            let mut enc = y_plane_encoder(&px);
+            encode_all_slices(&mut enc, 100);
+            let stats = band_stats(&enc);
+            let rel = band_rel(&stats);
+
+            // Coarsest band reconstructs well (< 40% residual).
+            assert!(
+                rel[0] < 0.40,
+                "page {page}: band 0 relative residual {:.3} unexpectedly high \
+                 (coarse band should reconstruct well)",
+                rel[0]
+            );
+            // Finest band is essentially unreconstructed within budget — its
+            // recon is at most a hair above all-zero (never meaningfully
+            // activated): residual ≥ 99% of the band energy.
+            assert!(
+                rel[9] >= 0.99,
+                "page {page}: band 9 relative residual {:.4} (expected ≈ 1.0; the \
+                 finest band should be starved by the slice budget)",
+                rel[9]
+            );
+            // High-frequency bands lose far more than low-frequency bands.
+            let low = (rel[0] + rel[1] + rel[2]) / 3.0;
+            let high = (rel[7] + rel[8] + rel[9]) / 3.0;
+            assert!(
+                high > low + 0.25,
+                "page {page}: residual must grow with frequency \
+                 (low-band mean {low:.3}, high-band mean {high:.3})"
+            );
+        }
+    }
+
+    /// Prints the full per-band energy/residual table for manual investigation.
+    /// Run with: `cargo test --features=std --lib \
+    /// loss_diagnostics::print_band_table -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "diagnostic dump for #320; run with --ignored --nocapture"]
+    fn print_band_table() {
+        for page in [3usize, 11] {
+            let Some(px) = page_background(CONQUETE, page) else {
+                println!("conquete_paix page {page}: no BG44 background");
+                continue;
+            };
+            let mut enc = y_plane_encoder(&px);
+            encode_all_slices(&mut enc, 100);
+            let stats = band_stats(&enc);
+            println!("conquete_paix page {page}: per-band [energy resid rel%] after 100 slices");
+            let (mut te, mut tr) = (0i64, 0i64);
+            for (band, &(energy, resid)) in stats.iter().enumerate() {
+                let (lo, hi) = band_idx_range(band);
+                let rel = if energy > 0 {
+                    100.0 * resid as f64 / energy as f64
+                } else {
+                    0.0
+                };
+                println!(
+                    "  band {band} idx[{lo}..{hi}): energy={energy} resid={resid} rel={rel:.1}%"
+                );
+                te += energy;
+                tr += resid;
+            }
+            let rel = if te > 0 {
+                100.0 * tr as f64 / te as f64
+            } else {
+                0.0
+            };
+            println!("  TOTAL: energy={te} resid={tr} rel={rel:.1}%");
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::iw44_new::Iw44Image;

--- a/src/jb2_encode.rs
+++ b/src/jb2_encode.rs
@@ -231,21 +231,18 @@ fn encode_bitmap_direct(zp: &mut ZpEncoder, ctx: &mut [u8], bm: &Bitmap) {
 /// Encode `cbm` relative to a reference (matched) bitmap `mbm` using the
 /// refinement 11-pixel context.
 ///
-/// Mirrors `decode_bitmap_ref` in `jb2.rs`. Center alignment is used per
-/// the DjVu spec: the reference bitmap is anchored at the centre of the
-/// child.
+/// Mirrors `decode_bitmap_ref` in the `djvu-jb2` crate **exactly**, including
+/// its row traversal order and centre alignment. The decoder works in packed
+/// Jbm storage, which is bottom-up: Jbm row `r` is image row `H - 1 - r`. It
+/// decodes rows from `r = H-1` (image top) down to `r = 0` (image bottom),
+/// and its centre-alignment `row_shift = mrow - crow` is applied in that
+/// Jbm-row space. Because the `>> 1` centre floor is not symmetric under a
+/// top-down/bottom-up flip, the encoder must operate in the *same* Jbm-row
+/// space rather than image space — otherwise the reference rows the two sides
+/// sample disagree on odd/even size deltas and the ZP streams desynchronise.
 ///
-/// Both bitmaps are in [`Bitmap`] top-down storage (y=0 = top of image).
-/// The decoder's bottom-up Jbm traversal corresponds to top-down image
-/// processing, so we iterate `y in 0..ch`. Context rows are then:
-///   * c_r1 = the row just above current in image  (Y - 1 in Bitmap storage)
-///   * m_r1 = mbm row at the same image height as the current cbm row
-///   * m_r0 = mbm row one below current in image    (m_r1's Bitmap Y + 1)
-///   * m_r2 = mbm row one above current in image    (m_r1's Bitmap Y - 1)
-///
-/// `row_offset = mrow - crow` is the centre-alignment shift expressed in
-/// Bitmap (top-down) row indices.
-#[allow(dead_code)]
+/// Both `cbm` and `mbm` are [`Bitmap`]s in top-down storage; the closures
+/// below translate Jbm row indices back into top-down `get` calls.
 fn encode_bitmap_ref(zp: &mut ZpEncoder, ctx: &mut [u8], cbm: &Bitmap, mbm: &Bitmap) {
     debug_assert_eq!(ctx.len(), 2048);
     let cw = cbm.width as i32;
@@ -260,47 +257,49 @@ fn encode_bitmap_ref(zp: &mut ZpEncoder, ctx: &mut [u8], cbm: &Bitmap, mbm: &Bit
     let ccol = (cw - 1) >> 1;
     let mrow = (mh - 1) >> 1;
     let mcol = (mw - 1) >> 1;
-    let row_offset = mrow - crow;
+    let row_shift = mrow - crow;
     let col_shift = mcol - ccol;
 
-    let mbm_pixel = |y: i32, x: i32| -> u32 {
-        if y < 0 || y >= mh || x < 0 || x >= mw {
+    // Jbm-space pixel reads: Jbm row `r` ↔ image row `height - 1 - r`.
+    let mbm_pix = |r: i32, x: i32| -> u32 {
+        if r < 0 || r >= mh || x < 0 || x >= mw {
             0
         } else {
-            mbm.get(x as u32, y as u32) as u32
+            mbm.get(x as u32, (mh - 1 - r) as u32) as u32
         }
     };
-    let cbm_pixel = |y: i32, x: i32| -> u32 {
-        if y < 0 || y >= ch || x < 0 || x >= cw {
+    let cbm_pix = |r: i32, x: i32| -> u32 {
+        if r < 0 || r >= ch || x < 0 || x >= cw {
             0
         } else {
-            cbm.get(x as u32, y as u32) as u32
+            cbm.get(x as u32, (ch - 1 - r) as u32) as u32
         }
     };
 
-    for y in 0..ch {
-        let my = y + row_offset; // mbm row at same image height as cbm row y
+    for row in (0..ch).rev() {
+        let mr = row + row_shift;
 
-        // Initialise rolling windows at col=0 (col-1 / col-2 OOB → 0).
-        let mut c_r1 = (cbm_pixel(y - 1, 0) << 1) | cbm_pixel(y - 1, 1);
+        // Rolling windows at col=0 (col-1 / col-2 OOB → 0). `c_r1` is the row
+        // decoded just before this one — Jbm row `row + 1`.
+        let mut c_r1 = (cbm_pix(row + 1, 0) << 1) | cbm_pix(row + 1, 1);
         let mut c_r0: u32 = 0;
-        let mut m_r1 = (mbm_pixel(my, col_shift - 1) << 2)
-            | (mbm_pixel(my, col_shift) << 1)
-            | mbm_pixel(my, col_shift + 1);
-        let mut m_r0 = (mbm_pixel(my + 1, col_shift - 1) << 2)
-            | (mbm_pixel(my + 1, col_shift) << 1)
-            | mbm_pixel(my + 1, col_shift + 1);
+        let mut m_r1 = (mbm_pix(mr, col_shift - 1) << 2)
+            | (mbm_pix(mr, col_shift) << 1)
+            | mbm_pix(mr, col_shift + 1);
+        let mut m_r0 = (mbm_pix(mr - 1, col_shift - 1) << 2)
+            | (mbm_pix(mr - 1, col_shift) << 1)
+            | mbm_pix(mr - 1, col_shift + 1);
 
         for col in 0..cw {
-            let m_r2 = mbm_pixel(my - 1, col + col_shift);
+            let m_r2 = mbm_pix(mr + 1, col + col_shift);
             let idx = ((c_r1 << 8) | (c_r0 << 7) | (m_r2 << 6) | (m_r1 << 3) | m_r0) & 2047;
-            let bit = cbm_pixel(y, col) != 0;
+            let bit = cbm_pix(row, col) != 0;
             zp.encode_bit(&mut ctx[idx as usize], bit);
 
-            c_r1 = ((c_r1 << 1) & 0b111) | cbm_pixel(y - 1, col + 2);
+            c_r1 = ((c_r1 << 1) & 0b111) | cbm_pix(row + 1, col + 2);
             c_r0 = bit as u32;
-            m_r1 = ((m_r1 << 1) & 0b111) | mbm_pixel(my, col + col_shift + 2);
-            m_r0 = ((m_r0 << 1) & 0b111) | mbm_pixel(my + 1, col + col_shift + 2);
+            m_r1 = ((m_r1 << 1) & 0b111) | mbm_pix(mr, col + col_shift + 2);
+            m_r0 = ((m_r0 << 1) & 0b111) | mbm_pix(mr - 1, col + col_shift + 2);
         }
     }
 }
@@ -775,6 +774,85 @@ fn find_lossy_copy_ref(
     best.map(|(i, _)| i)
 }
 
+/// Find the closest **cross-size** dict entry suitable for a lossless record-6
+/// matched refinement (#322 experiment).
+///
+/// Candidates are dict entries whose width and height each differ from `cand`
+/// by at most `max_dim_delta` (and are not exactly `cand`'s size). Distance is
+/// scored with [`scaled_hamming`] — nearest-neighbor resampling of the
+/// candidate into `cand`'s grid — and accepted when within
+/// `pixel_count × max_hamming_fraction` flipped pixels. Returns the dict index
+/// of the best (lowest-distance) accepted candidate.
+///
+/// The match only selects the *reference* glyph; the emitted refinement bitmap
+/// reproduces `cand` exactly, so this is lossless regardless of the score.
+fn find_cross_size_refine_ref(
+    cand: &Bitmap,
+    dict_entries: &[Bitmap],
+    by_size: &BTreeMap<(u32, u32), Vec<usize>>,
+    max_dim_delta: u32,
+    max_hamming_fraction: f32,
+) -> Option<usize> {
+    let pixel_count = (cand.width as u64) * (cand.height as u64);
+    if pixel_count < REFINEMENT_MIN_PIXELS {
+        return None;
+    }
+    let max_diff = ((pixel_count as f64) * (max_hamming_fraction as f64)).round() as u32;
+    let min_w = cand.width.saturating_sub(max_dim_delta);
+    let max_w = cand.width.saturating_add(max_dim_delta);
+    let min_h = cand.height.saturating_sub(max_dim_delta);
+    let max_h = cand.height.saturating_add(max_dim_delta);
+    let mut best: Option<(usize, u32)> = None;
+    for w in min_w..=max_w {
+        for h in min_h..=max_h {
+            if w == cand.width && h == cand.height {
+                continue;
+            }
+            let Some(indices) = by_size.get(&(w, h)) else {
+                continue;
+            };
+            for &idx in indices {
+                let d = scaled_hamming(cand, &dict_entries[idx]);
+                if d > max_diff {
+                    continue;
+                }
+                match best {
+                    None => best = Some((idx, d)),
+                    Some((_, bd)) if d < bd => best = Some((idx, d)),
+                    _ => {}
+                }
+            }
+        }
+    }
+    best.map(|(i, _)| i)
+}
+
+/// Experiment-only knobs for the cross-size record-6 refinement emitter (#322).
+///
+/// When present in [`Jb2EncodeOptions::cross_size_rec6_probe`], fresh
+/// connected components that have no exact dictionary hit are matched against
+/// dictionary entries whose bounding box differs by at most `max_dim_delta`
+/// pixels in each axis. If a near-twin is found within the normalized Hamming
+/// budget, the component is emitted as a **lossless** record-6 matched
+/// refinement (`wdiff`/`hdiff` + 11-bit refinement bitmap) referencing that
+/// entry instead of a fresh record-1.
+///
+/// This is a measurement vehicle: the refinement bitmap reproduces the
+/// component exactly (round-trip is pixel-lossless), but it is *not* wired into
+/// any shipped encoder path. [`encode_jb2_dict`] /
+/// [`encode_jb2_dict_with_shared`] / [`encode_djvm_bundle_jb2`] leave it
+/// disabled, so default output is byte-identical to before.
+#[derive(Debug, Clone, Copy)]
+pub struct CrossSizeRec6Probe {
+    /// Maximum per-axis bounding-box difference (in pixels) between a fresh
+    /// component and a candidate dictionary entry.
+    pub max_dim_delta: u32,
+    /// Accepted normalized Hamming budget as a fraction of the component's
+    /// pixel count, scored after nearest-neighbor resampling of the candidate
+    /// into the component's dimensions.
+    pub max_hamming_fraction: f32,
+}
+
 /// Tunable knobs for the JB2 dictionary encoder.
 ///
 /// Default values reproduce the lossless behavior of [`encode_jb2_dict`]
@@ -792,12 +870,18 @@ pub struct Jb2EncodeOptions {
     /// `0.0` (default) = lossless: rec-7 fires only on byte-exact matches.
     /// `cjb2 -lossy` ships at roughly the equivalent of 0.04–0.05 here.
     pub lossy_threshold: f32,
+    /// Experiment-only cross-size record-6 refinement (#322). `None` (default)
+    /// keeps the shipped behavior — only record-1 (new) and record-7 (copy)
+    /// are emitted. `Some(_)` enables the lossless cross-size refinement path
+    /// described on [`CrossSizeRec6Probe`].
+    pub cross_size_rec6_probe: Option<CrossSizeRec6Probe>,
 }
 
 impl Default for Jb2EncodeOptions {
     fn default() -> Self {
         Self {
             lossy_threshold: 0.0,
+            cross_size_rec6_probe: None,
         }
     }
 }
@@ -894,6 +978,13 @@ pub fn encode_jb2_dict_with_options(
     let mut symbol_height_ctx = NumContext::new();
     let mut symbol_index_ctx = NumContext::new();
     let mut inherit_dict_size_ctx = NumContext::new();
+    // Cross-size record-6 refinement contexts (#322 experiment). Declared
+    // unconditionally to mirror the decoder's context layout, but only touched
+    // when `opts.cross_size_rec6_probe` diverts a component to refinement —
+    // leaving the ZP state byte-identical for the default (probe-off) path.
+    let mut symbol_width_diff_ctx = NumContext::new();
+    let mut symbol_height_diff_ctx = NumContext::new();
+    let mut refinement_bitmap_ctx = vec![0u8; 2048];
     let mut hoff_ctx = NumContext::new();
     let mut voff_ctx = NumContext::new();
     let mut shoff_ctx = NumContext::new();
@@ -961,6 +1052,8 @@ pub fn encode_jb2_dict_with_options(
         enum Action {
             New,
             Copy(usize),
+            /// Cross-size record-6 matched refinement (#322 experiment).
+            Refine(usize),
         }
         let action = if let Some(idx) = exact_match {
             Action::Copy(idx)
@@ -977,9 +1070,23 @@ pub fn encode_jb2_dict_with_options(
             } else {
                 None
             };
-            match lossy_copy {
-                Some(idx) => Action::Copy(idx),
-                None => Action::New,
+            if let Some(idx) = lossy_copy {
+                Action::Copy(idx)
+            } else if let Some(probe) = opts.cross_size_rec6_probe {
+                // #322 experiment: divert fresh components with a near-size
+                // dictionary twin to a lossless cross-size rec-6 refinement.
+                match find_cross_size_refine_ref(
+                    &cc.bitmap,
+                    &dict_entries,
+                    &by_size,
+                    probe.max_dim_delta,
+                    probe.max_hamming_fraction,
+                ) {
+                    Some(idx) => Action::Refine(idx),
+                    None => Action::New,
+                }
+            } else {
+                Action::New
             }
         };
 
@@ -1000,6 +1107,26 @@ pub fn encode_jb2_dict_with_options(
                     (dict_size - 1) as i32,
                     *dict_idx as i32,
                 );
+            }
+            Action::Refine(dict_idx) => {
+                // Record type 6: matched refinement, blit only. The decoder
+                // computes the child size as `dict[idx].dim + diff`, decodes the
+                // refinement bitmap against that reference, then blits — it does
+                // not extend the dict (handled by the `Action::New` guard below).
+                let reference = &dict_entries[*dict_idx];
+                let wdiff = cc_w - reference.width as i32;
+                let hdiff = cc_h - reference.height as i32;
+                encode_num(&mut zp, &mut record_type_ctx, 0, 11, 6);
+                encode_num(
+                    &mut zp,
+                    &mut symbol_index_ctx,
+                    0,
+                    (dict_size - 1) as i32,
+                    *dict_idx as i32,
+                );
+                encode_num(&mut zp, &mut symbol_width_diff_ctx, -262143, 262142, wdiff);
+                encode_num(&mut zp, &mut symbol_height_diff_ctx, -262143, 262142, hdiff);
+                encode_bitmap_ref(&mut zp, &mut refinement_bitmap_ctx, &cc.bitmap, reference);
             }
         }
 
@@ -1993,6 +2120,180 @@ mod tests {
         assert_eq!(packed_hamming(&c, &d), 16);
     }
 
+    // ── #322 cross-size record-6 refinement probe ────────────────────────────
+
+    const REC6_PROBE: CrossSizeRec6Probe = CrossSizeRec6Probe {
+        max_dim_delta: 2,
+        max_hamming_fraction: 0.05,
+    };
+
+    fn probe_opts() -> Jb2EncodeOptions {
+        Jb2EncodeOptions {
+            cross_size_rec6_probe: Some(REC6_PROBE),
+            ..Jb2EncodeOptions::default()
+        }
+    }
+
+    #[test]
+    fn cross_size_rec6_probe_off_is_byte_identical() {
+        // With the probe disabled (default options), the option-based encoder
+        // must reproduce the shipped `encode_jb2_dict` byte stream exactly.
+        let src = make_bitmap(80, 40, |x, y| {
+            let a = (4..16).contains(&x) && (4..28).contains(&y);
+            let b = (40..53).contains(&x) && (4..28).contains(&y);
+            a || b
+        });
+        let shipped = encode_jb2_dict(&src);
+        let opt = encode_jb2_dict_with_options(&src, &[], &Jb2EncodeOptions::default());
+        assert_eq!(shipped, opt, "default options must match shipped output");
+    }
+
+    #[test]
+    fn cross_size_rec6_probe_roundtrips_solid_near_twins() {
+        // Two solid rectangles differing only in width by one pixel. The first
+        // is a fresh rec-1; the second is a cross-size near twin (resampled
+        // Hamming 0) so the probe diverts it to a lossless rec-6 refinement.
+        let src = make_bitmap(80, 40, |x, y| {
+            let a = (4..16).contains(&x) && (4..28).contains(&y); // 12×24 solid
+            let b = (40..53).contains(&x) && (4..28).contains(&y); // 13×24 solid
+            a || b
+        });
+
+        let default_bytes = encode_jb2_dict_with_options(&src, &[], &Jb2EncodeOptions::default());
+        let probe_bytes = encode_jb2_dict_with_options(&src, &[], &probe_opts());
+
+        // The probe must actually take the refinement path (different bytes)…
+        assert_ne!(
+            default_bytes, probe_bytes,
+            "probe should emit a rec-6 refinement, changing the byte stream"
+        );
+        // …and stay lossless.
+        let decoded = jb2::decode(&probe_bytes, None).expect("probe decode failed");
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    #[test]
+    fn cross_size_rec6_probe_roundtrips_perturbed_glyphs() {
+        // A column of near-duplicate near-solid "glyphs": a base block plus a
+        // few variants that differ by one bounding-box pixel and a small corner
+        // notch — keeping the resampled Hamming distance under the 5% budget so
+        // the probe fires, while still exercising non-trivial refinement
+        // bitmaps (a handful of differing pixels, not just solid blocks).
+        let mut src = Bitmap::new(64, 130);
+        let draw_block = |bm: &mut Bitmap, ox: u32, oy: u32, w: u32, h: u32, notch: bool| {
+            for y in 0..h {
+                for x in 0..w {
+                    // Solid fill minus a small 2×2 corner notch when requested.
+                    if notch && x >= w - 2 && y >= h - 2 {
+                        continue;
+                    }
+                    bm.set(ox + x, oy + y, true);
+                }
+            }
+        };
+        draw_block(&mut src, 4, 2, 14, 18, false); // reference, 14×18 solid
+        draw_block(&mut src, 4, 24, 15, 18, false); // +1 width, solid
+        draw_block(&mut src, 4, 46, 14, 19, true); // +1 height, corner notch
+        draw_block(&mut src, 4, 70, 15, 19, true); // +1/+1, corner notch
+        draw_block(&mut src, 4, 94, 13, 18, false); // −1 width, solid
+
+        let default_bytes = encode_jb2_dict_with_options(&src, &[], &Jb2EncodeOptions::default());
+        let probe_bytes = encode_jb2_dict_with_options(&src, &[], &probe_opts());
+        assert_ne!(
+            default_bytes, probe_bytes,
+            "probe should fire on near twins"
+        );
+
+        let decoded = jb2::decode(&probe_bytes, None).expect("probe decode failed");
+        assert_bitmaps_eq(&src, &decoded);
+    }
+
+    /// Aggregated cross-size rec-6 probe measurement over a set of page masks.
+    #[derive(Default)]
+    struct Rec6ProbeReport {
+        pages: usize,
+        pages_changed: usize,
+        baseline_bytes: u64,
+        probe_bytes: u64,
+        roundtrip_failures: usize,
+    }
+
+    fn measure_rec6_probe(path: &str, max_pages: usize) -> Rec6ProbeReport {
+        let data = std::fs::read(path).unwrap();
+        let doc = crate::DjVuDocument::parse(&data).unwrap();
+        let opts = probe_opts();
+        let mut report = Rec6ProbeReport::default();
+        let n = doc.page_count().min(max_pages);
+        for i in 0..n {
+            let page = doc.page(i).unwrap();
+            let Some(src) = page.extract_mask().unwrap() else {
+                continue;
+            };
+            if src.width == 0 || src.height == 0 {
+                continue;
+            }
+            report.pages += 1;
+
+            let baseline = encode_jb2_dict_with_options(&src, &[], &Jb2EncodeOptions::default());
+            let probe = encode_jb2_dict_with_options(&src, &[], &opts);
+            report.baseline_bytes += baseline.len() as u64;
+            report.probe_bytes += probe.len() as u64;
+            if baseline != probe {
+                report.pages_changed += 1;
+            }
+
+            // Round-trip the probe stream and require pixel-exact reconstruction
+            // (the cross-size rec-6 refinement is lossless).
+            match jb2::decode(&probe, None) {
+                Ok(decoded) => {
+                    let same = decoded.width == src.width
+                        && decoded.height == src.height
+                        && (0..src.height)
+                            .all(|y| (0..src.width).all(|x| decoded.get(x, y) == src.get(x, y)));
+                    if !same {
+                        report.roundtrip_failures += 1;
+                    }
+                }
+                Err(_) => report.roundtrip_failures += 1,
+            }
+        }
+        report
+    }
+
+    /// Experiment driver for #322. Ignored by default — it re-encodes corpus
+    /// page masks (slow) and prints the measured byte deltas + round-trip
+    /// status recorded in PERF_EXPERIMENTS.md. Run with:
+    ///   cargo test --lib --release cross_size_rec6_probe_corpus_measurement -- --ignored --nocapture
+    #[test]
+    #[ignore = "slow corpus re-encode; measurement driver for #322"]
+    fn cross_size_rec6_probe_corpus_measurement() {
+        for (path, max_pages) in [
+            ("tests/corpus/watchmaker.djvu", usize::MAX),
+            ("tests/corpus/pathogenic_bacteria_1896.djvu", 40),
+        ] {
+            let r = measure_rec6_probe(path, max_pages);
+            let delta = r.probe_bytes as i64 - r.baseline_bytes as i64;
+            let pct = if r.baseline_bytes > 0 {
+                100.0 * delta as f64 / r.baseline_bytes as f64
+            } else {
+                0.0
+            };
+            println!(
+                "{path}: pages={} changed={} baseline={}B probe={}B delta={}B ({pct:+.3}%) roundtrip_failures={}",
+                r.pages,
+                r.pages_changed,
+                r.baseline_bytes,
+                r.probe_bytes,
+                delta,
+                r.roundtrip_failures
+            );
+            assert_eq!(
+                r.roundtrip_failures, 0,
+                "cross-size rec-6 probe must round-trip losslessly on {path}"
+            );
+        }
+    }
+
     // ── #194 multi-page shared Djbz ────────────────────────────────────────────
 
     fn render_glyph(bm: &mut Bitmap, x: u32, y: u32, glyph: &[&[u8]]) {
@@ -2253,6 +2554,7 @@ mod tests {
             &[],
             &Jb2EncodeOptions {
                 lossy_threshold: 0.0,
+                ..Jb2EncodeOptions::default()
             },
         );
         let lossy = encode_jb2_dict_with_options(
@@ -2260,6 +2562,7 @@ mod tests {
             &[],
             &Jb2EncodeOptions {
                 lossy_threshold: 0.05,
+                ..Jb2EncodeOptions::default()
             },
         );
 


### PR DESCRIPTION
Implements four issues. No shipped encoder/default behavior changes.

## #325 — resolver-backed indirect DJVM rebundling
`DjVuDocumentMut::from_indirect_resolved` rebundles a resolver-backed indirect DJVM into a bundled document.

## #326 — explicit external-file rewrite plan
`IndirectRewritePlan`: write-plan preview, staged temp files + atomic rename, name-safety checks, atomicity docs.

## #320 — IW44 reconstruction-loss diagnostics (diagnostic only)
In-crate diagnostics on `conquete_paix` pages 3 & 11. Forward transform is bit-exact and overflow-free (0 divergence, max intermediate ≪ i16::MAX); loss localized to the progressive quantization/slice budget (finest bands starved). Two regression tests + an ignored band-table dump. No encoder change.

## #322 — experiment-only cross-size JB2 record-6 probe (reverted / kept disabled)
`Jb2EncodeOptions::cross_size_rec6_probe` (default `None`). Finishes the dormant `encode_bitmap_ref` by mirroring the decoder's bottom-up Jbm traversal exactly.

| corpus | baseline | probe | delta | round-trip |
|--------|----------|-------|-------|------------|
| watchmaker (12 pp) | 130,036 B | 135,720 B | **+4.37%** | lossless |
| pathogenic_bacteria_1896 (38 pp) | 1,539,929 B | 1,543,596 B | **+0.24%** | lossless |

Lossless but a byte regression → kept disabled. Byte-identity guard + round-trip tests + ignored corpus measurement driver.

Both experiments are logged in `PERF_EXPERIMENTS.md`.

## Verification
369 lib tests pass, 0 failures; clippy clean; fmt clean. Default output of all shipped encoders is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)