### PR TITLE
fix: repair main CI — pyo3 advisory bump + broken jb2 example

### DIFF
--- a/djvu-py/Cargo.toml
+++ b/djvu-py/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 djvu-rs = { path = "..", features = ["std"] }
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.24"
+pyo3-build-config = "0.29"

--- a/examples/encode_quality_jb2.rs
+++ b/examples/encode_quality_jb2.rs
@@ -112,7 +112,14 @@ fn process_file(path: &Path, lossy_threshold: f32) -> Vec<PageResult> {
         let rs_encoded = encode_jb2(&bitmap);
         let rs_dict_encoded = encode_jb2_dict(&bitmap);
         let rs_lossy_encoded = if lossy_threshold > 0.0 {
-            encode_jb2_dict_with_options(&bitmap, &[], &Jb2EncodeOptions { lossy_threshold })
+            encode_jb2_dict_with_options(
+                &bitmap,
+                &[],
+                &Jb2EncodeOptions {
+                    lossy_threshold,
+                    ..Default::default()
+                },
+            )
         } else {
             rs_dict_encoded.clone()
         };


### PR DESCRIPTION
`main` is currently **red on two independent counts**, both unrelated to feature work. This PR repairs both so CI goes green again.

## 1. `chore(deps)`: bump pyo3 0.24 → 0.29 (`djvu-py`)

The **Dependencies (deny + audit)** job fails: `cargo audit` flags `pyo3 0.24.2` for two advisories published 2026-06-11:

| Advisory | Issue | Fixed in |
|---|---|---|
| [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) | Out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators | `>= 0.29.0` |
| [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) | Missing `Sync` bound on `PyCFunction::new_closure` closures | `>= 0.29.0` |

`djvu-py` already uses pyo3's modern Bound API, so this is a pure version bump — no source changes. `djvu-py` is `publish = false` and excluded from the workspace build/test in CI (`--exclude djvu-py`), so the published `djvu-rs` crate's dependency tree is unaffected. `Cargo.lock` is gitignored, so the manifest constraint bump is what forces CI's fresh resolution onto the patched line.

## 2. `fix(examples)`: restore `encode_quality_jb2` build

The **Lint (fmt + clippy)** job fails (`cargo clippy --all-targets`):

```
error[E0063]: missing field `cross_size_rec6_probe` in initializer of `djvu_rs::jb2_encode::Jb2EncodeOptions`
  --> examples/encode_quality_jb2.rs:115
```

Commit 984a4b5 added the `cross_size_rec6_probe` field to the (non-`#[non_exhaustive]`) `Jb2EncodeOptions` struct without updating this example, which used an exhaustive struct literal. Fixed by filling the rest with `..Default::default()`, so the example sets only the `lossy_threshold` it sweeps and stays resilient to future field additions.

## Verification (local, against a fully-refreshed lock matching CI's fresh resolution)

```
cargo fmt --check                                       # clean
cargo clippy --all-targets -- -D warnings               # clean (default features)
cargo nextest run --workspace --exclude djvu-py --features cli   # 633 passed, 6 skipped
cargo audit                                             # exit 0 — vulnerabilities cleared
cargo rustc -p djvu-py --crate-type cdylib -- -C link-arg=-undefined -C link-arg=dynamic_lookup   # builds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)